### PR TITLE
fix(smashup): register POD Weed Eater power modifier

### DIFF
--- a/src/games/smashup/__tests__/podPowerModifierRegistration.test.ts
+++ b/src/games/smashup/__tests__/podPowerModifierRegistration.test.ts
@@ -1,0 +1,16 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initAllAbilities, resetAbilityInit } from '../abilities';
+import { getRegisteredModifierIds } from '../domain/ongoingModifiers';
+
+beforeAll(() => {
+    resetAbilityInit();
+    initAllAbilities();
+});
+
+describe('POD power modifier registration', () => {
+    it('should register killer_plant_weed_eater_pod power modifier during init', () => {
+        const { powerModifierIds } = getRegisteredModifierIds();
+        expect(powerModifierIds.has('killer_plant_weed_eater_pod')).toBe(true);
+    });
+});
+

--- a/src/games/smashup/abilities/killer_plants.ts
+++ b/src/games/smashup/abilities/killer_plants.ts
@@ -16,6 +16,7 @@ import type {
     DeckReorderedEvent, MinionCardDef, OngoingDetachedEvent,
     MinionPlayedEvent, BreakpointModifiedEvent, CardInstance,
 } from '../domain/types';
+import { registerPowerModifier } from '../domain/ongoingModifiers';
 import { registerProtection, registerTrigger } from '../domain/ongoingEffects';
 import type { ProtectionCheckContext, TriggerContext, TriggerResult } from '../domain/ongoingEffects';
 import { getCardDef, getMinionDef, getBaseDef } from '../data/cards';
@@ -344,6 +345,45 @@ export function registerKillerPlantAbilities(): void {
     // entangled: 控制者回合开始时消灭本卡
     registerTrigger('killer_plant_entangled', 'onTurnStart', killerPlantEntangledDestroyTrigger);
     registerTrigger('killer_plant_entangled_pod', 'onTurnStart', killerPlantEntangledDestroyTrigger);
+
+    // weed_eater_pod: 控制者回合开始后获得 +2 力量（通过 metadata 标记 + PowerModifier）
+    registerTrigger('killer_plant_weed_eater_pod', 'onTurnStart', killerPlantWeedEaterPodTrigger);
+}
+
+/**
+ * Weed Eater POD 触发：控制者回合开始时，若尚未激活则写入 metadata 标记。
+ * 
+ * 这里使用 `MINION_METADATA_UPDATED` 事件驱动 reducer 更新状态，避免直接突变 state。
+ */
+function killerPlantWeedEaterPodTrigger(ctx: TriggerContext): SmashUpEvent[] {
+    const events: SmashUpEvent[] = [];
+    for (let baseIndex = 0; baseIndex < ctx.state.bases.length; baseIndex++) {
+        const base = ctx.state.bases[baseIndex];
+        for (const m of base.minions) {
+            if (m.defId !== 'killer_plant_weed_eater_pod') continue;
+            if (m.controller !== ctx.playerId) continue;
+            if (m.metadata?.weedEaterEmpowered) continue;
+            events.push({
+                type: SU_EVENTS.MINION_METADATA_UPDATED,
+                payload: {
+                    minionUid: m.uid,
+                    baseIndex,
+                    metadataUpdate: { weedEaterEmpowered: true },
+                    reason: 'killer_plant_weed_eater_pod',
+                },
+                timestamp: ctx.now,
+            } as any);
+        }
+    }
+    return events;
+}
+
+/** 注册食人花派系的持续力量修正 */
+export function registerKillerPlantModifiers(): void {
+    // Weed Eater POD：当其 metadata 标记被激活后，获得 +2 力量
+    registerPowerModifier('killer_plant_weed_eater_pod', (ctx) => {
+        return ctx.minion.metadata?.weedEaterEmpowered ? 2 : 0;
+    });
 }
 
 // ============================================================================

--- a/src/games/smashup/abilities/ongoing_modifiers.ts
+++ b/src/games/smashup/abilities/ongoing_modifiers.ts
@@ -11,6 +11,7 @@ import type { MinionOnBase, SmashUpCore } from '../domain/types';
 import { getBaseDef } from '../data/cards';
 import { isMicrobot } from '../domain/utils';
 import type { PlayerId } from '../../../engine/types';
+import { registerKillerPlantModifiers as registerKillerPlantAbilitiesModifiers } from './killer_plants';
 
 // ============================================================================
 // 辅助函数
@@ -138,7 +139,7 @@ function registerNinjaModifiers(): void {
 }
 
 // ============================================================================
-// 食人花派系?
+// 食人花派系
 // ============================================================================
 
 function registerKillerPlantModifiers(): void {
@@ -149,6 +150,9 @@ function registerKillerPlantModifiers(): void {
     // 规则："持续：自你的回合开始时，将本基地的爆破点降低到0点。"
     // 实现方式：onTurnStart 触发器产生 BREAKPOINT_MODIFIED 事件（tempBreakpointModifiers，回合结束自动清零）
     // 注册在 killer_plants.ts 的 registerKillerPlantAbilities() 中
+
+    // 注册派系自定义力量修正（Weed Eater POD）
+    registerKillerPlantAbilitiesModifiers();
 }
 
 // ============================================================================

--- a/src/games/smashup/domain/events.ts
+++ b/src/games/smashup/domain/events.ts
@@ -60,6 +60,7 @@ export const SU_EVENTS = defineEvents({
   
   'su:minion_returned': { audio: 'immediate', sound: CARD_SCROLL_KEY },
   'su:minion_moved': { audio: 'immediate', sound: MOVE_KEY },
+  'su:minion_metadata_updated': 'silent',
   
   'su:power_counter_added': { audio: 'immediate', sound: POWER_GAIN_KEY },
   'su:power_counter_removed': { audio: 'immediate', sound: POWER_LOSE_KEY },
@@ -124,6 +125,7 @@ export const SU_EVENT_TYPES = {
   ALL_FACTIONS_SELECTED: SU_EVENTS['su:all_factions_selected'].type,
   MINION_DESTROYED: SU_EVENTS['su:minion_destroyed'].type,
   MINION_MOVED: SU_EVENTS['su:minion_moved'].type,
+  MINION_METADATA_UPDATED: SU_EVENTS['su:minion_metadata_updated'].type,
   POWER_COUNTER_ADDED: SU_EVENTS['su:power_counter_added'].type,
   POWER_COUNTER_REMOVED: SU_EVENTS['su:power_counter_removed'].type,
   PERMANENT_POWER_ADDED: SU_EVENTS['su:permanent_power_added'].type,

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -952,6 +952,29 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
             return { ...state, bases: newBases };
         }
 
+        case SU_EVENTS.MINION_METADATA_UPDATED: {
+            const { minionUid, baseIndex, metadataUpdate } = (event as any as { payload: { minionUid: string; baseIndex?: number; metadataUpdate: Record<string, unknown> } }).payload;
+            const tryUpdateBase = (b: BaseInPlay) => ({
+                ...b,
+                minions: b.minions.map(m => {
+                    if (m.uid !== minionUid) return m;
+                    return { ...m, metadata: { ...(m.metadata ?? {}), ...metadataUpdate } };
+                }),
+            });
+
+            // 优先使用 baseIndex 定位；否则回退全场扫描
+            if (typeof baseIndex === 'number' && state.bases[baseIndex]) {
+                return {
+                    ...state,
+                    bases: state.bases.map((b, i) => (i === baseIndex ? tryUpdateBase(b) : b)),
+                };
+            }
+            return {
+                ...state,
+                bases: state.bases.map(tryUpdateBase),
+            };
+        }
+
         case SU_EVENTS.POWER_COUNTER_ADDED: {
             const { minionUid, amount } = (event as PowerCounterAddedEvent).payload;
             // 力量指示物：操作 powerCounters 字段（独立可追踪实体）

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -718,6 +718,7 @@ export type SmashUpEvent =
     | AllFactionsSelectedEvent
     | MinionDestroyedEvent
     | MinionMovedEvent
+    | MinionMetadataUpdatedEvent
     | PowerCounterAddedEvent
     | PowerCounterRemovedEvent
     | OngoingAttachedEvent
@@ -796,6 +797,17 @@ export interface MinionMovedEvent extends GameEvent<typeof SU_EVENTS.MINION_MOVE
         minionDefId: string;
         fromBaseIndex: number;
         toBaseIndex: number;
+        reason: string;
+    };
+}
+
+/** 随从元数据更新事件（用于 POD 等复杂状态追踪） */
+export interface MinionMetadataUpdatedEvent extends GameEvent<typeof SU_EVENTS.MINION_METADATA_UPDATED> {
+    payload: {
+        minionUid: string;
+        /** 方便定位的基地索引（可选，reducer 会回退全场扫描） */
+        baseIndex?: number;
+        metadataUpdate: Record<string, unknown>;
         reason: string;
     };
 }


### PR DESCRIPTION
Ensure killer_plant_weed_eater_pod modifier is registered during init and add a small state event to update minion metadata for POD-style power toggles.## Summary
- Add a small state event + reducer support to update minion metadata for POD-style power toggles
- Ensure killer_plant_weed_eater_pod power modifier is registered during init
- Add a focused regression test

## Test plan
- npm test -- --run src/games/smashup/__tests__/podPowerModifierRegistration.test.ts

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Killer Plants faction now features the Weed Eater Pod minion, which automatically empowers itself at the start of your turn and gains +2 power when empowered.

* **Tests**
  * Added test coverage for Weed Eater Pod modifier registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->