### PR TITLE
test(smashup): standardize validate() error field

### DIFF
--- a/src/games/smashup/__tests__/commandsValidation.test.ts
+++ b/src/games/smashup/__tests__/commandsValidation.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { validate } from '../domain/commands';
+import { makeMatchState, makeState } from './helpers';
+
+describe('SmashUp command validation', () => {
+    it('should return error when command type is missing', () => {
+        const core = makeState();
+        const ms = makeMatchState(core);
+
+        const result = validate(ms as any, {} as any);
+        expect(result.valid).toBe(false);
+        expect((result as any).error).toBe('Invalid command: missing type');
+    });
+});
+

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -29,7 +29,7 @@ export function validate(
 
     // 防御性检查：确保 command 和 type 存在
     if (!command || typeof command.type !== 'string') {
-        return { valid: false, reason: 'Invalid command: missing type' };
+        return { valid: false, error: 'Invalid command: missing type' };
     }
 
     // 系统命令（SYS_ 前缀）由引擎层处理，领域层直接放行


### PR DESCRIPTION
## Summary
- Standardize validate() to return ValidationResult.error (not reason) when command type is missing
- Add a small regression test

## Test plan
- npm test -- --run src/games/smashup/__tests__/commandsValidation.test.ts