### PR TITLE
Fix/pod ninja infiltrate pod talent

### DIFF
--- a/src/games/smashup/__tests__/baseAbilitySuppressionState.test.ts
+++ b/src/games/smashup/__tests__/baseAbilitySuppressionState.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isBaseAbilitySuppressed } from '../domain/ongoingEffects';
+import { makeStateWithBases, makeBase } from './helpers';
+
+describe('isBaseAbilitySuppressed: state-based suppression', () => {
+    it('should treat suppressedBasesUntilTurnStart as suppressed even without any active cards', () => {
+        const state = makeStateWithBases([makeBase('base_the_jungle')], {
+            suppressedBasesUntilTurnStart: [{ baseIndex: 0, suppressorPlayerId: '0' }],
+        } as any);
+
+        expect(isBaseAbilitySuppressed(state, 0)).toBe(true);
+    });
+});
+

--- a/src/games/smashup/__tests__/ninja-infiltrate-pod-talent.test.ts
+++ b/src/games/smashup/__tests__/ninja-infiltrate-pod-talent.test.ts
@@ -1,0 +1,45 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initAllAbilities, resetAbilityInit } from '../abilities';
+import { clearRegistry } from '../domain/abilityRegistry';
+import { clearInteractionHandlers } from '../domain/abilityInteractionHandlers';
+import { clearOngoingEffectRegistry } from '../domain/ongoingEffects';
+import { resolveAbility } from '../domain/abilityRegistry';
+import { applyEvents, makeMatchState, makeStateWithBases } from './helpers';
+import { isBaseAbilitySuppressed } from '../domain/ongoingEffects';
+
+beforeAll(() => {
+    clearRegistry();
+    clearInteractionHandlers();
+    clearOngoingEffectRegistry();
+    resetAbilityInit();
+    initAllAbilities();
+});
+
+describe('ninja_infiltrate_pod talent', () => {
+    it('should suppress base ability until next turn start', () => {
+        const core = makeStateWithBases([{
+            defId: 'test_base',
+            minions: [],
+            ongoingActions: [{ uid: 'inf-1', defId: 'ninja_infiltrate_pod', ownerId: '0' }],
+        } as any]);
+        const matchState = makeMatchState(core);
+
+        const exec = resolveAbility('ninja_infiltrate_pod', 'talent');
+        expect(exec).toBeDefined();
+
+        const result = exec!({
+            state: matchState.core,
+            matchState,
+            playerId: '0',
+            cardUid: 'inf-1',
+            defId: 'ninja_infiltrate_pod',
+            baseIndex: 0,
+            now: 1000,
+            random: { shuffle: <T>(xs: T[]) => xs } as any,
+        } as any);
+
+        const newCore = applyEvents(core, result.events ?? []);
+        expect(isBaseAbilitySuppressed(newCore, 0)).toBe(true);
+    });
+});
+

--- a/src/games/smashup/abilities/ninjas.ts
+++ b/src/games/smashup/abilities/ninjas.ts
@@ -30,6 +30,9 @@ export function registerNinjaAbilities(): void {
     registerAbility('ninja_disguise', 'onPlay', ninjaDisguise);
     // 渗透（ongoing 行动卡）：onPlay 消灭基地上一个已有的战术
     registerAbility('ninja_infiltrate', 'onPlay', ninjaInfiltrateOnPlay);
+    // 渗透 POD（ongoing 行动卡）：onPlay 可选消灭基地上另一张战术；talent 可自毁以压制基地能力
+    registerAbility('ninja_infiltrate_pod', 'onPlay', ninjaInfiltratePodOnPlay);
+    registerAbility('ninja_infiltrate_pod', 'talent', ninjaInfiltratePodTalent);
     // 隐忍（special action）：基地计分前打出手牌中的随从到该基地
     registerAbility('ninja_hidden_ninja', 'special', ninjaHiddenNinja);
     // 忍者侍从（special）：基地计分前返回手牌并额外打出一个随从到该基地
@@ -190,6 +193,60 @@ function ninjaInfiltrateOnPlay(ctx: AbilityContext): AbilityResult {
         { sourceId: 'ninja_infiltrate_destroy', targetType: 'ongoing' },
     );
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
+}
+
+/**
+ * 渗透 POD onPlay：可选消灭基地上一个已有的战术（ongoing 行动卡）
+ * 描述："Play on a base. You may destroy another action on this base."
+ */
+function ninjaInfiltratePodOnPlay(ctx: AbilityContext): AbilityResult {
+    const base = ctx.state.bases[ctx.baseIndex];
+    if (!base) return { events: [] };
+
+    const targets: { uid: string; defId: string; ownerId: string; label: string }[] = [];
+    for (const o of base.ongoingActions) {
+        if (o.uid === ctx.cardUid) continue;
+        const def = getCardDef(o.defId);
+        targets.push({ uid: o.uid, defId: o.defId, ownerId: o.ownerId, label: def?.name ?? o.defId });
+    }
+
+    if (targets.length === 0) return { events: [] };
+
+    const options: any[] = targets.map((t, i) => ({
+        id: `tactic-${i}`,
+        label: t.label,
+        value: { cardUid: t.uid, defId: t.defId, ownerId: t.ownerId },
+        _source: 'ongoing' as const,
+        displayMode: 'card' as const,
+    }));
+    options.push({ id: 'skip', label: '跳过（不消灭）', value: { skip: true }, displayMode: 'button' as const });
+
+    const interaction = createSimpleChoice(
+        `ninja_infiltrate_pod_onplay_${ctx.now}`, ctx.playerId,
+        '你可以消灭该基地上的另一张战术', options,
+        { sourceId: 'ninja_infiltrate_pod_destroy', targetType: 'ongoing' },
+    );
+    return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
+}
+
+/**
+ * 渗透 POD talent：消灭本战术，压制该基地能力直到你的下回合开始。
+ */
+function ninjaInfiltratePodTalent(ctx: AbilityContext): AbilityResult {
+    const ownerId = ctx.playerId;
+    const events: SmashUpEvent[] = [
+        {
+            type: SU_EVENTS.ONGOING_DETACHED,
+            payload: { cardUid: ctx.cardUid, defId: 'ninja_infiltrate_pod', ownerId, reason: 'ninja_infiltrate_pod_talent' },
+            timestamp: ctx.now,
+        } as OngoingDetachedEvent,
+        {
+            type: SU_EVENTS.BASE_ABILITY_SUPPRESSED,
+            payload: { baseIndex: ctx.baseIndex, suppressorPlayerId: ownerId, reason: 'ninja_infiltrate_pod_talent' },
+            timestamp: ctx.now,
+        } as any,
+    ];
+    return { events };
 }
 
 /** 欺骗之道 onPlay：选择己方一个随从移动到另一个基地*/
@@ -727,6 +784,19 @@ export function registerNinjaInteractionHandlers(): void {
             events: [{
                 type: SU_EVENTS.ONGOING_DETACHED,
                 payload: { cardUid: ongoingUid, defId, ownerId, reason: 'ninja_infiltrate_destroy' },
+                timestamp,
+            } as OngoingDetachedEvent],
+        };
+    });
+
+    registerInteractionHandler('ninja_infiltrate_pod_destroy', (state, _playerId, value, _iData, _random, timestamp) => {
+        if (value && (value as any).skip) return { state, events: [] };
+        const { cardUid: ongoingUid, defId, ownerId } = value as { cardUid: string; defId: string; ownerId: string };
+        return {
+            state,
+            events: [{
+                type: SU_EVENTS.ONGOING_DETACHED,
+                payload: { cardUid: ongoingUid, defId, ownerId, reason: 'ninja_infiltrate_pod_destroy' },
                 timestamp,
             } as OngoingDetachedEvent],
         };

--- a/src/games/smashup/data/factions/ninjas_pod.ts
+++ b/src/games/smashup/data/factions/ninjas_pod.ts
@@ -148,7 +148,7 @@ export const NINJA_POD_ACTIONS: ActionCardDef[] = [
         // [POD版效果] Play on a base. You may destroy another action on this base.
         // Talent: Destroy this action to cancel this base's ability until the start of your turn.
         // 注意：即时消灭战术是 onPlay 效果，加入 onPlay 标签
-        abilityTags: ['onPlay', 'ongoing'],
+        abilityTags: ['onPlay', 'ongoing', 'talent'],
         ongoingTarget: 'base',
         count: 1,
         previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.CARDS1, index: 22 },

--- a/src/games/smashup/domain/events.ts
+++ b/src/games/smashup/domain/events.ts
@@ -60,6 +60,7 @@ export const SU_EVENTS = defineEvents({
   
   'su:minion_returned': { audio: 'immediate', sound: CARD_SCROLL_KEY },
   'su:minion_moved': { audio: 'immediate', sound: MOVE_KEY },
+  'su:base_ability_suppressed': 'silent',
   
   'su:power_counter_added': { audio: 'immediate', sound: POWER_GAIN_KEY },
   'su:power_counter_removed': { audio: 'immediate', sound: POWER_LOSE_KEY },
@@ -124,6 +125,7 @@ export const SU_EVENT_TYPES = {
   ALL_FACTIONS_SELECTED: SU_EVENTS['su:all_factions_selected'].type,
   MINION_DESTROYED: SU_EVENTS['su:minion_destroyed'].type,
   MINION_MOVED: SU_EVENTS['su:minion_moved'].type,
+  BASE_ABILITY_SUPPRESSED: SU_EVENTS['su:base_ability_suppressed'].type,
   POWER_COUNTER_ADDED: SU_EVENTS['su:power_counter_added'].type,
   POWER_COUNTER_REMOVED: SU_EVENTS['su:power_counter_removed'].type,
   PERMANENT_POWER_ADDED: SU_EVENTS['su:permanent_power_added'].type,

--- a/src/games/smashup/domain/ongoingEffects.ts
+++ b/src/games/smashup/domain/ongoingEffects.ts
@@ -386,6 +386,12 @@ export function isBaseAbilitySuppressed(
     state: SmashUpCore,
     baseIndex: number
 ): boolean {
+    // 1. 检查基于状态的临时压制（例如：效果已结算/卡已离场，但压制持续到下个回合开始）
+    if (state.suppressedBasesUntilTurnStart?.some(s => s.baseIndex === baseIndex)) {
+        return true;
+    }
+
+    // 2. 检查基于场上卡牌的持续压制
     if (baseAbilitySuppressionRegistry.length === 0) return false;
     for (const entry of baseAbilitySuppressionRegistry) {
         if (!isSourceActiveOnBase(state, entry.sourceDefId, baseIndex)) continue;

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -554,6 +554,12 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 minionsMovedToBaseThisTurn: undefined,
                 // 清空临时临界点修正
                 tempBreakpointModifiers: undefined,
+                // 清理“直到本回合开始”的基地压制（仅清除由当前回合玩家施加的条目）
+                suppressedBasesUntilTurnStart: (() => {
+                    const remaining = (state.suppressedBasesUntilTurnStart ?? [])
+                        .filter(s => s.suppressorPlayerId !== playerId);
+                    return remaining.length ? remaining : undefined;
+                })(),
                 // 清空 special 能力限制组使用记录
                 specialLimitUsed: undefined,
                 // 清空巨石阵双才能追踪

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -1388,6 +1388,19 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
             };
         }
 
+        case SU_EVENTS.BASE_ABILITY_SUPPRESSED: {
+            const { baseIndex, suppressorPlayerId } = (event as BaseAbilitySuppressedEvent).payload;
+            const prev = state.suppressedBasesUntilTurnStart ?? [];
+            // 去重：同一基地同一压制者只记录一次
+            if (prev.some(s => s.baseIndex === baseIndex && s.suppressorPlayerId === suppressorPlayerId)) {
+                return state;
+            }
+            return {
+                ...state,
+                suppressedBasesUntilTurnStart: [...prev, { baseIndex, suppressorPlayerId }],
+            };
+        }
+
         // 基地牌库洗混
         case SU_EVENTS.BASE_DECK_SHUFFLED: {
             const { newBaseDeckDefIds } = (event as BaseDeckShuffledEvent).payload;

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -408,6 +408,13 @@ export interface SmashUpCore {
      * 在 scoreBases 阶段结束时清空。
      */
     afterScoringTriggeredBases?: number[];
+
+    /**
+     * 临时基地能力压制（直到压制者的下个回合开始）
+     *
+     * 用于实现类似“渗透 POD 天赋”这种“即使牌已离场，压制仍持续到下回合开始”的规则。
+     */
+    suppressedBasesUntilTurnStart?: Array<{ baseIndex: number; suppressorPlayerId: PlayerId }>;
 }
 
 export interface FactionSelectionState {

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -750,6 +750,7 @@ export type SmashUpEvent =
     | SpecialAfterScoringConsumedEvent
     | AbilityFeedbackEvent
     | AbilityTriggeredEvent
+    | BaseAbilitySuppressedEvent
     | BaseClearedEvent;
 
 // ============================================================================
@@ -1017,6 +1018,15 @@ export interface BreakpointModifiedEvent extends GameEvent<typeof SU_EVENTS.BREA
     payload: {
         baseIndex: number;
         delta: number;
+        reason: string;
+    };
+}
+
+/** 基地能力压制事件（直到压制者的下个回合开始） */
+export interface BaseAbilitySuppressedEvent extends GameEvent<typeof SU_EVENTS.BASE_ABILITY_SUPPRESSED> {
+    payload: {
+        baseIndex: number;
+        suppressorPlayerId: PlayerId;
         reason: string;
     };
 }


### PR DESCRIPTION
这条 依赖 PR3（用到了 suppressedBasesUntilTurnStart 语义）。
## Summary
- Implement ninja_infiltrate_pod onPlay: may destroy another action on this base (with skip option)
- Implement ninja_infiltrate_pod talent: self-destruct to suppress base ability until next turn start
- Add BASE_ABILITY_SUPPRESSED event + reducer support
- Add a focused regression test

## Dependency
- Depends on PR3 (state-based base suppression infrastructure)

## Test plan
- npm test -- --run src/games/smashup/__tests__/ninja-infiltrate-pod-talent.test.ts