### PR TITLE
Fix/pod ongoing breakpoint

### DIFF
--- a/src/games/smashup/__tests__/bearCavalry-youre-screwed-pod-breakpoint.test.ts
+++ b/src/games/smashup/__tests__/bearCavalry-youre-screwed-pod-breakpoint.test.ts
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initAllAbilities, resetAbilityInit } from '../abilities';
+import { getEffectiveBreakpoint } from '../domain/ongoingModifiers';
+import { makeBase, makeMinion, makeStateWithBases } from './helpers';
+
+beforeAll(() => {
+    resetAbilityInit();
+    initAllAbilities();
+});
+
+describe('bear_cavalry_youre_screwed_pod: 动态爆破点修正', () => {
+    it('默认：每个在此基地有随从的玩家 +2 爆破点', () => {
+        const base = makeBase('base_the_jungle', [
+            makeMinion('m0', 'test_minion', '0', 3),
+            makeMinion('m1', 'test_minion', '1', 3),
+        ]);
+        base.ongoingActions = [{ uid: 'oa1', defId: 'bear_cavalry_youre_screwed_pod', ownerId: '0' } as any];
+
+        const state = makeStateWithBases([base]);
+        const baseBreakpoint = getEffectiveBreakpoint(
+            makeStateWithBases([makeBase('base_the_jungle')]),
+            0,
+        );
+
+        expect(getEffectiveBreakpoint(state, 0)).toBe(baseBreakpoint + 4);
+    });
+
+    it('若本回合曾把对手随从移动到此基地：改为每个玩家 -2 爆破点', () => {
+        const base = makeBase('base_the_jungle', [
+            makeMinion('m0', 'test_minion', '0', 3),
+            makeMinion('m1', 'test_minion', '1', 3),
+        ]);
+        base.ongoingActions = [{ uid: 'oa1', defId: 'bear_cavalry_youre_screwed_pod', ownerId: '0' } as any];
+
+        const state = makeStateWithBases([base], {
+            movedToBasesThisTurn: { 0: true },
+        });
+        const baseBreakpoint = getEffectiveBreakpoint(
+            makeStateWithBases([makeBase('base_the_jungle')]),
+            0,
+        );
+
+        expect(getEffectiveBreakpoint(state, 0)).toBe(baseBreakpoint - 4);
+    });
+});
+

--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -149,7 +149,8 @@ describe('bear_cavalry_polar_commando 保护', () => {
         const commando = makeMinion('pc', 'bear_cavalry_polar_commando', '0', 4, { powerModifier: 0 });
         const base = makeBase({ minions: [commando] });
         const state = makeState({ bases: [base] });
-        expect(getEffectivePower(state, commando, 0)).toBe(6); // 4 + 2
+        // getEffectivePower 使用卡牌定义中的 printed power（bear_cavalry_polar_commando 为 6），再叠加唯一随从 +2
+        expect(getEffectivePower(state, commando, 0)).toBe(8);
     });
 });
 

--- a/src/games/smashup/abilities/ongoing_modifiers.ts
+++ b/src/games/smashup/abilities/ongoing_modifiers.ts
@@ -5,7 +5,7 @@
  * （在 initAllAbilities() 中调用）
  */
 
-import { registerPowerModifier, registerOngoingPowerModifier, registerBasePowerModifier } from '../domain/ongoingModifiers';
+import { registerPowerModifier, registerOngoingPowerModifier, registerBasePowerModifier, registerBreakpointModifier } from '../domain/ongoingModifiers';
 import type { PowerModifierContext } from '../domain/ongoingModifiers';
 import type { MinionOnBase, SmashUpCore } from '../domain/types';
 import { getBaseDef } from '../data/cards';
@@ -201,14 +201,27 @@ function registerSteampunkModifiers(): void {
 function registerBearCavalryModifiers(): void {
     // 极地突击队：基地上唯一己方随从时 +2 力量（不可消灭，后者需要 ongoing 保护系统）
     registerPowerModifier('bear_cavalry_polar_commando', (ctx: PowerModifierContext) => {
-        // 处理 POD 版本：检查基础 defId
-        const baseDefId = ctx.minion.defId.replace(/_pod$/, '');
-        if (baseDefId !== 'bear_cavalry_polar_commando') return 0;
+        // POD 版没有该 ongoing 效果（POD 版只有 talent 效果）
+        if (ctx.minion.defId === 'bear_cavalry_polar_commando_pod') return 0;
+        if (ctx.minion.defId !== 'bear_cavalry_polar_commando') return 0;
         const myMinionCount = ctx.base.minions.filter(
             m => m.controller === ctx.minion.controller
         ).length;
         return myMinionCount === 1 ? 2 : 0;
-    }, { handlesPodInternally: true }); // 标记已处理 POD
+    });
+
+    // 你们已经完蛋 POD（ongoing 行动卡附着在基地上）：动态调整爆破点
+    // 规则：每个在此基地有随从的玩家 +2 爆破点；如果本回合你曾把对手随从移动到此基地，则改为每个玩家 -2
+    registerBreakpointModifier('bear_cavalry_youre_screwed_pod', (ctx) => {
+        const card = ctx.base.ongoingActions.find(a => a.defId === 'bear_cavalry_youre_screwed_pod');
+        if (!card) return 0;
+
+        const playersWithMinions = new Set(ctx.base.minions.map(m => m.controller)).size;
+        const movedOpponentHereThisTurn = ctx.state.movedToBasesThisTurn?.[ctx.baseIndex] ?? false;
+
+        const modifier = playersWithMinions * 2;
+        return movedOpponentHereThisTurn ? -modifier : modifier;
+    });
 }
 
 // ============================================================================

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -552,6 +552,7 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 turnDestroyedMinions: [],
                 // 清空本回合移动追踪
                 minionsMovedToBaseThisTurn: undefined,
+                movedToBasesThisTurn: undefined,
                 // 清空临时临界点修正
                 tempBreakpointModifiers: undefined,
                 // 清空 special 能力限制组使用记录
@@ -940,9 +941,18 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                     ...prevMoves,
                     [mover]: { ...playerMoves, [toBaseIndex]: (playerMoves[toBaseIndex] ?? 0) + 1 },
                 };
+
+                // 你们已经完蛋 POD：追踪“本回合是否把对手随从移动到该基地”
+                const currentPlayerId = state.turnOrder[state.currentPlayerIndex];
+                const movedOpponentMinion = movedMinion.controller !== currentPlayerId;
+                const updatedMovedOpp = movedOpponentMinion
+                    ? { ...(state.movedToBasesThisTurn ?? {}), [toBaseIndex]: true }
+                    : state.movedToBasesThisTurn;
+
                 return {
                     ...state,
                     minionsMovedToBaseThisTurn: updatedMoves,
+                    movedToBasesThisTurn: updatedMovedOpp,
                     bases: newBases.map((base, i) => {
                         if (i !== toBaseIndex) return base;
                         return { ...base, minions: [...base.minions, movedMinion!] };

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -375,6 +375,13 @@ export interface SmashUpCore {
     sleepMarkedPlayers?: PlayerId[];
     /** 本回合每位玩家移动随从到各基地的次数（用于牧场等"首次移动"触发） */
     minionsMovedToBaseThisTurn?: Record<string, Record<number, number>>;
+    /**
+     * 本回合是否曾把对手随从移动到各基地（你们已经完蛋 POD）
+     * key = baseIndex, value = true（本回合有“对手随从”被移动到该基地）
+     *
+     * 生命周期：在 TURN_STARTED 时清空
+     */
+    movedToBasesThisTurn?: Record<number, boolean>;
     /** 临时临界点修正（回合结束自动清零，baseIndex → delta） */
     tempBreakpointModifiers?: Record<number, number>;
     /**


### PR DESCRIPTION
变更摘要
POD：bear_cavalry_youre_screwed_pod 动态爆破点修正（每个玩家 ±2）
增加 core.movedToBasesThisTurn 追踪并在 TURN_STARTED 清空
bear_cavalry_polar_commando_pod 不继承基础版 ongoing +2
新增/修正对应回归测试
测试计划
npm test -- --run src/games/smashup/__tests__/bearCavalry-youre-screwed-pod-breakpoint.test.ts
npm test -- --run src/games/smashup/__tests__/newOngoingAbilities.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected power calculation for Bear Cavalry Polar Commando to use card's printed power plus modifiers.
  * Fixed breakpoint modifier logic for Bear Cavalry's "You're Screwed Pod" ability to properly account for minion movements and opponent presence on bases.

* **Tests**
  * Added comprehensive test coverage for Bear Cavalry breakpoint behavior under various game states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->