### PR TITLE
fix(smashup): align Innsmouth Locals / Return to the Sea / In Plain Sight POD with wiki

### DIFF
--- a/src/games/smashup/__tests__/baseFactionOngoing.test.ts
+++ b/src/games/smashup/__tests__/baseFactionOngoing.test.ts
@@ -635,8 +635,8 @@ describe('忍者 ongoing/special 能力', () => {
 });
 
 // ============================================================================
-// 机器人 ongoing 能力
-// ============================================================================
+ // 机器人 ongoing 能力
+ // ============================================================================
 
 describe('机器人 ongoing 能力', () => {
     beforeEach(() => {
@@ -737,7 +737,6 @@ describe('机器人 ongoing 能力', () => {
             const base = makeBase({ minions: [archive] });
             const state = makeState([base]);
 
-            // playerId='1' 表示被消灭随从属于对手
             const { events } = fireTriggers(state, 'onMinionDestroyed', {
                 state,
                 playerId: '1',
@@ -750,9 +749,133 @@ describe('机器人 ongoing 能力', () => {
 
             expect(events).toHaveLength(0);
         });
+
+        test('有 Alpha 时普通随从被视为微型机并触发抽牌', () => {
+            // 玩家0：Microbot Archive + Microbot Alpha + 普通随从
+            const archive = makeMinion({ defId: 'robot_microbot_archive', uid: 'ma-alpha-1', controller: '0' });
+            const alpha = makeMinion({ defId: 'robot_microbot_alpha', uid: 'alpha-1', controller: '0' });
+            const normal = makeMinion({ defId: 'test_normal_minion', uid: 'nm-1', controller: '0' });
+            const base = makeBase({ minions: [archive, alpha, normal] });
+            const state = makeState([base]);
+
+            const { events } = fireTriggers(state, 'onMinionDestroyed', {
+                state,
+                playerId: '0',
+                baseIndex: 0,
+                triggerMinionUid: 'nm-1',
+                triggerMinionDefId: 'test_normal_minion',
+                triggerMinion: normal,
+                random: dummyRandom,
+                now: 1000,
+            } as any);
+
+            const drawEvents = events.filter(
+                e => e.type === SU_EVENTS.CARDS_DRAWN && (e as any).payload.playerId === '0',
+            );
+            expect(drawEvents.length).toBe(1);
+        });
+
+        test('Alpha + 普通随从在不同基地时 Archive 仍对己方普通随从触发', () => {
+            // base0: Archive
+            const archive = makeMinion({ defId: 'robot_microbot_archive', uid: 'ma-alpha-remote', controller: '0' });
+            const base0 = makeBase({ defId: 'base_a', minions: [archive] });
+            // base1: Alpha + 普通随从
+            const alpha = makeMinion({ defId: 'robot_microbot_alpha', uid: 'alpha-remote', controller: '0' });
+            const normal = makeMinion({ defId: 'test_normal_minion', uid: 'nm-remote', controller: '0' });
+            const base1 = makeBase({ defId: 'base_b', minions: [alpha, normal] });
+            const state = makeState([base0, base1]);
+
+            const { events } = fireTriggers(state, 'onMinionDestroyed', {
+                state,
+                playerId: '0',
+                baseIndex: 1,
+                triggerMinionUid: 'nm-remote',
+                triggerMinionDefId: 'test_normal_minion',
+                triggerMinion: normal,
+                random: dummyRandom,
+                now: 1000,
+            } as any);
+
+            const drawEvents = events.filter(
+                e => e.type === SU_EVENTS.CARDS_DRAWN && (e as any).payload.playerId === '0',
+            );
+            expect(drawEvents.length).toBe(1);
+        });
+
+        test('对手的微型机（含 Alpha 视为）被消灭时不触发', () => {
+            // 玩家0：Archive；玩家1：Alpha + 普通随从
+            const archive = makeMinion({ defId: 'robot_microbot_archive', uid: 'ma-enemy', controller: '0' });
+            const base0 = makeBase({ defId: 'base_a', minions: [archive] });
+
+            const alphaEnemy = makeMinion({
+                defId: 'robot_microbot_alpha',
+                uid: 'alpha-enemy',
+                controller: '1',
+                owner: '1',
+            });
+            const normalEnemy = makeMinion({
+                defId: 'test_normal_minion',
+                uid: 'nm-enemy',
+                controller: '1',
+                owner: '1',
+            });
+            const base1 = makeBase({ defId: 'base_b', minions: [alphaEnemy, normalEnemy] });
+
+            const state = makeState([base0, base1], {
+                '1': {
+                    id: '1',
+                    vp: 0,
+                    hand: [],
+                    deck: [makeCard('od1', 'opp_deck_1', 'minion', '1', SMASHUP_FACTION_IDS.ROBOTS)],
+                    discard: [],
+                    minionsPlayed: 0,
+                    minionLimit: 1,
+                    actionsPlayed: 0,
+                    actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.ROBOTS, 'test_d'] as [string, string],
+                },
+            });
+
+            const { events } = fireTriggers(state, 'onMinionDestroyed', {
+                state,
+                playerId: '1',
+                baseIndex: 1,
+                triggerMinionUid: 'nm-enemy',
+                triggerMinionDefId: 'test_normal_minion',
+                triggerMinion: normalEnemy,
+                random: dummyRandom,
+                now: 1000,
+            } as any);
+
+            const drawEventsP0 = events.filter(
+                e => e.type === SU_EVENTS.CARDS_DRAWN && (e as any).payload.playerId === '0',
+            );
+            expect(drawEventsP0.length).toBe(0);
+        });
+
+        test('Archive 自身作为微型机被消灭时也会触发抽牌', () => {
+            const archive = makeMinion({ defId: 'robot_microbot_archive', uid: 'ma-self', controller: '0' });
+            const base = makeBase({ minions: [archive] });
+            const state = makeState([base]);
+
+            const { events } = fireTriggers(state, 'onMinionDestroyed', {
+                state,
+                playerId: '0',
+                baseIndex: 0,
+                triggerMinionUid: 'ma-self',
+                triggerMinionDefId: 'robot_microbot_archive',
+                triggerMinion: archive,
+                random: dummyRandom,
+                now: 1000,
+            } as any);
+
+            const drawEvents = events.filter(
+                e => e.type === SU_EVENTS.CARDS_DRAWN && (e as any).payload.playerId === '0',
+            );
+            expect(drawEvents.length).toBe(1);
+        });
     });
 });
-
 
 // ============================================================================
 // 巫师 ongoing 能力

--- a/src/games/smashup/abilities/robots.ts
+++ b/src/games/smashup/abilities/robots.ts
@@ -6,14 +6,22 @@
 
 import { registerAbility } from '../domain/abilityRegistry';
 import type { AbilityContext, AbilityResult } from '../domain/abilityRegistry';
-import { grantExtraMinion, destroyMinion, getMinionPower, buildMinionTargetOptions, buildBaseTargetOptions, peekDeckTop, buildAbilityFeedback } from '../domain/abilityHelpers';
+import {
+    grantExtraMinion,
+    destroyMinion,
+    getMinionPower,
+    buildMinionTargetOptions,
+    buildBaseTargetOptions,
+    peekDeckTop,
+    buildAbilityFeedback,
+} from '../domain/abilityHelpers';
 import { SU_EVENTS } from '../domain/types';
 import type { SmashUpEvent, MinionPlayedEvent } from '../domain/types';
 import type { MinionCardDef } from '../domain/types';
 import { registerProtection, registerTrigger } from '../domain/ongoingEffects';
 import { getCardDef, getBaseDef } from '../data/cards';
 import { createSimpleChoice, queueInteraction, type PromptOption } from '../../../engine/systems/InteractionSystem';
-import { drawCards, isDiscardMicrobot, matchesDefId, MICROBOT_DEF_IDS } from '../domain/utils';
+import { drawCards, isDiscardMicrobot, isMicrobot, matchesDefId, MICROBOT_DEF_IDS } from '../domain/utils';
 import { registerInteractionHandler } from '../domain/abilityInteractionHandlers';
 
 /** 注册机器人派系所有能力*/
@@ -26,33 +34,45 @@ export function registerRobotAbilities(): void {
     registerAbility('robot_zapbot', 'onPlay', robotZapbot);
     // 技术中心（行动卡）：按基地上随从数抽牌
     registerAbility('robot_tech_center', 'onPlay', robotTechCenter);
-    // 核弹机器人?onDestroy：被消灭后消灭同基地其他玩家所有随从
+    // 核弹机器人 onDestroy：被消灭后消灭同基地其他玩家所有随从
     registerAbility('robot_nukebot', 'onDestroy', robotNukebotOnDestroy);
 
-    // 注册 ongoing 拦截器?
+    // 注册 ongoing 拦截器
     registerRobotOngoingEffects();
 }
 
-/** 微型机守护者?onPlay：消灭力量低于己方随从数量的随从 */
+/** 微型机守护者 onPlay：消灭力量低于己方随从数量的随从 */
 function robotMicrobotGuard(ctx: AbilityContext): AbilityResult {
     const base = ctx.state.bases[ctx.baseIndex];
     if (!base) return { events: [] };
+
     const myMinionCount = base.minions.filter(m => m.controller === ctx.playerId).length + 1;
     const targets = base.minions.filter(
-        m => m.uid !== ctx.cardUid && getMinionPower(ctx.state, m, ctx.baseIndex) < myMinionCount
+        m => m.uid !== ctx.cardUid && getMinionPower(ctx.state, m, ctx.baseIndex) < myMinionCount,
     );
-    if (targets.length === 0) return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.no_valid_targets', ctx.now)] };
-    // Prompt 选择
+    if (targets.length === 0) {
+        return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.no_valid_targets', ctx.now)] };
+    }
+
     const options = targets.map(t => {
+        const def = getCardDef(t.defId) as MinionCardDef | undefined;
+        const name = def?.name ?? t.defId;
         const power = getMinionPower(ctx.state, t, ctx.baseIndex);
-        return { uid: t.uid, defId: t.defId, baseIndex: ctx.baseIndex, label: `cards.${t.defId}.name (力量 ${power})` };
+        return { uid: t.uid, defId: t.defId, baseIndex: ctx.baseIndex, label: `${name} (力量 ${power})` };
     });
+
     const interaction = createSimpleChoice(
-        `robot_microbot_guard_${ctx.now}`, ctx.playerId,
+        `robot_microbot_guard_${ctx.now}`,
+        ctx.playerId,
         '选择要消灭的随从（力量低于己方随从数量）',
-        buildMinionTargetOptions(options, { state: ctx.state, sourcePlayerId: ctx.playerId, effectType: 'destroy' }),
+        buildMinionTargetOptions(options, {
+            state: ctx.state,
+            sourcePlayerId: ctx.playerId,
+            effectType: 'destroy',
+        }),
         { sourceId: 'robot_microbot_guard', targetType: 'minion' },
     );
+
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
 }
 
@@ -60,7 +80,7 @@ function robotMicrobotGuard(ctx: AbilityContext): AbilityResult {
 function robotMicrobotFixer(ctx: AbilityContext): AbilityResult {
     const player = ctx.state.players[ctx.playerId];
     // onPlay 在 reduce 之后执行，第一个随从打出后 minionsPlayed 已从 0 变为 1
-    // 所以 minionsPlayed > 1 表示"之前已经打过随从"，此时不触发
+    // 所以 minionsPlayed > 1 表示“之前已经打过随从”，此时不触发
     if (player.minionsPlayed > 1) return { events: [] };
     return { events: [grantExtraMinion(ctx.playerId, 'robot_microbot_fixer', ctx.now)] };
 }
@@ -71,33 +91,49 @@ function robotMicrobotReclaimer(ctx: AbilityContext): AbilityResult {
     const events: SmashUpEvent[] = [];
 
     // onPlay 在 reduce 之后执行，第一个随从打出后 minionsPlayed 已从 0 变为 1
-    // 所以 minionsPlayed === 1 表示"这是本回合第一个随从"
+    // 所以 minionsPlayed === 1 表示“这是本回合第一个随从”
     if (player.minionsPlayed === 1) {
         events.push(grantExtraMinion(ctx.playerId, 'robot_microbot_reclaimer', ctx.now));
     }
 
-    // 将弃牌堆中的微型机洗回牌库（"任意数量"：玩家选择）
-    // alpha 在场时所有己方随从卡都算微型机
-    const microbotsInDiscard = player.discard.filter(
-        c => isDiscardMicrobot(ctx.state, c, ctx.playerId)
-    );
+    // 将弃牌堆中的微型机洗回牌库（“任意数量”：玩家选择）
+    // Alpha 在场时所有己方随从卡都算微型机
+    const microbotsInDiscard = player.discard.filter(c => isDiscardMicrobot(ctx.state, c, ctx.playerId));
     if (microbotsInDiscard.length === 0) return { events };
 
-    const options: PromptOption<{ cardUid: string; defId: string } | { skip: true }>[] = microbotsInDiscard.map((c, i) => {
-        return { 
-            id: `microbot-${i}`, 
-            label: `cards.${c.defId}.name`, 
-            value: { cardUid: c.uid, defId: c.defId },
-            _source: 'discard' as const,
-            displayMode: 'card' as const,
-        };
-    });
-    const skipOption: PromptOption<{ cardUid: string; defId: string } | { skip: true }> = { id: 'skip', label: '跳过（不洗回）', value: { skip: true } , displayMode: 'button' as const };
-    const interaction = createSimpleChoice<{ cardUid: string; defId: string } | { skip: true }>(
-        `robot_microbot_reclaimer_${ctx.now}`, ctx.playerId,
-        '选择要洗回牌库的微型机（任意数量，可跳过）', [...options, skipOption],
-        { sourceId: 'robot_microbot_reclaimer', targetType: 'generic', multi: { min: 0, max: microbotsInDiscard.length } },
+    const options: PromptOption<{ cardUid: string; defId: string } | { skip: true }>[] = microbotsInDiscard.map(
+        (c, i) => {
+            const def = getCardDef(c.defId);
+            const name = def?.name ?? c.defId;
+            return {
+                id: `microbot-${i}`,
+                label: name,
+                value: { cardUid: c.uid, defId: c.defId },
+                _source: 'discard' as const,
+                displayMode: 'card' as const,
+            };
+        },
     );
+
+    const skipOption: PromptOption<{ cardUid: string; defId: string } | { skip: true }> = {
+        id: 'skip',
+        label: '跳过（不洗回）',
+        value: { skip: true },
+        displayMode: 'button' as const,
+    };
+
+    const interaction = createSimpleChoice<{ cardUid: string; defId: string } | { skip: true }>(
+        `robot_microbot_reclaimer_${ctx.now}`,
+        ctx.playerId,
+        '选择要洗回牌库的微型机（任意数量，可跳过）',
+        [...options, skipOption],
+        {
+            sourceId: 'robot_microbot_reclaimer',
+            targetType: 'generic',
+            multi: { min: 0, max: microbotsInDiscard.length },
+        },
+    );
+
     return { events, matchState: queueInteraction(ctx.matchState, interaction) };
 }
 
@@ -109,119 +145,126 @@ export function resetRobotHoverbotCounter(): void {
     robotHoverbotCounter = 0;
 }
 
-/** 盘旋机器人 onPlay：展示牌库顶，如果是随从"你可以"将其作为额外随从打出 */
+/** 盘旋机器人 onPlay：展示牌库顶，如果是随从“你可以”将其作为额外随从打出 */
 function robotHoverbot(ctx: AbilityContext): AbilityResult {
-    const peek = peekDeckTop(
-        ctx.state.players[ctx.playerId], ctx.playerId,
-        'all', 'robot_hoverbot', ctx.now,
-    );
-    
+    const peek = peekDeckTop(ctx.state.players[ctx.playerId], ctx.playerId, 'all', 'robot_hoverbot', ctx.now);
     if (!peek) {
         return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.deck_empty', ctx.now)] };
     }
+
     const events: SmashUpEvent[] = [peek.revealEvent];
-    
+
     if (peek.card.type === 'minion') {
         const def = getCardDef(peek.card.defId) as MinionCardDef | undefined;
         const power = def?.power ?? 0;
-        
-        // "你可以" → 创建交互让玩家选择是否打出该特定随从
-        // 使用静态计数器而非时间戳，确保交互 ID 稳定（防止重复处理时 ID 变化）
-        // 标题和选项 label 使用 i18n key，由 UI 层的 resolveI18nKeys 翻译
-        const initialOptions: PromptOption<{ cardUid: string; defId: string; power: number } | { skip: true }>[] = [
-            { 
-                id: 'play', 
-                label: `打出 cards.${peek.card.defId}.name`, 
+
+        const initialOptions: PromptOption<
+            { cardUid: string; defId: string; power: number } | { skip: true }
+        >[] = [
+            {
+                id: 'play',
+                label: `打出 cards.${peek.card.defId}.name`,
                 value: { cardUid: peek.card.uid, defId: peek.card.defId, power },
                 displayMode: 'card' as const,
-                _source: 'static' as const,  // ✅ 关键修复：显式声明为静态选项，防止框架层自动刷新时误判为手牌选项
+                _source: 'static' as const,
             },
-            { id: 'skip', label: '放回牌库顶', value: { skip: true } , displayMode: 'button' as const },
+            {
+                id: 'skip',
+                label: '放回牌库顶',
+                value: { skip: true },
+                displayMode: 'button' as const,
+            },
         ];
-        
+
         const interaction = createSimpleChoice<{ cardUid: string; defId: string; power: number } | { skip: true }>(
-            `robot_hoverbot_${robotHoverbotCounter++}`, ctx.playerId,
+            `robot_hoverbot_${robotHoverbotCounter++}`,
+            ctx.playerId,
             `牌库顶是 cards.${peek.card.defId}.name（力量 ${power}），是否作为额外随从打出？`,
             initialOptions,
             { sourceId: 'robot_hoverbot', targetType: 'generic' },
         );
-        
-        // ⚠️ 关键：必须先设置 continuationContext，再设置 optionsGenerator
-        // 因为 optionsGenerator 可能在交互创建时立即被调用（如果没有 current 交互）
+
         const interactionData = interaction.data as any;
         interactionData.continuationContext = {
             cardUid: peek.card.uid,
             defId: peek.card.defId,
             power,
         };
-        
-        // 手动提供 optionsGenerator：从 continuationContext 读取卡牌信息，而不是从牌库顶读取
-        // 这样即使牌库顶变化了，交互选项仍然显示原来看到的那张卡
+
         interactionData.optionsGenerator = (_state: any, iData: any) => {
-            const ctx = iData?.continuationContext as { cardUid: string; defId: string; power: number } | undefined;
-            
-            if (!ctx) {
-                return [{ id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const }];
+            const c = iData?.continuationContext as { cardUid: string; defId: string; power: number } | undefined;
+            if (!c) {
+                return [
+                    { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
+                ];
             }
-            
-            // 从 continuationContext 读取卡牌信息（不依赖牌库顶状态）
             return [
-                { 
-                    id: 'play', 
-                    label: `打出 cards.${ctx.defId}.name`, 
-                    value: { cardUid: ctx.cardUid, defId: ctx.defId, power: ctx.power },
+                {
+                    id: 'play',
+                    label: `打出 cards.${c.defId}.name`,
+                    value: { cardUid: c.cardUid, defId: c.defId, power: c.power },
                     displayMode: 'card' as const,
                     _source: 'static' as const,
                 },
-                { id: 'skip', label: '放回牌库顶', value: { skip: true } , displayMode: 'button' as const },
+                { id: 'skip', label: '放回牌库顶', value: { skip: true }, displayMode: 'button' as const },
             ];
         };
-        
+
         return { events, matchState: queueInteraction(ctx.matchState, interaction) };
     }
-    
-    // 非随从→放回牌库顶（peek 不移除卡，无需操作）
+
+    // 非随从 → 只展示并放回牌库顶（peek 不移除卡，无需额外事件）
     return { events };
 }
 
-/** 高速机器人 onPlay：你可以打出一张力量≤2的额外随从（+1额度，力量限制由验证层自动检查） */
+/** 高速机器人 onPlay：你可以打出一张力量≤2的额外随从（+1 额度，力量限制由验证层自动检查） */
 function robotZapbot(ctx: AbilityContext): AbilityResult {
-    return { events: [grantExtraMinion(ctx.playerId, 'robot_zapbot', ctx.now, undefined, { powerMax: 2 })] };
+    return {
+        events: [grantExtraMinion(ctx.playerId, 'robot_zapbot', ctx.now, undefined, { powerMax: 2 })],
+    };
 }
 
-/** 技术中心?onPlay：选择一个基地，该基地上你每有一个随从就抽一张牌 */
+/** 技术中心 onPlay：选择一个基地，该基地上你每有一个随从就抽一张牌 */
 function robotTechCenter(ctx: AbilityContext): AbilityResult {
-    // 收集有己方随从的基地
     const candidates: { baseIndex: number; count: number; label: string }[] = [];
+
     for (let i = 0; i < ctx.state.bases.length; i++) {
         const count = ctx.state.bases[i].minions.filter(m => m.controller === ctx.playerId).length;
         if (count > 0) {
-            const baseDefId = ctx.state.bases[i].defId;
-            candidates.push({ baseIndex: i, count, label: `cards.${baseDefId}.name (${count} 个随从)` });
+            const baseDef = getBaseDef(ctx.state.bases[i].defId);
+            const baseName = baseDef?.name ?? `基地 ${i + 1}`;
+            candidates.push({ baseIndex: i, count, label: `${baseName} (${count} 个随从)` });
         }
     }
-    if (candidates.length === 0) return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.no_valid_targets', ctx.now)] };
-    // Prompt 选择（包含取消选项）
+
+    if (candidates.length === 0) {
+        return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.no_valid_targets', ctx.now)] };
+    }
+
     const interaction = createSimpleChoice(
-        `robot_tech_center_${ctx.now}`, ctx.playerId,
-        '选择一个基地（按该基地上你的随从数抽牌）', buildBaseTargetOptions(candidates, ctx.state),
-        { sourceId: 'robot_tech_center', targetType: 'base', autoCancelOption: true }
+        `robot_tech_center_${ctx.now}`,
+        ctx.playerId,
+        '选择一个基地（按该基地上你的随从数抽牌）',
+        buildBaseTargetOptions(candidates, ctx.state),
+        { sourceId: 'robot_tech_center', targetType: 'base', autoCancelOption: true },
     );
+
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
 }
 
-/** 核弹机器人 onDestroy：被消灭后消灭同基地其他玩家所有随从*/
+/** 核弹机器人 onDestroy：被消灭后消灭同基地其他玩家所有随从 */
 function robotNukebotOnDestroy(ctx: AbilityContext): AbilityResult {
     const base = ctx.state.bases[ctx.baseIndex];
     if (!base) return { events: [] };
-    // 消灭同基地上不属于自己的所有随从
+
     const targets = base.minions.filter(
-        m => m.uid !== ctx.cardUid && m.controller !== ctx.playerId
+        m => m.uid !== ctx.cardUid && m.controller !== ctx.playerId,
     );
     if (targets.length === 0) return { events: [] };
+
     return {
         events: targets.map(t =>
-            destroyMinion(t.uid, t.defId, ctx.baseIndex, t.owner, undefined, 'robot_nukebot', ctx.now)
+            destroyMinion(t.uid, t.defId, ctx.baseIndex, t.owner, undefined, 'robot_nukebot', ctx.now),
         ),
     };
 }
@@ -234,21 +277,28 @@ function robotNukebotOnDestroy(ctx: AbilityContext): AbilityResult {
 export function registerRobotInteractionHandlers(): void {
     // 微型机回收者：玩家选择任意数量的微型机洗回牌库
     registerInteractionHandler('robot_microbot_reclaimer', (state, playerId, value, _iData, random, timestamp) => {
-        const selectedCards = Array.isArray(value) ? value : (value ? [value] : []);
+        const selectedCards = Array.isArray(value) ? value : value ? [value] : [];
         if (selectedCards.length === 0) return { state, events: [] };
+
         const cardUids = selectedCards.map((v: any) => v.cardUid).filter(Boolean) as string[];
         if (cardUids.length === 0) return { state, events: [] };
+
         const player = state.core.players[playerId];
         const selectedUidSet = new Set(cardUids);
         const microbotsFromDiscard = player.discard.filter(c => selectedUidSet.has(c.uid));
         const newDeck = [...player.deck, ...microbotsFromDiscard];
         const shuffled = random.shuffle([...newDeck]);
-        // DECK_REORDERED：包含弃牌堆中选中的卡 UID，reducer 会自动从弃牌堆移除
-        return { state, events: [{
-            type: SU_EVENTS.DECK_REORDERED,
-            payload: { playerId, deckUids: shuffled.map(c => c.uid) },
-            timestamp,
-        }] };
+
+        return {
+            state,
+            events: [
+                {
+                    type: SU_EVENTS.DECK_REORDERED,
+                    payload: { playerId, deckUids: shuffled.map(c => c.uid) },
+                    timestamp,
+                },
+            ],
+        };
     });
 
     // 微型机守护者：选择目标后消灭
@@ -256,72 +306,104 @@ export function registerRobotInteractionHandlers(): void {
         const { minionUid, baseIndex } = value as { minionUid: string; baseIndex: number };
         const base = state.core.bases[baseIndex];
         if (!base) return undefined;
+
         const target = base.minions.find(m => m.uid === minionUid);
         if (!target) return undefined;
-        return { state, events: [destroyMinion(target.uid, target.defId, baseIndex, target.owner, sourcePlayerId, 'robot_microbot_guard', timestamp)] };
+
+        return {
+            state,
+            events: [
+                destroyMinion(
+                    target.uid,
+                    target.defId,
+                    baseIndex,
+                    target.owner,
+                    sourcePlayerId,
+                    'robot_microbot_guard',
+                    timestamp,
+                ),
+            ],
+        };
     });
 
     // 技术中心：选择基地后按随从数抽牌
     registerInteractionHandler('robot_tech_center', (state, playerId, value, _iData, _random, timestamp) => {
-        // 检查取消标记
         if ((value as any).__cancel__) return { state, events: [] };
-        
+
         const { baseIndex } = value as { baseIndex: number };
         const base = state.core.bases[baseIndex];
         if (!base) return undefined;
+
         const count = base.minions.filter(m => m.controller === playerId).length;
         if (count === 0) return undefined;
+
         const player = state.core.players[playerId];
         if (!player || player.deck.length === 0) return undefined;
+
         const actualDraw = Math.min(count, player.deck.length);
         const drawnUids = player.deck.slice(0, actualDraw).map(c => c.uid);
-        return { state, events: [{
-            type: SU_EVENTS.CARDS_DRAWN,
-            payload: { playerId, count: actualDraw, cardUids: drawnUids },
-            timestamp,
-        }] };
+
+        return {
+            state,
+            events: [
+                {
+                    type: SU_EVENTS.CARDS_DRAWN,
+                    payload: { playerId, count: actualDraw, cardUids: drawnUids },
+                    timestamp,
+                },
+            ],
+        };
     });
 
     // 盘旋机器人：选择是否打出牌库顶随从
     registerInteractionHandler('robot_hoverbot', (state, playerId, value, _iData, _random, timestamp) => {
         if (value && (value as any).skip) return { state, events: [] };
+
         const { cardUid, defId, power } = value as { cardUid: string; defId: string; power: number };
         if (!cardUid) return undefined;
-        // 该卡必须在牌库顶
+
         const player = state.core.players[playerId];
         if (player.deck.length === 0 || player.deck[0].uid !== cardUid) {
-            // 验证失败：卡牌不在牌库顶（可能被其他效果移除）
-            // 抛出错误以阻止命令执行
             throw new Error(`卡牌 ${cardUid} 不在牌库顶，无法打出`);
         }
-        // 单基地直接打出
+
         if (state.core.bases.length === 1) {
             const playedEvt: MinionPlayedEvent = {
                 type: SU_EVENTS.MINION_PLAYED,
-                payload: { 
-                    playerId, 
-                    cardUid, 
-                    defId, 
-                    baseIndex: 0, 
+                payload: {
+                    playerId,
+                    cardUid,
+                    defId,
+                    baseIndex: 0,
                     baseDefId: state.core.bases[0].defId,
                     power,
                     fromDeck: true,
                 },
                 timestamp,
             };
-            return { state, events: [
-                grantExtraMinion(playerId, 'robot_hoverbot', timestamp),
-                playedEvt,
-            ] };
+
+            return {
+                state,
+                events: [
+                    grantExtraMinion(playerId, 'robot_hoverbot', timestamp),
+                    playedEvt,
+                ],
+            };
         }
-        // 多基地→链式选基地
+
         const baseCandidates = state.core.bases.map((b, i) => {
             const bd = getBaseDef(b.defId);
             return { baseIndex: i, label: bd?.name ?? `基地 ${i + 1}` };
         });
+
         const next = createSimpleChoice(
-            `robot_hoverbot_base_${timestamp}`, playerId, '选择打出随从的基地', buildBaseTargetOptions(baseCandidates, state.core), { sourceId: 'robot_hoverbot_base', targetType: 'base' }
-            );
+            `robot_hoverbot_base_${timestamp}`,
+            playerId,
+            '选择打出随从的基地',
+            buildBaseTargetOptions(baseCandidates, state.core),
+            { sourceId: 'robot_hoverbot_base', targetType: 'base' },
+        );
+
         return {
             state: queueInteraction(state, {
                 ...next,
@@ -334,42 +416,81 @@ export function registerRobotInteractionHandlers(): void {
     // 盘旋机器人：选基地后打出
     registerInteractionHandler('robot_hoverbot_base', (state, playerId, value, iData, _random, timestamp) => {
         const { baseIndex } = value as { baseIndex: number };
-        const ctx = iData?.continuationContext as { cardUid: string; defId: string; power: number } | undefined;
+        const ctx = iData?.continuationContext as
+            | { cardUid: string; defId: string; power: number }
+            | undefined;
+
         if (!ctx) return undefined;
+
         const playedEvt: MinionPlayedEvent = {
             type: SU_EVENTS.MINION_PLAYED,
-            payload: { playerId, cardUid: ctx.cardUid, defId: ctx.defId, baseIndex, power: ctx.power, fromDeck: true },
+            payload: {
+                playerId,
+                cardUid: ctx.cardUid,
+                defId: ctx.defId,
+                baseIndex,
+                power: ctx.power,
+                fromDeck: true,
+            },
             timestamp,
         };
-        return { state, events: [
-            grantExtraMinion(playerId, 'robot_hoverbot', timestamp),
-            playedEvt,
-        ] };
+
+        return {
+            state,
+            events: [
+                grantExtraMinion(playerId, 'robot_hoverbot', timestamp),
+                playedEvt,
+            ],
+        };
     });
 }
 
 // ============================================================================
-// Ongoing 拦截器注册?
+// Ongoing 拦截器注册
 // ============================================================================
 
-/** 注册机器人派系的 ongoing 拦截器?*/
+/** 注册机器人派系的 ongoing 拦截器 */
 function registerRobotOngoingEffects(): void {
     // 战争机器人：不能被消灭
-    registerProtection('robot_warbot', 'destroy', (ctx) => {
-        return matchesDefId(ctx.targetMinion.defId, 'robot_warbot');
-    });
+    registerProtection('robot_warbot', 'destroy', ctx =>
+        matchesDefId(ctx.targetMinion.defId, 'robot_warbot'),
+    );
 
-    // 微型机档案馆：微型机被消灭后控制者抽1张牌
-    registerTrigger('robot_microbot_archive', 'onMinionDestroyed', (trigCtx) => {
-        if (!trigCtx.triggerMinionDefId) return [];
-        // 检查被消灭的是否是微型机
-        // 需要找到被消灭随从的控制者来判断 alpha 是否在场
-        // trigCtx 中没有被消灭随从的完整信息，用 defId 判断原始微型机
-        // alpha 联动需要知道控制者，但 onMinionDestroyed 触发时随从已移除
-        // 保守实现：原始微型机 defId 始终触发
-        if (!Array.from(MICROBOT_DEF_IDS).some(defId => matchesDefId(trigCtx.triggerMinionDefId, defId))) return [];
+    // 微型机档案馆：微型机被消灭后控制者抽 1 张牌（支持 Alpha “视为微型机”）
+    registerTrigger('robot_microbot_archive', 'onMinionDestroyed', trigCtx => {
+        // 必须有触发随从的基本信息
+        if (!trigCtx.triggerMinionDefId && !trigCtx.triggerMinionUid && !trigCtx.triggerMinion) {
+            return [];
+        }
 
-        // 找到 microbot_archive 的拥有者
+        // 尝试拿到被消灭随从的实体
+        let destroyedMinion = trigCtx.triggerMinion;
+        if (!destroyedMinion && trigCtx.triggerMinionUid) {
+            for (const base of trigCtx.state.bases) {
+                const found = base.minions.find(m => m.uid === trigCtx.triggerMinionUid);
+                if (found) {
+                    destroyedMinion = found;
+                    break;
+                }
+            }
+        }
+
+        if (!destroyedMinion) {
+            // 没有实体，只能按原始 defId 判断是否是“印刷微型机”
+            if (!trigCtx.triggerMinionDefId) return [];
+            if (
+                !Array.from(MICROBOT_DEF_IDS).some(defId =>
+                    matchesDefId(trigCtx.triggerMinionDefId, defId),
+                )
+            ) {
+                return [];
+            }
+        } else {
+            // 有实体时，按统一规则判断是否为微型机（支持 Alpha 视为）
+            if (!isMicrobot(trigCtx.state, destroyedMinion)) return [];
+        }
+
+        // 找到 Archive 的控制者
         let archiveOwner: string | undefined;
         for (const base of trigCtx.state.bases) {
             const archive = base.minions.find(m => matchesDefId(m.defId, 'robot_microbot_archive'));
@@ -380,19 +501,21 @@ function registerRobotOngoingEffects(): void {
         }
         if (!archiveOwner) return [];
 
-        // "你的"微型机 → 被消灭随从必须属于 archive 控制者
+        // “你的 Microbot” → 被消灭随从必须由 Archive 控制者控制
         if (trigCtx.playerId !== archiveOwner) return [];
 
-        // 抽1张牌
         const player = trigCtx.state.players[archiveOwner];
         if (!player || player.deck.length === 0) return [];
+
         const { drawnUids } = drawCards(player, 1, trigCtx.random);
         if (drawnUids.length === 0) return [];
 
-        return [{
-            type: SU_EVENTS.CARDS_DRAWN,
-            payload: { playerId: archiveOwner, count: 1, cardUids: drawnUids },
-            timestamp: trigCtx.now,
-        }];
+        return [
+            {
+                type: SU_EVENTS.CARDS_DRAWN,
+                payload: { playerId: archiveOwner, count: 1, cardUids: drawnUids },
+                timestamp: trigCtx.now,
+            },
+        ];
     });
 }


### PR DESCRIPTION
Fix The Locals reveal behavior to reshuffle discard when deck is empty
Fix Return to the Sea to return controlled minions to controller’s hand
Make In Plain Sight POD use printed power ≤ 2 for protection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed microbot-related card drawing interactions with Alpha compatibility.
  * Improved Guard, Reclaimer, and Hoverbot robot ability handling across multiple bases.
  * Enhanced Microbot Archive destruction trigger logic.
  * Fixed Tech Center base labeling and edge cases.

* **Tests**
  * Added comprehensive test coverage for robot ongoing abilities and microbot interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->