### PR TITLE
fix(smashup): support state-based base ability suppression

### DIFF
--- a/src/games/smashup/__tests__/baseAbilitySuppressionState.test.ts
+++ b/src/games/smashup/__tests__/baseAbilitySuppressionState.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isBaseAbilitySuppressed } from '../domain/ongoingEffects';
+import { makeStateWithBases, makeBase } from './helpers';
+
+describe('isBaseAbilitySuppressed: state-based suppression', () => {
+    it('should treat suppressedBasesUntilTurnStart as suppressed even without any active cards', () => {
+        const state = makeStateWithBases([makeBase('base_the_jungle')], {
+            suppressedBasesUntilTurnStart: [{ baseIndex: 0, suppressorPlayerId: '0' }],
+        } as any);
+
+        expect(isBaseAbilitySuppressed(state, 0)).toBe(true);
+    });
+});
+

--- a/src/games/smashup/domain/ongoingEffects.ts
+++ b/src/games/smashup/domain/ongoingEffects.ts
@@ -386,6 +386,12 @@ export function isBaseAbilitySuppressed(
     state: SmashUpCore,
     baseIndex: number
 ): boolean {
+    // 1. 检查基于状态的临时压制（例如：效果已结算/卡已离场，但压制持续到下个回合开始）
+    if (state.suppressedBasesUntilTurnStart?.some(s => s.baseIndex === baseIndex)) {
+        return true;
+    }
+
+    // 2. 检查基于场上卡牌的持续压制
     if (baseAbilitySuppressionRegistry.length === 0) return false;
     for (const entry of baseAbilitySuppressionRegistry) {
         if (!isSourceActiveOnBase(state, entry.sourceDefId, baseIndex)) continue;

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -554,6 +554,12 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 minionsMovedToBaseThisTurn: undefined,
                 // 清空临时临界点修正
                 tempBreakpointModifiers: undefined,
+                // 清理“直到本回合开始”的基地压制（仅清除由当前回合玩家施加的条目）
+                suppressedBasesUntilTurnStart: (() => {
+                    const remaining = (state.suppressedBasesUntilTurnStart ?? [])
+                        .filter(s => s.suppressorPlayerId !== playerId);
+                    return remaining.length ? remaining : undefined;
+                })(),
                 // 清空 special 能力限制组使用记录
                 specialLimitUsed: undefined,
                 // 清空巨石阵双才能追踪

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -408,6 +408,13 @@ export interface SmashUpCore {
      * 在 scoreBases 阶段结束时清空。
      */
     afterScoringTriggeredBases?: number[];
+
+    /**
+     * 临时基地能力压制（直到压制者的下个回合开始）
+     *
+     * 用于实现类似“渗透 POD 天赋”这种“即使牌已离场，压制仍持续到下回合开始”的规则。
+     */
+    suppressedBasesUntilTurnStart?: Array<{ baseIndex: number; suppressorPlayerId: PlayerId }>;
 }
 
 export interface FactionSelectionState {


### PR DESCRIPTION
## Summary
- Treat suppressedBasesUntilTurnStart as base ability suppression in ongoingEffects
- Clear suppression entries for the suppressor at TURN_STARTED
- Add a focused regression test for state-based suppression

## Test plan
- npm test -- --run src/games/smashup/__tests__/baseAbilitySuppressionState.test.ts
- npm test -- --run src/games/smashup/__tests__/baseFactionOngoing.test.ts
Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for state-based base ability suppression that persists until the next turn with automatic cleanup at turn start

* **Tests**
  * Added test coverage validating base ability suppression state recognition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->