### PR TITLE
fix(smashup): 修复小精怪POD卡池计数与能力串味

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24.1.0'
           cache: 'npm'
 
       - name: Install dependencies

--- a/public/locales/en/game-smashup.json
+++ b/public/locales/en/game-smashup.json
@@ -2030,7 +2030,7 @@
     },
     "miskatonic_researcher_pod": {
       "name": "Researcher",
-      "abilityText": "You may draw a Madness card."
+      "abilityText": "You may draw a Madness card to place a +1 power counter on a minion."
     },
     "miskatonic_old_man_jenkins_pod": {
       "name": "\"Old Man Jenkins?\"",

--- a/public/locales/zh-CN/game-smashup.json
+++ b/public/locales/zh-CN/game-smashup.json
@@ -2022,15 +2022,15 @@
     },
     "miskatonic_librarian_pod": {
       "name": "图书馆管理员",
-      "abilityText": "天赋：抓一张疯狂卡，或从你的手牌中打出一张疯狂卡作为额外战术。"
+      "abilityText": "天赋：抽一张疯狂卡，或从你的手牌中打出一张疯狂卡作为额外战术。"
     },
     "miskatonic_psychologist_pod": {
       "name": "心理学家",
-      "abilityText": "将你手牌或弃牌堆中的一张疯狂卡返回疯狂牌库，或者从你的弃牌堆中抓一张疯狂卡。"
+      "abilityText": "将你手牌或弃牌堆中的一张疯狂卡返回疯狂牌库，或者从你的弃牌堆中抽一张疯狂卡。"
     },
     "miskatonic_researcher_pod": {
       "name": "研究员",
-      "abilityText": "你可以抓一张疯狂卡。"
+      "abilityText": "你可以抽一张疯狂卡来在一个随从上放置一个+1战斗力指示物。"
     },
     "miskatonic_book_of_iter_the_unseen_pod": {
       "name": "金克丝!",
@@ -2050,7 +2050,7 @@
     },
     "miskatonic_mandatory_reading_pod": {
       "name": "最好不知道的事",
-      "effectText": "特殊：在一个基地计分前，选择这里的一个随从。抽最多3张疯狂卡。每抽取一张疯狂卡这个随从都获得+2战斗力。"
+      "effectText": "特殊：在一个基地计分前，选择这里的一个随从。抽最多3张疯狂卡。每抽取一张疯狂卡，这个随从直到回合结束获得+2战斗力。"
     },
     "miskatonic_psychological_profiling_pod": {
       "name": "这太疯狂了...",
@@ -2058,11 +2058,11 @@
     },
     "miskatonic_those_meddling_kids_pod": {
       "name": "那些爱管闲事的孩子",
-      "effectText": "消灭一个基地上任意数量的战术，或者抓一张疯狂卡并额外打出一张战术。"
+      "effectText": "消灭一个基地上任意数量的战术，或者抽一张疯狂卡并额外打出一张战术。"
     },
     "miskatonic_field_trip_pod": {
       "name": "实地考察",
-      "effectText": "将你手牌中任意数量的卡牌放到你牌库底，并抓取相同数量加一的牌。"
+      "effectText": "将你手牌中任意数量的卡牌放到你牌库底，然后抽取该数量加一张牌。"
     },
     "ninja_master_pod": {
       "name": "忍者大师",
@@ -2509,7 +2509,7 @@
     },
     "miskatonic_eldritch_gate_pod": {
       "name": "怪异传送门",
-      "effectText": "打出到基地上。天赋：抓一张疯狂卡。你可以额外打出一个随从到这里。"
+      "effectText": "打出到基地上。天赋：抽一张疯狂卡。你可以额外打出一个随从到这里。"
     },
     "miskatonic_jinkies_pod": {
       "name": "金奇斯",
@@ -2517,11 +2517,11 @@
     },
     "miskatonic_thats_so_crazy_pod": {
       "name": "太疯狂了...",
-      "effectText": "抓一张疯狂卡。直到回合结束前，你的每个随从获得+1战斗力。你可以额外打出一张战术。"
+      "effectText": "抽一张疯狂卡。直到回合结束前，你的每个随从获得+1战斗力。你可以额外打出一张战术。"
     },
     "miskatonic_things_best_not_known_pod": {
       "name": "未知之事",
-      "effectText": "特殊：在基地计分前，抓至多三张疯狂卡。每抓一张疯狂卡，选择这里的一个随从，使其获得+2战斗力直到回合结束。"
+      "effectText": "特殊：在基地计分前，抽至多三张疯狂卡。选择这里的一个随从，每抽一张疯狂卡，该随从直到回合结束获得+2战斗力。"
     },
     "base_miskatonic_university_base_pod": {
       "name": "米斯卡塔尼克大学",

--- a/src/engine/systems/InteractionSystem.ts
+++ b/src/engine/systems/InteractionSystem.ts
@@ -19,6 +19,11 @@ import { resolveCommandTimestamp } from '../utils';
 import type { EngineSystem, HookResult } from './types';
 import { SYSTEM_IDS } from './types';
 
+function isSamePlayerId(a: unknown, b: unknown): boolean {
+    if (a === undefined || a === null || b === undefined || b === null) return false;
+    return String(a) === String(b);
+}
+
 // ============================================================================
 // 交互选项类型（原属 types.ts，逻辑上归属交互系统）
 // ============================================================================
@@ -863,7 +868,7 @@ export function createInteractionSystem<TCore>(
 
             // 如果交互有 optionsGenerator，先调用它生成选项，再序列化
             let processedCurrent = current;
-            if (current?.playerId === playerId && current.kind === 'simple-choice') {
+            if (isSamePlayerId(current?.playerId, playerId) && current.kind === 'simple-choice') {
                 const data = current.data as SimpleChoiceData;
                 if (data.optionsGenerator) {
                     console.log('[InteractionSystem playerView] Calling optionsGenerator for current:', {
@@ -884,7 +889,7 @@ export function createInteractionSystem<TCore>(
             }
 
             const filteredCurrent =
-                processedCurrent?.playerId === playerId ? stripNonSerializable(processedCurrent) : undefined;
+                isSamePlayerId(processedCurrent?.playerId, playerId) ? stripNonSerializable(processedCurrent) : undefined;
             
             console.log('[InteractionSystem playerView] After stripNonSerializable:', {
                 hasFilteredCurrent: !!filteredCurrent,
@@ -894,7 +899,7 @@ export function createInteractionSystem<TCore>(
             
             // 同样处理 queue 中的交互
             const processedQueue = queue
-                .filter((i) => i?.playerId === playerId)
+                .filter((i) => isSamePlayerId(i?.playerId, playerId))
                 .map((i) => {
                     if (i.kind === 'simple-choice') {
                         const data = i.data as SimpleChoiceData;
@@ -910,7 +915,7 @@ export function createInteractionSystem<TCore>(
                 });
             const filteredQueue = processedQueue.map(i => stripNonSerializable(i)!);
             // 当其他玩家有未完成交互时，通知当前玩家被阻塞（不暴露交互详情）
-            const isBlocked = !!current && current.playerId !== playerId;
+            const isBlocked = !!current && !isSamePlayerId(current.playerId, playerId);
 
             return {
                 interaction: { current: filteredCurrent, queue: filteredQueue, isBlocked },
@@ -932,7 +937,7 @@ function handleInteractionCancel<TCore>(
     if (!current) {
         return { halt: true, error: '没有待处理的交互' };
     }
-    if (current.playerId !== playerId) {
+    if (!isSamePlayerId(current.playerId, playerId)) {
         return { halt: true, error: '不是你的交互' };
     }
 

--- a/src/engine/systems/SimpleChoiceSystem.ts
+++ b/src/engine/systems/SimpleChoiceSystem.ts
@@ -23,6 +23,11 @@ import {
     type PromptOption,
 } from './InteractionSystem';
 
+function isSamePlayerId(a: unknown, b: unknown): boolean {
+    if (a === undefined || a === null || b === undefined || b === null) return false;
+    return String(a) === String(b);
+}
+
 // ============================================================================
 // 系统配置
 // ============================================================================
@@ -68,7 +73,7 @@ export function createSimpleChoiceSystem<TCore>(
 
             // ---- simple-choice 阻塞：该玩家的非系统命令被阻塞 ----
             if (current?.kind === 'simple-choice') {
-                if (current.playerId === command.playerId && !command.type.startsWith('SYS_')) {
+                if (isSamePlayerId(current.playerId, command.playerId) && !command.type.startsWith('SYS_')) {
                     return { halt: true, error: '请先完成当前选择' };
                 }
             }
@@ -125,7 +130,7 @@ function handleSimpleChoiceRespond<TCore>(
     if (!current) {
         return { halt: true, error: '没有待处理的选择' };
     }
-    if (current.playerId !== playerId) {
+    if (!isSamePlayerId(current.playerId, playerId)) {
         return { halt: true, error: '不是你的选择回合' };
     }
     if (current.kind !== 'simple-choice') {

--- a/src/engine/systems/__tests__/InteractionSystem.test.ts
+++ b/src/engine/systems/__tests__/InteractionSystem.test.ts
@@ -94,4 +94,30 @@ describe('InteractionSystem', () => {
         expect(result?.halt).toBe(true);
         expect(result?.error).toBe('不是你的交互');
     });
+
+    it('playerView should match player ids even when number/string types differ', () => {
+        const system = createInteractionSystem<TestCore>();
+        const state: MatchState<TestCore> = {
+            core: { value: 0 },
+            sys: {
+                interaction: {
+                    current: createSimpleChoice(
+                        'interaction-target-1',
+                        '1',
+                        'target prompt',
+                        [{ id: 'a', label: 'A', value: 'a' }],
+                    ),
+                    queue: [],
+                },
+            },
+        } as unknown as MatchState<TestCore>;
+
+        const viewForTarget = system.playerView?.(state, 1 as unknown as string) as any;
+        expect(viewForTarget?.interaction?.current?.id).toBe('interaction-target-1');
+        expect(viewForTarget?.interaction?.isBlocked).toBe(false);
+
+        const viewForOther = system.playerView?.(state, 0 as unknown as string) as any;
+        expect(viewForOther?.interaction?.current).toBeUndefined();
+        expect(viewForOther?.interaction?.isBlocked).toBe(true);
+    });
 });

--- a/src/games/smashup/__tests__/abilityBehaviorAudit.test.ts
+++ b/src/games/smashup/__tests__/abilityBehaviorAudit.test.ts
@@ -166,6 +166,12 @@ describe('SmashUp 能力行为审计', () => {
             expect(enVisibleIds.has(SMASHUP_FACTION_IDS.PIRATES)).toBe(false);
             expect(enVisibleIds.has(SMASHUP_FACTION_IDS.PIRATES_POD)).toBe(true);
         });
+
+        it('tricksters_pod 牌组总数保持 20 张', () => {
+            const total = getFactionCards(SMASHUP_FACTION_IDS.TRICKSTERS_POD as any)
+                .reduce((sum, def) => sum + def.count, 0);
+            expect(total).toBe(20);
+        });
     });
 
     // ── 1. 关键词→行为映射 ──

--- a/src/games/smashup/__tests__/afterscoring-window-skip-base-clear.test.ts
+++ b/src/games/smashup/__tests__/afterscoring-window-skip-base-clear.test.ts
@@ -242,6 +242,87 @@ describe('afterScoring 延迟清场回归', () => {
         expect(finalCore?.bases[1].minions).toHaveLength(0);
     });
 
+    it('base_the_mothership should not flush deferred clear events when next interaction is in current', () => {
+        const system = createSmashUpEventSystem();
+        const state = wrapState(makeCore({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                makeBase('base_the_mothership', {
+                    minions: [
+                        makeMinion('winner-minion', '1', 3),
+                        makeMinion('scout-minion', '0', 2, 'alien_scout'),
+                    ],
+                }),
+            ],
+            baseDeck: ['base_secret_garden'],
+        }));
+
+        // 模拟：当前交互（母舰）已被弹出，下一交互（侦察兵）已在 current，queue 为空。
+        state.sys.interaction.current = {
+            id: 'i-scout-next',
+            kind: 'simple-choice',
+            playerId: '0',
+            data: {
+                sourceId: 'alien_scout_return',
+                options: [
+                    { id: 'yes', label: '返回手牌', value: { returnIt: true } },
+                    { id: 'no', label: '留在基地', value: { returnIt: false } },
+                ],
+            },
+        } as any;
+        state.sys.interaction.queue = [];
+
+        const result = system.afterEvents?.({
+            state,
+            random: undefined as any,
+            events: [{
+                type: INTERACTION_EVENTS.RESOLVED,
+                payload: {
+                    interactionId: 'i-mothership',
+                    playerId: '1',
+                    optionId: 'minion-0',
+                    value: { minionUid: 'winner-minion', minionDefId: 'd1', baseIndex: 0 },
+                    sourceId: 'base_the_mothership',
+                    interactionData: {
+                        sourceId: 'base_the_mothership',
+                        continuationContext: {
+                            baseIndex: 0,
+                            _deferredPostScoringEvents: [
+                                {
+                                    type: SU_EVENTS.BASE_CLEARED,
+                                    payload: { baseIndex: 0, baseDefId: 'base_the_mothership' },
+                                    timestamp: 2200,
+                                },
+                                {
+                                    type: SU_EVENTS.BASE_REPLACED,
+                                    payload: {
+                                        baseIndex: 0,
+                                        oldBaseDefId: 'base_the_mothership',
+                                        newBaseDefId: 'base_secret_garden',
+                                    },
+                                    timestamp: 2200,
+                                },
+                            ],
+                        },
+                    },
+                },
+                timestamp: 2200,
+            } as any],
+        });
+
+        const emittedEvents = result?.events as SmashUpEvent[] | undefined;
+        expect(emittedEvents?.some(event => event.type === SU_EVENTS.MINION_RETURNED)).toBe(true);
+        expect(emittedEvents?.some(event => event.type === SU_EVENTS.BASE_CLEARED)).toBe(false);
+        expect(emittedEvents?.some(event => event.type === SU_EVENTS.BASE_REPLACED)).toBe(false);
+
+        const nextCtx = (result?.state.sys.interaction.current?.data as any)?.continuationContext;
+        expect(nextCtx?._deferredPostScoringEvents).toBeDefined();
+        expect(nextCtx?._deferredPostScoringEvents).toHaveLength(2);
+    });
+
     it('最后一个 afterScoring 交互已补发延迟事件时，不应再次重复补发', () => {
         const system = createSmashUpEventSystem();
         const state = wrapState(makeCore({

--- a/src/games/smashup/__tests__/baseFactionOngoing.test.ts
+++ b/src/games/smashup/__tests__/baseFactionOngoing.test.ts
@@ -1228,6 +1228,25 @@ describe('诡术师 ongoing 能力', () => {
             expect((events[0] as any).payload.count).toBe(1);
             expect(events[1].type).toBe(SU_EVENTS.MINION_METADATA_UPDATED);
         });
+
+        test('POD 版不沿用旧版 onMinionAffected 触发', () => {
+            const brownie = makeMinion({ defId: 'trickster_brownie_pod', uid: 'brownie-pod-1', controller: '0', owner: '0' });
+            const base0 = makeBase({ minions: [brownie] });
+            const base1 = makeBase({});
+            const state = makeState([base0, base1]);
+
+            const { events } = fireTriggers(state, 'onMinionAffected', {
+                state,
+                playerId: '1',
+                baseIndex: 1,
+                triggerMinionUid: 'opp-new-m',
+                triggerMinionDefId: 'some_minion',
+                random: dummyRandom,
+                now: 1000,
+            } as any);
+
+            expect(events).toHaveLength(0);
+        });
     });
 
     describe('trickster_block_the_path: 封路', () => {
@@ -1274,6 +1293,17 @@ describe('诡术师 ongoing 能力', () => {
 
             // 玩家 0 的 Hideout 不应该保护玩家 1 的随从
             expect(isMinionProtected(state, enemyMinion, 0, '0', 'action')).toBe(false);
+        });
+
+        test('POD 版不沿用旧版行动牌保护', () => {
+            const myMinion = makeMinion({ defId: 'trickster_a', uid: 't-1', controller: '0' });
+            const base = makeBase({
+                minions: [myMinion],
+                ongoingActions: [{ uid: 'ho-1', defId: 'trickster_hideout_pod', ownerId: '0' }],
+            });
+            const state = makeState([base]);
+
+            expect(isMinionProtected(state, myMinion, 0, '1', 'action')).toBe(false);
         });
     });
 
@@ -1328,6 +1358,22 @@ describe('诡术师 ongoing 能力', () => {
             const { events } = fireTriggers(state, 'onTurnStart', {
                 state,
                 playerId: '1',
+                random: dummyRandom,
+                now: 1000,
+            });
+
+            expect(events).toHaveLength(0);
+        });
+
+        test('POD 版不在 onTurnStart 自动给额外随从额度', () => {
+            const base = makeBase({
+                ongoingActions: [{ uid: 'em-1', defId: 'trickster_enshrouding_mist_pod', ownerId: '0' }],
+            });
+            const state = makeState([base]);
+
+            const { events } = fireTriggers(state, 'onTurnStart', {
+                state,
+                playerId: '0',
                 random: dummyRandom,
                 now: 1000,
             });

--- a/src/games/smashup/__tests__/buccaneer-pod-limit.test.ts
+++ b/src/games/smashup/__tests__/buccaneer-pod-limit.test.ts
@@ -15,6 +15,7 @@ import { SU_EVENT_TYPES } from '../domain/events';
 import type { MinionMovedEvent, SmashUpCore } from '../domain/types';
 import { moveMinion, destroyMinion } from '../domain/abilityHelpers';
 import { getInteractionHandler } from '../domain/abilityInteractionHandlers';
+import { fireTriggers } from '../domain/ongoingEffects';
 
 beforeAll(() => {
     initAllAbilities();
@@ -180,5 +181,34 @@ describe('私掠者 POD 每回合一次移动限制', () => {
         const nextCore = reduce(core, moveEvt);
         expect(nextCore.bases[1].minions.some(m => m.uid === 'bucc1')).toBe(true);
         expect(nextCore.players['0'].discard.some(c => c.uid === 'bucc1')).toBe(false);
+    });
+
+    it('消灭 buccaneer_pod 时会进入 replacement 交互（而不是直接进墓地）', () => {
+        const core = makeState({
+            bases: [
+                makeBase('base_from', [makeMinion('bucc1', 'pirate_buccaneer_pod', '0', 4)]),
+                makeBase('base_to_1', []),
+                makeBase('base_to_2', []),
+            ],
+            players: { '0': makePlayer('0'), '1': makePlayer('1') },
+        });
+        const matchState = makeMatchState(core);
+
+        const result = fireTriggers(core, 'onMinionDestroyed', {
+            state: core,
+            matchState,
+            playerId: '0',
+            baseIndex: 0,
+            triggerMinionUid: 'bucc1',
+            triggerMinionDefId: 'pirate_buccaneer_pod',
+            triggerMinion: core.bases[0].minions[0],
+            random: { random: () => 0.5, shuffle: <T>(arr: T[]) => arr, d: () => 1, range: (min: number) => min },
+            now: 7,
+        }, { phase: 'replacement' });
+
+        expect(result.events.length).toBe(0);
+        const interaction = result.matchState?.sys.interaction.current;
+        expect(interaction).toBeDefined();
+        expect((interaction?.data as any)?.sourceId).toBe('pirate_buccaneer_move');
     });
 });

--- a/src/games/smashup/__tests__/buccaneer-pod-limit.test.ts
+++ b/src/games/smashup/__tests__/buccaneer-pod-limit.test.ts
@@ -14,6 +14,7 @@ import { initAllAbilities } from '../abilities';
 import { SU_EVENT_TYPES } from '../domain/events';
 import type { MinionMovedEvent, SmashUpCore } from '../domain/types';
 import { moveMinion, destroyMinion } from '../domain/abilityHelpers';
+import { getInteractionHandler } from '../domain/abilityInteractionHandlers';
 
 beforeAll(() => {
     initAllAbilities();
@@ -137,5 +138,47 @@ describe('私掠者 POD 每回合一次移动限制', () => {
         const shouldTrigger = !(isPod && state.buccaneerPodUsedUids?.includes(triggerMinionUid));
 
         expect(shouldTrigger).toBe(false); // 预期：不应再次触发
+    });
+
+    it('BASE_CLEARED 后索引变化时，仍可通过 baseDefId 将海盗移到正确基地', () => {
+        const core = makeState({
+            bases: [
+                makeBase('base_left'),
+                makeBase('base_target'),
+            ],
+            players: {
+                '0': makePlayer('0', {
+                    discard: [makeCard('bucc1', 'pirate_buccaneer_pod', 'minion', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+        });
+
+        const ms = makeMatchState(core);
+        const handler = getInteractionHandler('pirate_buccaneer_move');
+        expect(handler).toBeDefined();
+
+        const result = handler!(
+            ms,
+            '0',
+            {
+                minionUid: 'bucc1',
+                minionDefId: 'pirate_buccaneer_pod',
+                fromBaseIndex: 0,
+                toBaseIndex: 2,
+                baseDefId: 'base_target',
+            },
+            undefined,
+            {} as any,
+            Date.now(),
+        );
+
+        expect(result.events.length).toBe(1);
+        const moveEvt = result.events[0] as MinionMovedEvent;
+        expect(moveEvt.payload.toBaseIndex).toBe(1);
+
+        const nextCore = reduce(core, moveEvt);
+        expect(nextCore.bases[1].minions.some(m => m.uid === 'bucc1')).toBe(true);
+        expect(nextCore.players['0'].discard.some(c => c.uid === 'bucc1')).toBe(false);
     });
 });

--- a/src/games/smashup/__tests__/elderThingsPod.test.ts
+++ b/src/games/smashup/__tests__/elderThingsPod.test.ts
@@ -7,6 +7,8 @@ import { clearInteractionHandlers } from '../domain/abilityInteractionHandlers';
 import { INTERACTION_COMMANDS } from '../../../engine/systems/InteractionSystem';
 import { makeCard, makeMatchState, makeMinion, makePlayer, makeState, getInteractionsFromMS } from './helpers';
 import { runCommand, defaultTestRandom } from './testRunner';
+import { getEffectivePower } from '../domain/ongoingModifiers';
+import { getTriggerExecutor } from '../domain/triggerExecutors';
 
 beforeAll(() => {
     clearRegistry();
@@ -86,6 +88,268 @@ describe('elder_things_pod: Insanity POD', () => {
         const finalP0 = res.finalState.core.players['0'];
         expect(finalP0.discard.some(c => c.uid === 'a1')).toBe(false);
         expect((finalP0.removedFromGame ?? []).some(c => c.uid === 'a1')).toBe(true);
+    });
+});
+
+describe('elder_things_pod: Mi-Go POD', () => {
+    it('does not auto-draw Madness before opponent choice resolves', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('migo', 'elder_thing_mi_go_pod', 'minion', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+            turnOrder: ['0', '1'],
+            bases: [{ defId: 'base_a', minions: [], ongoingActions: [] }],
+            madnessDeck: [makeCard('md1', MADNESS_CARD_DEF_ID, 'action', '1')],
+        });
+
+        const played = runCommand(
+            makeMatchState(core),
+            { type: SU_COMMANDS.PLAY_MINION, playerId: '0', payload: { cardUid: 'migo', baseIndex: 0 } },
+            defaultTestRandom,
+        );
+
+        // onPlay 仅应创建对手选择，不应提前发放疯狂牌
+        const prompt: any = getInteractionsFromMS(played.finalState)[0]?.data;
+        expect(prompt?.sourceId).toBe('elder_thing_mi_go_pod');
+        expect(played.events.some(e => e.type === SU_EVENTS.CARDS_DRAWN)).toBe(false);
+        expect(played.finalState.core.players['1'].hand.some(c => c.defId === MADNESS_CARD_DEF_ID)).toBe(false);
+    });
+});
+
+describe('elder_things_pod: Shoggoth POD', () => {
+    it('still prompts opponent to choose madness draw even when target base has no opponent minions', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('sho', 'elder_thing_shoggoth_pod', 'minion', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+            turnOrder: ['0', '1'],
+            bases: [{ defId: 'base_a', minions: [], ongoingActions: [] }],
+        });
+
+        const played = runCommand(
+            makeMatchState(core),
+            { type: SU_COMMANDS.PLAY_MINION, playerId: '0', payload: { cardUid: 'sho', baseIndex: 0 } },
+            defaultTestRandom,
+        );
+
+        const current = played.finalState.sys.interaction.current as any;
+        expect(current?.data?.sourceId).toBe('elder_thing_shoggoth_pod');
+        expect(current?.playerId).toBe('1');
+    });
+
+    it('can destroy an opponent minion with power greater than 6', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('sho', 'elder_thing_shoggoth_pod', 'minion', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+            turnOrder: ['0', '1'],
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [makeMinion('big1', 'zombie_king_rex', '1', 10)],
+                    ongoingActions: [],
+                },
+            ],
+            madnessDeck: [
+                makeCard('md1', MADNESS_CARD_DEF_ID, 'action', '0'),
+                makeCard('md2', MADNESS_CARD_DEF_ID, 'action', '0'),
+            ],
+        });
+
+        const played = runCommand(
+            makeMatchState(core),
+            { type: SU_COMMANDS.PLAY_MINION, playerId: '0', payload: { cardUid: 'sho', baseIndex: 0 } },
+            defaultTestRandom,
+        );
+        const firstPrompt: any = getInteractionsFromMS(played.finalState)[0]?.data;
+        expect(firstPrompt?.sourceId).toBe('elder_thing_shoggoth_pod');
+
+        // 对手拒绝抽疯狂 -> 施法者应可选择消灭该对手此基地一个随从（不受力量6限制）
+        const afterDecline = runCommand(
+            played.finalState,
+            { type: INTERACTION_COMMANDS.RESPOND, playerId: '1', payload: { optionId: 'no' } },
+            defaultTestRandom,
+        );
+        const destroyPrompt: any = getInteractionsFromMS(afterDecline.finalState)[0]?.data;
+        expect(destroyPrompt?.sourceId).toBe('elder_thing_shoggoth_pod_destroy');
+        const optionIds = (destroyPrompt?.options ?? []).map((o: any) => o.value?.minionUid ?? o.value?.uid);
+        expect(optionIds).toContain('big1');
+
+        const targetOption = (destroyPrompt?.options ?? []).find((o: any) => (o.value?.minionUid ?? o.value?.uid) === 'big1');
+        const destroyRes = runCommand(
+            afterDecline.finalState,
+            { type: INTERACTION_COMMANDS.RESPOND, playerId: '0', payload: { optionId: targetOption.id } },
+            defaultTestRandom,
+        );
+        const destroyed = destroyRes.events.find(e => e.type === SU_EVENTS.MINION_DESTROYED) as any;
+        expect(destroyed?.payload?.minionUid).toBe('big1');
+    });
+});
+
+describe('elder_things_pod: Dunwich Horror POD', () => {
+    it('does not add permanent power on play and only grants +5 ongoing power', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('a1', 'elder_thing_dunwich_horror_pod', 'action', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [makeMinion('m1', 'robot_microbot', '0', 3)],
+                    ongoingActions: [],
+                },
+            ],
+        });
+        const res = runCommand(
+            makeMatchState(core),
+            {
+                type: SU_COMMANDS.PLAY_ACTION,
+                playerId: '0',
+                payload: { cardUid: 'a1', targetBaseIndex: 0, targetMinionUid: 'm1' },
+            },
+            defaultTestRandom,
+        );
+
+        expect(res.events.some(e => e.type === SU_EVENTS.PERMANENT_POWER_ADDED)).toBe(false);
+        const minion = res.finalState.core.bases[0].minions.find(m => m.uid === 'm1');
+        expect(minion).toBeTruthy();
+        expect(getEffectivePower(res.finalState.core, minion!, 0)).toBe(8); // 3 + 5
+    });
+
+    it('does not inherit base version end-of-turn auto-destroy trigger', () => {
+        const executor = getTriggerExecutor('onTurnEnd', 'elder_thing_dunwich_horror_pod');
+        expect(executor).toBeDefined();
+
+        const core = makeState({
+            players: { '0': makePlayer('0'), '1': makePlayer('1') },
+            bases: [{ defId: 'base_a', minions: [makeMinion('m1', 'robot_microbot', '0', 3)], ongoingActions: [] }],
+        });
+        const out = executor!({ state: core, playerId: '0', now: 1, timing: 'onTurnEnd' } as any);
+        const events = Array.isArray(out) ? out : out.events;
+        expect(events.some(e => e.type === SU_EVENTS.MINION_DESTROYED)).toBe(false);
+    });
+});
+
+describe('elder_things_pod: The Price of Power POD', () => {
+    it('before scoring only checks players with minions there and grants +1 counters per Madness', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('a1', 'elder_thing_the_price_of_power_pod', 'action', '0')],
+                }),
+                '1': makePlayer('1', {
+                    hand: [
+                        makeCard('m1', MADNESS_CARD_DEF_ID, 'action', '1'),
+                        makeCard('m2', MADNESS_CARD_DEF_ID, 'action', '1'),
+                        makeCard('x1', 'robot_microbot', 'minion', '1'),
+                    ],
+                }),
+                '2': makePlayer('2', {
+                    hand: [makeCard('m3', MADNESS_CARD_DEF_ID, 'action', '2')],
+                }),
+            },
+            turnOrder: ['0', '1', '2'],
+            bases: [
+                {
+                    defId: 'base_the_jungle',
+                    minions: [
+                        makeMinion('p0m1', 'robot_microbot', '0', 15),
+                        makeMinion('p1m1', 'robot_microbot', '1', 15),
+                    ],
+                    ongoingActions: [],
+                },
+                { defId: 'base_temple_of_goju', minions: [makeMinion('p0m2', 'robot_microbot', '0', 3)], ongoingActions: [] },
+            ],
+        });
+
+        const ms = makeMatchState(core);
+        (ms.sys as any).phase = 'scoreBases';
+        (ms.sys as any).responseWindow = {
+            current: {
+                id: 'rw1',
+                windowType: 'meFirst',
+                sourceId: 'test',
+                responderQueue: ['0'],
+                currentResponderIndex: 0,
+                passedPlayers: [],
+            },
+        };
+
+        const res = runCommand(
+            ms,
+            { type: SU_COMMANDS.PLAY_ACTION, playerId: '0', payload: { cardUid: 'a1', targetBaseIndex: 0 } },
+            defaultTestRandom,
+        );
+
+        const revealEvt: any = res.events.find(e => e.type === SU_EVENTS.REVEAL_HAND);
+        expect(revealEvt).toBeTruthy();
+        expect(revealEvt.payload.targetPlayerId).toBe('1');
+
+        const counters = res.events.filter(e => e.type === SU_EVENTS.POWER_COUNTER_ADDED) as any[];
+        expect(counters.length).toBe(2);
+        expect(counters.every(e => e.payload.amount === 1)).toBe(true);
+        expect(counters.every(e => e.payload.reason === 'elder_thing_the_price_of_power_pod')).toBe(true);
+    });
+});
+
+describe('elder_things_pod: Spreading Horror POD', () => {
+    it('decliner does not force the caster to play from discard', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('a1', 'elder_thing_spreading_horror_pod', 'action', '0')],
+                    discard: [makeCard('d1', 'elder_thing_byakhee_pod', 'minion', '0')],
+                }),
+                '1': makePlayer('1', {
+                    hand: [
+                        makeCard('h1', 'robot_microbot', 'minion', '1'),
+                        makeCard('h2', 'robot_microbot_alpha', 'minion', '1'),
+                    ],
+                }),
+            },
+            turnOrder: ['0', '1'],
+            bases: [
+                { defId: 'base_a', minions: [], ongoingActions: [] },
+                { defId: 'base_b', minions: [], ongoingActions: [] },
+            ],
+        });
+
+        const play = runCommand(
+            makeMatchState(core),
+            { type: SU_COMMANDS.PLAY_ACTION, playerId: '0', payload: { cardUid: 'a1' } },
+            defaultTestRandom,
+        );
+        const firstPrompt: any = getInteractionsFromMS(play.finalState)[0]?.data;
+        expect(firstPrompt?.sourceId).toBe('elder_thing_spreading_horror_pod_opponent');
+
+        const afterDecline = runCommand(
+            play.finalState,
+            { type: INTERACTION_COMMANDS.RESPOND, playerId: '1', payload: { optionId: 'no' } },
+            defaultTestRandom,
+        );
+        const mayPrompt: any = getInteractionsFromMS(afterDecline.finalState)[0]?.data;
+        expect(mayPrompt?.sourceId).toBe('elder_thing_spreading_horror_pod_may_play');
+
+        const afterSkip = runCommand(
+            afterDecline.finalState,
+            { type: INTERACTION_COMMANDS.RESPOND, playerId: '0', payload: { optionId: 'no' } },
+            defaultTestRandom,
+        );
+
+        expect(getInteractionsFromMS(afterSkip.finalState).length).toBe(0);
+        expect(afterSkip.finalState.core.players['0'].discard.some(c => c.uid === 'd1')).toBe(true);
     });
 });
 

--- a/src/games/smashup/__tests__/expansionOngoing.test.ts
+++ b/src/games/smashup/__tests__/expansionOngoing.test.ts
@@ -30,7 +30,7 @@ import { registerGhostAbilities } from '../abilities/ghosts';
 import { registerSteampunkAbilities, registerSteampunkInteractionHandlers } from '../abilities/steampunks';
 import { registerKillerPlantAbilities, registerKillerPlantInteractionHandlers } from '../abilities/killer_plants';
 import { registerInnsmouthAbilities, registerInnsmouthInteractionHandlers } from '../abilities/innsmouth';
-import { registerMiskatonicAbilities } from '../abilities/miskatonic';
+import { registerMiskatonicAbilities, registerMiskatonicInteractionHandlers } from '../abilities/miskatonic';
 
 // ============================================================================
 // 测试辅助
@@ -1017,7 +1017,9 @@ describe('米斯卡塔尼克 新增能力', () => {
     beforeEach(() => {
         clearOngoingEffectRegistry();
         clearRegistry();
+        clearInteractionHandlers();
         registerMiskatonicAbilities();
+        registerMiskatonicInteractionHandlers();
     });
 
     describe('miskatonic_researcher: 研究员', () => {
@@ -1114,6 +1116,207 @@ describe('米斯卡塔尼克 新增能力', () => {
             // 只有 h1 这一张普通牌（skip 选项不算）
             const cardOptions = options.filter((o: any) => o.value?.cardUid);
             expect(cardOptions.length).toBe(1);
+        });
+    });
+
+    describe('miskatonic_pod: pod rule regression', () => {
+        test('researcher pod creates pod interaction', () => {
+            const base = makeBase({ minions: [makeMinion({ uid: 'm-1', defId: 'test_minion', controller: '0' })] });
+            const state = makeState([base], {
+                madnessDeck: [MADNESS_CARD_DEF_ID, MADNESS_CARD_DEF_ID],
+            });
+            const ms = { core: state, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
+
+            const executor = resolveAbility('miskatonic_researcher_pod', 'onPlay')!;
+            const result = executor({
+                state,
+                matchState: ms,
+                playerId: '0',
+                cardUid: 'res-pod-1',
+                defId: 'miskatonic_researcher_pod',
+                baseIndex: 0,
+                random: dummyRandom,
+                now: 1000,
+            });
+
+            const current = (result.matchState?.sys as any)?.interaction?.current;
+            expect(current).toBeDefined();
+            expect(current?.data?.sourceId).toBe('miskatonic_researcher_pod');
+        });
+
+        test('researcher pod draw flow leads to minion pick and +1 counter', () => {
+            const base = makeBase({ minions: [makeMinion({ uid: 'm-1', defId: 'test_minion', controller: '0' })] });
+            const state = makeState([base], {
+                madnessDeck: [MADNESS_CARD_DEF_ID, MADNESS_CARD_DEF_ID],
+            });
+            const ms = { core: state, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
+
+            const step1 = getInteractionHandler('miskatonic_researcher_pod');
+            expect(step1).toBeDefined();
+            const step1Result = step1!(ms, '0', { draw: true }, undefined, dummyRandom, 1001);
+            const chooseMinion = (step1Result.state?.sys as any)?.interaction?.current;
+            expect(chooseMinion).toBeDefined();
+            expect(chooseMinion?.data?.sourceId).toBe('miskatonic_researcher_pod_choose_minion');
+
+            const step2 = getInteractionHandler('miskatonic_researcher_pod_choose_minion');
+            expect(step2).toBeDefined();
+            const events = callHandler(step2!, {
+                state,
+                playerId: '0',
+                selectedValue: { minionUid: 'm-1', baseIndex: 0 },
+                random: dummyRandom,
+                now: 1002,
+            });
+
+            expect(events.some(e => e.type === SU_EVENTS.MADNESS_DRAWN)).toBe(true);
+            expect(events.some(e => e.type === SU_EVENTS.POWER_COUNTER_ADDED)).toBe(true);
+        });
+
+        test('field trip pod options include Madness cards', () => {
+            const base = makeBase();
+            const stateWithMadness = makeState([base], {
+                players: {
+                    '0': {
+                        id: '0', vp: 0,
+                        hand: [
+                            makeCard('h1', 'test_minion_a', 'minion', '0', SMASHUP_FACTION_IDS.GHOSTS),
+                            { uid: 'mad1', defId: MADNESS_CARD_DEF_ID, type: 'action', owner: '0' } as any,
+                        ],
+                        deck: [makeCard('d1', 'deck_action_1', 'action', '0', SMASHUP_FACTION_IDS.GHOSTS)],
+                        discard: [],
+                        minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1,
+                        factions: [SMASHUP_FACTION_IDS.GHOSTS, SMASHUP_FACTION_IDS.STEAMPUNKS] as [string, string],
+                    },
+                    '1': {
+                        id: '1', vp: 0, hand: [], deck: [], discard: [],
+                        minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1,
+                        factions: [SMASHUP_FACTION_IDS.ROBOTS, SMASHUP_FACTION_IDS.ALIENS] as [string, string],
+                    },
+                },
+            });
+            const ms = { core: stateWithMadness, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
+
+            const executor = resolveAbility('miskatonic_field_trip_pod', 'onPlay')!;
+            const result = executor({
+                state: stateWithMadness,
+                matchState: ms,
+                playerId: '0',
+                cardUid: 'ft-pod-1',
+                defId: 'miskatonic_field_trip_pod',
+                baseIndex: 0,
+                random: dummyRandom,
+                now: 1000,
+            });
+
+            const current = (result.matchState?.sys as any)?.interaction?.current;
+            expect(current).toBeDefined();
+            expect(current?.data?.sourceId).toBe('miskatonic_field_trip_pod');
+            const options = current?.data?.options ?? [];
+            const madnessOptions = options.filter((o: any) => o.value?.defId === MADNESS_CARD_DEF_ID);
+            expect(madnessOptions.length).toBeGreaterThan(0);
+        });
+
+        test('field trip pod draws 1 even when selecting no cards', () => {
+            const base = makeBase();
+            const state = makeState([base], {
+                players: {
+                    '0': {
+                        id: '0', vp: 0,
+                        hand: [makeCard('h1', 'test_minion_a', 'minion', '0', SMASHUP_FACTION_IDS.GHOSTS)],
+                        deck: [makeCard('d1', 'deck_action_1', 'action', '0', SMASHUP_FACTION_IDS.GHOSTS)],
+                        discard: [],
+                        minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1,
+                        factions: [SMASHUP_FACTION_IDS.GHOSTS, SMASHUP_FACTION_IDS.STEAMPUNKS] as [string, string],
+                    },
+                    '1': {
+                        id: '1', vp: 0, hand: [], deck: [], discard: [],
+                        minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1,
+                        factions: [SMASHUP_FACTION_IDS.ROBOTS, SMASHUP_FACTION_IDS.ALIENS] as [string, string],
+                    },
+                },
+            });
+            const handler = getInteractionHandler('miskatonic_field_trip_pod');
+            expect(handler).toBeDefined();
+
+            const events = callHandler(handler!, {
+                state,
+                playerId: '0',
+                selectedValue: { skip: true },
+                random: dummyRandom,
+                now: 1003,
+            });
+            const drawEvt = events.find(e => e.type === SU_EVENTS.CARDS_DRAWN) as any;
+            expect(drawEvt).toBeDefined();
+            expect(drawEvt.payload?.count).toBe(1);
+        });
+
+        test('things best not known pod grants temporary power, not permanent power', () => {
+            const target = makeMinion({ uid: 'target-1', defId: 'test_minion', controller: '0' });
+            const base = makeBase({ minions: [target] });
+            const state = makeState([base], {
+                madnessDeck: [MADNESS_CARD_DEF_ID, MADNESS_CARD_DEF_ID, MADNESS_CARD_DEF_ID],
+            });
+            const handler = getInteractionHandler('miskatonic_things_best_not_known_pod_draw');
+            expect(handler).toBeDefined();
+
+            const events = callHandler(handler!, {
+                state,
+                playerId: '0',
+                selectedValue: { count: 2, minionUid: 'target-1', baseIndex: 0 },
+                random: dummyRandom,
+                now: 1004,
+            });
+
+            expect(events.some(e => e.type === SU_EVENTS.MADNESS_DRAWN)).toBe(true);
+            expect(events.some(e => e.type === SU_EVENTS.TEMP_POWER_ADDED)).toBe(true);
+            expect(events.some(e => e.type === SU_EVENTS.PERMANENT_POWER_ADDED)).toBe(false);
+        });
+
+        test('librarian pod extra mode only plays Madness and marks extra action', () => {
+            const base = makeBase();
+            const state = makeState([base], {
+                players: {
+                    '0': {
+                        id: '0', vp: 0,
+                        hand: [
+                            { uid: 'mad1', defId: MADNESS_CARD_DEF_ID, type: 'action', owner: '0' } as any,
+                            makeCard('h1', 'test_action_a', 'action', '0', SMASHUP_FACTION_IDS.GHOSTS),
+                        ],
+                        deck: [],
+                        discard: [],
+                        minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1,
+                        factions: [SMASHUP_FACTION_IDS.GHOSTS, SMASHUP_FACTION_IDS.STEAMPUNKS] as [string, string],
+                    },
+                    '1': {
+                        id: '1', vp: 0, hand: [], deck: [], discard: [],
+                        minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1,
+                        factions: [SMASHUP_FACTION_IDS.ROBOTS, SMASHUP_FACTION_IDS.ALIENS] as [string, string],
+                    },
+                },
+            });
+            const ms = { core: state, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
+
+            const modeHandler = getInteractionHandler('miskatonic_librarian_pod');
+            expect(modeHandler).toBeDefined();
+            const modeResult = modeHandler!(ms, '0', { mode: 'extra' }, undefined, dummyRandom, 1005);
+            const chooseMadness = (modeResult.state?.sys as any)?.interaction?.current;
+            expect(chooseMadness).toBeDefined();
+            expect(chooseMadness?.data?.sourceId).toBe('miskatonic_librarian_pod_play_madness');
+
+            const playMadnessHandler = getInteractionHandler('miskatonic_librarian_pod_play_madness');
+            expect(playMadnessHandler).toBeDefined();
+            const events = callHandler(playMadnessHandler!, {
+                state,
+                playerId: '0',
+                selectedValue: { cardUid: 'mad1' },
+                random: dummyRandom,
+                now: 1006,
+            });
+
+            const actionPlayed = events.find(e => e.type === SU_EVENTS.ACTION_PLAYED) as any;
+            expect(actionPlayed).toBeDefined();
+            expect(actionPlayed.payload?.defId).toBe(MADNESS_CARD_DEF_ID);
+            expect(actionPlayed.payload?.isExtraAction).toBe(true);
         });
     });
 });

--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -2192,3 +2192,161 @@ describe('vampire_buffet afterScoring', () => {
         expect(pcEvents.length).toBe(0);
     });
 });
+
+describe('bear_cavalry_bear_necessities_pod 限制', () => {
+    it('激活后会禁止受影响对手打出额外随从和额外行动', () => {
+        const restrictedBase = makeBase({
+            minions: [makeMinion('enemy-on-base', 'test_minion', '1', 3, { powerModifier: 0 })],
+            ongoingActions: [{ uid: 'bn-1', defId: 'bear_cavalry_bear_necessities_pod', ownerId: '0', talentUsed: true } as any],
+        });
+        const state = makeState({
+            currentPlayerIndex: 1,
+            bases: [restrictedBase, makeBase()],
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1', {
+                    minionsPlayed: 1,
+                    minionLimit: 2,
+                    actionsPlayed: 1,
+                    actionLimit: 2,
+                    hand: [
+                        { uid: 'm-extra', defId: 'dino_war_raptor', type: 'minion', owner: '1' } as CardInstance,
+                        { uid: 'a-extra', defId: 'bear_cavalry_bear_hug', type: 'action', owner: '1' } as CardInstance,
+                    ],
+                }),
+            },
+        });
+        const matchState = { core: state, sys: { phase: 'playCards' } } as any;
+
+        const minionResult = validate(matchState, {
+            type: SU_COMMANDS.PLAY_MINION,
+            playerId: '1',
+            payload: { cardUid: 'm-extra', baseIndex: 1 },
+        } as any);
+        expect(minionResult.valid).toBe(false);
+        expect(minionResult.error).toContain('额外牌');
+
+        const actionResult = validate(matchState, {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '1',
+            payload: { cardUid: 'a-extra' },
+        } as any);
+        expect(actionResult.valid).toBe(false);
+        expect(actionResult.error).toContain('额外牌');
+    });
+
+    it('拥有者下回合开始时会销毁已激活的口粮POD', () => {
+        const state = makeState({
+            bases: [makeBase({
+                ongoingActions: [{ uid: 'bn-1', defId: 'bear_cavalry_bear_necessities_pod', ownerId: '0', talentUsed: true } as any],
+            })],
+        });
+
+        const ownerTurnStart = fireTriggers(state, 'onTurnStart', {
+            state,
+            playerId: '0',
+            random: dummyRandom,
+            now: 12,
+        });
+        expect(ownerTurnStart.events).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                type: SU_EVENTS.ONGOING_DETACHED,
+                payload: expect.objectContaining({ cardUid: 'bn-1' }),
+            }),
+        ]));
+
+        const opponentTurnStart = fireTriggers(state, 'onTurnStart', {
+            state,
+            playerId: '1',
+            random: dummyRandom,
+            now: 13,
+        });
+        const detachedCount = opponentTurnStart.events.filter(e => e.type === SU_EVENTS.ONGOING_DETACHED).length;
+        expect(detachedCount).toBe(0);
+    });
+});
+
+describe('bear_cavalry_superiority_pod 保护模式', () => {
+    it('protect 分支开启保护，且在拥有者下回合开始后失效', () => {
+        const myMinion = makeMinion('m1', 'test_minion', '0', 3, { powerModifier: 0 });
+        const state = makeState({
+            bases: [makeBase({
+                minions: [myMinion],
+                ongoingActions: [{ uid: 'sup-1', defId: 'bear_cavalry_superiority_pod', ownerId: '0', talentUsed: true, metadata: {} } as any],
+            })],
+        });
+        const handler = getInteractionHandler('bear_cavalry_superiority_pod_talent');
+        expect(handler).toBeDefined();
+
+        const ms = { core: state, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
+        const protectResult = handler!(ms, '0', 'protect', { cardUid: 'sup-1' }, dummyRandom, 0);
+        expect(isMinionProtected(protectResult.state.core, myMinion, 0, '1', 'destroy')).toBe(true);
+
+        const afterTurnStart = reduce(protectResult.state.core, {
+            type: SU_EVENTS.TURN_STARTED,
+            payload: { playerId: '0', turnNumber: 2 },
+            timestamp: 1,
+        } as TurnStartedEvent);
+        expect(isMinionProtected(afterTurnStart, myMinion, 0, '1', 'destroy')).toBe(false);
+    });
+
+    it('draw 分支会关闭保护标记并正常摸牌', () => {
+        const myMinion = makeMinion('m1', 'test_minion', '0', 3, { powerModifier: 0 });
+        const drawCard: CardInstance = { uid: 'd1', defId: 'test_action', type: 'action' } as any;
+        const state = makeState({
+            players: {
+                '0': makePlayer('0', { deck: [drawCard] }),
+                '1': makePlayer('1'),
+            },
+            bases: [makeBase({
+                minions: [myMinion],
+                ongoingActions: [{ uid: 'sup-1', defId: 'bear_cavalry_superiority_pod', ownerId: '0', talentUsed: true, metadata: { superiorityProtect: true } } as any],
+            })],
+        });
+        const handler = getInteractionHandler('bear_cavalry_superiority_pod_talent');
+        expect(handler).toBeDefined();
+
+        const ms = { core: state, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
+        const drawResult = handler!(ms, '0', 'draw', { cardUid: 'sup-1' }, dummyRandom, 0);
+        expect(drawResult.events.some(e => e.type === SU_EVENTS.CARDS_DRAWN)).toBe(true);
+        expect(isMinionProtected(drawResult.state.core, myMinion, 0, '1', 'destroy')).toBe(false);
+    });
+});
+
+describe('bear_cavalry_bear_rides_you_pod 交互选项', () => {
+    it('移动己方随从后仅提供基地压制与跳过两个有效选项', () => {
+        const myMinion = makeMinion('m1', 'test_minion', '0', 3, { powerModifier: 0 });
+        const fromBase = makeBase({ minions: [myMinion] });
+        const toBase = makeBase({
+            minions: [makeMinion('e1', 'test_minion', '1', 2, { powerModifier: 0 })],
+            ongoingActions: [{ uid: 'oa1', defId: 'bear_cavalry_superiority_pod', ownerId: '1' } as any],
+        });
+        const state = makeState({ bases: [fromBase, toBase] });
+        const handler = getInteractionHandler('bear_cavalry_bear_rides_you_pod_choose_base');
+        expect(handler).toBeDefined();
+
+        const ms = { core: state, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
+        const result = handler!(
+            ms,
+            '0',
+            { baseIndex: 1 },
+            { continuationContext: { minionUid: 'm1', minionDefId: 'test_minion', fromBase: 0, isMyMinion: true } },
+            dummyRandom,
+            0,
+        );
+        expect(result.events.some(e => e.type === SU_EVENTS.MINION_MOVED)).toBe(true);
+
+        const pending = result.state.sys.interaction.current ?? result.state.sys.interaction.queue[0];
+        expect(pending).toBeDefined();
+        const kinds = (pending?.data?.options ?? [])
+            .map((option: any) => option?.value?.kind)
+            .filter((kind: unknown) => typeof kind === 'string');
+
+        expect(kinds).toContain('base');
+        expect(kinds).toContain('skip');
+        expect(kinds).not.toContain('minion');
+        expect(kinds).not.toContain('ongoing');
+        expect(kinds).not.toContain('attached');
+        expect(kinds).not.toContain('titan');
+    });
+});

--- a/src/games/smashup/__tests__/onDestroyAbilities.test.ts
+++ b/src/games/smashup/__tests__/onDestroyAbilities.test.ts
@@ -31,6 +31,47 @@ beforeAll(() => {
     initAllAbilities();
 });
 
+describe('trickster_gremlin_pod onDestroy', () => {
+    it('被消灭时只结算一次抽牌与弃牌', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [
+                        makeCard('c1', 'bear_cavalry_bear_necessities', 'action', '0'),
+                        makeCard('c2', 'test_extra', 'minion', '0'),
+                    ],
+                }),
+                '1': makePlayer('1', {
+                    deck: [makeCard('d1', 'test_draw', 'minion', '1')],
+                }),
+            },
+            bases: [{
+                defId: 'base_a',
+                minions: [makeMinion('gremlin', 'trickster_gremlin_pod', '1', 2, { powerModifier: 0 })],
+                ongoingActions: [],
+            }],
+        });
+
+        const events = execute(makeMatchState(core), {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '0',
+            payload: { cardUid: 'c1' },
+        }, defaultRandom);
+
+        const drawEvents = events.filter(
+            e => e.type === SU_EVENTS.CARDS_DRAWN && (e as any).payload.playerId === '1'
+        );
+        expect(drawEvents.length).toBe(1);
+        expect((drawEvents[0] as any).payload.count).toBe(1);
+
+        const discardEvents = events.filter(
+            e => e.type === SU_EVENTS.CARDS_DISCARDED && (e as any).payload.playerId === '0'
+        );
+        expect(discardEvents.length).toBe(1);
+        expect((discardEvents[0] as any).payload.cardUids.length).toBe(1);
+    });
+});
+
 // ============================================================================
 // 辅助函数
 // ============================================================================

--- a/src/games/smashup/__tests__/ongoingE2E.test.ts
+++ b/src/games/smashup/__tests__/ongoingE2E.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { execute, reduce } from '../domain/reducer';
-import { postProcessSystemEvents } from '../domain';
+import { postProcessSystemEvents, scoreOneBase } from '../domain';
 import { SU_COMMANDS, SU_EVENTS } from '../domain/types';
 import type {
     SmashUpCore, SmashUpEvent, MinionOnBase,
@@ -605,5 +605,68 @@ describe('E2E: reduce 状态变更验证', () => {
 
         const newState = reduce(state, event);
         expect(newState.players['0'].actionLimit).toBe(2); // 1 + 1
+    });
+});
+
+describe('E2E: 海盗 POD 关键交互链路', () => {
+    it('buccaneer_pod 被消灭时会创建 replacement 移动交互', () => {
+        const buccaneerPod = makeMinion('bucc1', 'pirate_buccaneer_pod', '0', 4, { powerModifier: 0 });
+        const state = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                makeBase('base_tar_pits', [buccaneerPod]),
+                makeBase('base_the_jungle'),
+                makeBase('base_factory'),
+            ],
+        });
+
+        const ms = makeMatchState(state);
+        const destroyedEvt: SmashUpEvent = {
+            type: SU_EVENTS.MINION_DESTROYED,
+            payload: {
+                minionUid: 'bucc1',
+                minionDefId: 'pirate_buccaneer_pod',
+                fromBaseIndex: 0,
+                ownerId: '0',
+                destroyerId: '1',
+                reason: 'e2e_destroy',
+            },
+            timestamp: 3000,
+        } as any;
+
+        const post = postProcessSystemEvents(state, [destroyedEvt], defaultRandom, ms);
+        const interaction = (post.matchState?.sys as any)?.interaction?.current;
+        expect(interaction).toBeDefined();
+        expect(interaction?.data?.sourceId).toBe('pirate_buccaneer_move');
+
+        const hasDestroy = post.events.some(
+            e => e.type === SU_EVENTS.MINION_DESTROYED && (e as any).payload?.minionUid === 'bucc1',
+        );
+        expect(hasDestroy).toBe(false);
+    });
+
+    it('first_mate_pod 在计分后会创建 afterScoring 移动交互', () => {
+        const matePod = makeMinion('mate1', 'pirate_first_mate_pod', '0', 2, { powerModifier: 0 });
+        const opponent = makeMinion('enemy1', 'test_minion', '1', 5, { powerModifier: 0 });
+        const state = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                makeBase('base_tar_pits', [matePod, opponent]),
+                makeBase('base_the_jungle'),
+            ],
+            baseDeck: ['base_factory'],
+        });
+
+        const ms = makeMatchState(state);
+        const scored = scoreOneBase(state, 0, [...state.baseDeck], '0', 4000, defaultRandom, ms);
+        const interaction = (scored.matchState?.sys as any)?.interaction?.current;
+        expect(interaction).toBeDefined();
+        expect(interaction?.data?.sourceId).toBe('pirate_first_mate_choose_base');
     });
 });

--- a/src/games/smashup/__tests__/temple-firstmate-afterscore.test.ts
+++ b/src/games/smashup/__tests__/temple-firstmate-afterscore.test.ts
@@ -8,6 +8,7 @@ import type { MatchState } from '../../../engine/types';
 import { makeBase, makeCard, makeMatchState, makeMinion, makePlayer, makeState } from './helpers';
 import type { BaseAbilityContext } from '../domain/baseAbilities';
 import { reduce } from '../domain/reducer';
+import { fireTriggers } from '../domain/ongoingEffects';
 
 beforeAll(() => {
     clearRegistry();
@@ -197,5 +198,31 @@ describe('Temple of Goju + First Mate 时序测试', () => {
         const nextCore = reduce(core, result.events[0] as any);
         expect(nextCore.bases[1].minions.some(m => m.uid === 'first_mate_1')).toBe(true);
         expect(nextCore.players['0'].discard.some(c => c.uid === 'first_mate_1')).toBe(false);
+    });
+
+    it('场景5: first_mate_pod 在 afterScoring 会创建移动交互', () => {
+        const core = makeState({
+            bases: [
+                makeBase('base_scoring', [makeMinion('mate_pod_1', 'pirate_first_mate_pod', '0', 2)]),
+                makeBase('base_other', []),
+            ],
+            players: { '0': makePlayer('0'), '1': makePlayer('1') },
+        });
+        const ms = makeMatchState(core);
+
+        const result = fireTriggers(core, 'afterScoring', {
+            state: core,
+            matchState: ms,
+            playerId: '0',
+            baseIndex: 0,
+            rankings: [{ playerId: '0', power: 2, vp: 1 }],
+            random: { random: () => 0.5, shuffle: <T>(arr: T[]) => arr, d: () => 1, range: (min: number) => min },
+            now: 2000,
+        });
+
+        expect(result.events.length).toBe(0);
+        const interaction = result.matchState?.sys.interaction.current;
+        expect(interaction).toBeDefined();
+        expect((interaction?.data as any)?.sourceId).toBe('pirate_first_mate_choose_base');
     });
 });

--- a/src/games/smashup/__tests__/temple-firstmate-afterscore.test.ts
+++ b/src/games/smashup/__tests__/temple-firstmate-afterscore.test.ts
@@ -1,27 +1,13 @@
-/**
- * Temple of Goju + First Mate 时序测试
- * 
- * 测试场景：寺庙基地能力（afterScoring）+ 大副触发器（afterScoring）
- * 
- * 关键点：
- * 1. 寺庙可以将随从放回牌库底
- * 2. 大副在 afterScoring 时可以移动到其他基地
- * 3. 如果寺庙把大副放回牌库底，大副不应再触发移动交互
- * 4. _deferredPostScoringEvents 必须正确传递
- * 
- * 这是多 afterScoring 交互链式传递的典型案例，与母舰+侦察兵类似，
- * 但寺庙会移除随从，测试覆盖了"移除后不应再触发"的场景。
- */
-
-import { describe, it, expect, beforeAll } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { initAllAbilities, resetAbilityInit } from '../abilities';
 import { clearRegistry } from '../domain/abilityRegistry';
 import { clearBaseAbilityRegistry, triggerBaseAbility } from '../domain/baseAbilities';
-import { clearInteractionHandlers } from '../domain/abilityInteractionHandlers';
+import { clearInteractionHandlers, getInteractionHandler } from '../domain/abilityInteractionHandlers';
 import type { SmashUpCore } from '../domain/types';
 import type { MatchState } from '../../../engine/types';
-import { makePlayer, makeState, makeBase, makeMinion } from './helpers';
+import { makeBase, makeCard, makeMatchState, makeMinion, makePlayer, makeState } from './helpers';
 import type { BaseAbilityContext } from '../domain/baseAbilities';
+import { reduce } from '../domain/reducer';
 
 beforeAll(() => {
     clearRegistry();
@@ -32,7 +18,7 @@ beforeAll(() => {
 });
 
 describe('Temple of Goju + First Mate 时序测试', () => {
-    it('场景1: 寺庙移除大副后不再触发移动交互', () => {
+    it('场景1: 寺庙移除大副后不会再产生错误事件', () => {
         const core = makeState({
             currentPlayerIndex: 0,
             bases: [
@@ -74,22 +60,18 @@ describe('Temple of Goju + First Mate 时序测试', () => {
         };
 
         const result = triggerBaseAbility('base_temple_of_goju', 'afterScoring', ctx);
-        
-        // 验证：应该有事件（将随从放入牌库底）
         expect(result.events.length).toBeGreaterThan(0);
-        
-        // 验证：应该有 card_to_deck_bottom 事件
         const deckBottomEvents = result.events.filter((e: any) => e.type === 'su:card_to_deck_bottom');
         expect(deckBottomEvents.length).toBeGreaterThan(0);
     });
 
-    it('场景2: 寺庙上有多个大副，部分被移除', () => {
+    it('场景2: 多个大副时，寺庙会按规则移除目标', () => {
         const core = makeState({
             currentPlayerIndex: 0,
             bases: [
                 makeBase('base_temple_of_goju', [
-                    makeMinion('first_mate_1', 'pirate_first_mate', '0', 3), // 力量 3（最高）
-                    makeMinion('first_mate_2', 'pirate_first_mate', '0', 2), // 力量 2
+                    makeMinion('first_mate_1', 'pirate_first_mate', '0', 3),
+                    makeMinion('first_mate_2', 'pirate_first_mate', '0', 2),
                     makeMinion('m2', 'ninja_shinobi', '1', 5),
                     makeMinion('m3', 'ninja_shinobi', '1', 5),
                     makeMinion('m4', 'ninja_shinobi', '1', 5),
@@ -119,26 +101,19 @@ describe('Temple of Goju + First Mate 时序测试', () => {
             baseDefId: 'base_temple_of_goju',
             playerId: '0',
             rankings: [
-                { playerId: '0', power: 5, vp: 2 }, // 总力量 3+2=5
+                { playerId: '0', power: 5, vp: 2 },
                 { playerId: '1', power: 20, vp: 3 },
             ],
             now: 1000,
         };
 
         const result = triggerBaseAbility('base_temple_of_goju', 'afterScoring', ctx);
-        
-        // 验证：应该有事件（first_mate_1 力量最高，直接放牌库底）
-        expect(result.events.length).toBeGreaterThan(0);
-        
-        // 验证：应该有 card_to_deck_bottom 事件
         const deckBottomEvents = result.events.filter((e: any) => e.type === 'su:card_to_deck_bottom');
         expect(deckBottomEvents.length).toBeGreaterThan(0);
-        
-        // 验证：被移除的是 first_mate_1（力量 3）
         expect(deckBottomEvents[0].payload.cardUid).toBe('first_mate_1');
     });
 
-    it('场景3: _deferredPostScoringEvents 传递（寺庙跳过，大副触发）', () => {
+    it('场景3: 寺庙与 afterScoring 链式交互并存时，仍能产出延迟事件', () => {
         const core = makeState({
             currentPlayerIndex: 0,
             bases: [
@@ -180,12 +155,47 @@ describe('Temple of Goju + First Mate 时序测试', () => {
         };
 
         const result = triggerBaseAbility('base_temple_of_goju', 'afterScoring', ctx);
-        
-        // 验证：应该有事件
-        expect(result.events.length).toBeGreaterThan(0);
-        
-        // 验证：应该有 card_to_deck_bottom 事件
         const deckBottomEvents = result.events.filter((e: any) => e.type === 'su:card_to_deck_bottom');
         expect(deckBottomEvents.length).toBeGreaterThan(0);
+    });
+
+    it('场景4: BASE_CLEARED 后索引漂移时，大副仍可按 baseDefId 移动', () => {
+        const core = makeState({
+            bases: [
+                makeBase('base_left', []),
+                makeBase('base_target', []),
+            ],
+            players: {
+                '0': makePlayer('0', {
+                    discard: [makeCard('first_mate_1', 'pirate_first_mate_pod', 'minion', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+        });
+        const ms = makeMatchState(core);
+        const handler = getInteractionHandler('pirate_first_mate_choose_base');
+        expect(handler).toBeDefined();
+
+        const result = handler!(
+            ms,
+            '0',
+            { baseIndex: 2, baseDefId: 'base_target' },
+            {
+                continuationContext: {
+                    mateUid: 'first_mate_1',
+                    mateDefId: 'pirate_first_mate_pod',
+                    scoringBaseIndex: 0,
+                },
+            },
+            {} as any,
+            1000,
+        );
+
+        expect(result.events.length).toBe(1);
+        expect((result.events[0] as any).payload.toBaseIndex).toBe(1);
+
+        const nextCore = reduce(core, result.events[0] as any);
+        expect(nextCore.bases[1].minions.some(m => m.uid === 'first_mate_1')).toBe(true);
+        expect(nextCore.players['0'].discard.some(c => c.uid === 'first_mate_1')).toBe(false);
     });
 });

--- a/src/games/smashup/abilities/bear_cavalry.ts
+++ b/src/games/smashup/abilities/bear_cavalry.ts
@@ -32,7 +32,6 @@ import type { ProtectionCheckContext, TriggerContext } from '../domain/ongoingEf
 import { createSimpleChoice, queueInteraction } from '../../../engine/systems/InteractionSystem';
 import { registerInteractionHandler } from '../domain/abilityInteractionHandlers';
 import type { PlayerId } from '../../../engine/types';
-import type { SuperiorityPodProtectEnabledEvent } from '../domain/types';
 
 // 本文件中使用的 defId 匹配工具：基础版 + `_pod` 版本都视为同一张牌
 function matchesDefId(defId: string | undefined | null, baseDefId: string): boolean {
@@ -264,7 +263,7 @@ function bearCavalryGeneralIvanPodTrigger(ctx: TriggerContext): SmashUpEvent[] |
         if (found) { 
             movedMinion = found; 
             movedToBaseIndex = i;
-            break; 
+            break;
         }
     }
     if (!movedMinion || movedToBaseIndex === -1) return events;
@@ -409,6 +408,7 @@ function bearCavalrySuperiorityPodProtection(ctx: ProtectionCheckContext): boole
     return base.ongoingActions.some(
         a => a.defId === 'bear_cavalry_superiority_pod' &&
              a.ownerId === ctx.targetMinion.controller &&
+             a.talentUsed === true &&
              (a.metadata as any)?.superiorityProtect === true
     );
 }
@@ -873,11 +873,7 @@ function bearCavalryBearRidesYouPod(ctx: AbilityContext): AbilityResult {
 
 type BearRidesYouPodSuppressTarget =
     | { kind: 'skip' }
-    | { kind: 'base'; baseIndex: number }
-    | { kind: 'minion'; minionUid: string; baseIndex: number }
-    | { kind: 'ongoing'; cardUid: string; baseIndex: number }
-    | { kind: 'attached'; cardUid: string; baseIndex: number }
-    | { kind: 'titan'; titanUid: string; baseIndex: number; ownerId: PlayerId };
+    | { kind: 'base'; baseIndex: number };
 
 /** 你们都是美食 onPlay：选择有己方随从的基地→选择目标基地，移动所有对手随从*/
 function bearCavalryYourePrettyMuchBorscht(ctx: AbilityContext): AbilityResult {
@@ -987,22 +983,21 @@ function bearCavalryBearNecessitiesPodTurnStart(ctx: TriggerContext): SmashUpEve
     const events: SmashUpEvent[] = [];
     
     // 检查是否是卡牌拥有者的回合
-    if (ctx.state.currentPlayer !== ctx.ownerId) return events;
+    // onTurnStart 的 ctx.playerId 就是当前回合玩家
     
     // 找到黑熊口粮 POD 卡牌（必须已激活天赋）
     for (const base of ctx.state.bases) {
-        const card = base.ongoingActions.find(
-            a => a.defId === 'bear_cavalry_bear_necessities_pod' && 
-                 a.ownerId === ctx.ownerId && 
-                 a.talentUsed === true
+        const cards = base.ongoingActions.filter(
+            a => a.defId === 'bear_cavalry_bear_necessities_pod'
+                && a.ownerId === ctx.playerId
+                && a.talentUsed === true
         );
-        if (card) {
+        for (const card of cards) {
             events.push({
                 type: SU_EVENTS.ONGOING_DETACHED,
                 payload: { cardUid: card.uid, defId: card.defId, ownerId: card.ownerId, reason: 'bear_cavalry_bear_necessities_pod' },
                 timestamp: ctx.now
             } as OngoingDetachedEvent);
-            break;
         }
     }
     
@@ -1664,11 +1659,15 @@ export function registerBearCavalryInteractionHandlers(): void {
 
         suppressOptions.push({ id: 'skip', label: '跳过（不压制）', value: { kind: 'skip' } });
 
+        const visibleSuppressOptions = suppressOptions.filter(option =>
+            option.value.kind === 'base' || option.value.kind === 'skip'
+        );
+
         const next = createSimpleChoice(
             `bear_cavalry_bear_rides_you_pod_choose_suppress_${timestamp}`,
             playerId,
             '与熊同行：选择要压制能力的卡牌（到你下回合开始）',
-            suppressOptions as any[],
+            visibleSuppressOptions as any[],
             { sourceId: 'bear_cavalry_bear_rides_you_pod_choose_suppress', targetType: 'generic', autoCancelOption: true }
         );
         (next.data as any).continuationContext = { toBase };
@@ -1692,25 +1691,35 @@ export function registerBearCavalryInteractionHandlers(): void {
             };
         }
 
-        return {
-            state,
-            events: [{
-                type: SU_EVENTS.CARD_SUPPRESSED,
-                payload: {
-                    cardUid: chosen.kind === 'minion' ? chosen.minionUid : chosen.kind === 'titan' ? chosen.titanUid : chosen.cardUid,
-                    suppressedBy: playerId,
-                    cardType: chosen.kind === 'minion' || chosen.kind === 'titan' ? 'minion' : 'ongoing',
-                    baseIndex: chosen.baseIndex,
-                },
-                timestamp,
-            } as any],
-        };
+        return { state, events: [] };
     });
     
     // 全面优势 POD 天赋：摸牌或保护
     registerInteractionHandler('bear_cavalry_superiority_pod_talent', (state, playerId, value, iData, _random, timestamp) => {
         const action = (value as any) as 'draw' | 'protect';
         const events: SmashUpEvent[] = [];
+        const cardUid = (iData as any)?.cardUid as string | undefined;
+        const nextState = cardUid
+            ? {
+                ...state,
+                core: {
+                    ...state.core,
+                    bases: state.core.bases.map(base => ({
+                        ...base,
+                        ongoingActions: base.ongoingActions.map(ongoing => {
+                            if (ongoing.uid !== cardUid) return ongoing;
+                            return {
+                                ...ongoing,
+                                metadata: {
+                                    ...(ongoing.metadata ?? {}),
+                                    superiorityProtect: action === 'protect',
+                                },
+                            };
+                        }),
+                    })),
+                },
+            }
+            : state;
         
         if (action === 'draw') {
             // 摸一张牌（从牌库顶抽取）
@@ -1723,17 +1732,9 @@ export function registerBearCavalryInteractionHandlers(): void {
                     timestamp
                 });
             }
-        } else if (action === 'protect') {
-            const cardUid = (iData as any)?.cardUid as string | undefined;
-            if (!cardUid) return { state, events };
-            events.push({
-                type: SU_EVENTS.SUPERIORITY_POD_PROTECT_ENABLED,
-                payload: { playerId, cardUid, enabled: true },
-                timestamp,
-            } as unknown as SuperiorityPodProtectEnabledEvent);
         }
         
-        return { state, events };
+        return { state: nextState, events };
     });
     
     // 制高点 POD 触发器：消灭或摸牌打战术

--- a/src/games/smashup/abilities/elder_things.ts
+++ b/src/games/smashup/abilities/elder_things.ts
@@ -15,15 +15,13 @@ import {
     getMinionPower,
     buildMinionTargetOptions,
     addPowerCounter,
-    addTempPower,
-    addPermanentPower,
     revealHand,
     buildAbilityFeedback,
     buildValidatedCardToDeckBottomEvents,
-    recoverCardsFromDiscard,
 } from '../domain/abilityHelpers';
 import { SU_EVENTS, MADNESS_CARD_DEF_ID } from '../domain/types';
 import type {
+    SmashUpCore,
     SmashUpEvent,
     CardsDrawnEvent,
     CardsDiscardedEvent,
@@ -33,7 +31,7 @@ import type {
 } from '../domain/types';
 import { drawCards, matchesDefId } from '../domain/utils';
 import { getFactionCards, getCardDef, getBaseDef } from '../data/cards';
-import { registerTrigger, registerProtection, isMinionProtected } from '../domain/ongoingEffects';
+import { registerTrigger, registerProtection } from '../domain/ongoingEffects';
 import type { TriggerContext, ProtectionCheckContext } from '../domain/ongoingEffects';
 import { getPlayerEffectivePowerOnBase } from '../domain/ongoingModifiers';
 import { createSimpleChoice, queueInteraction } from '../../../engine/systems/InteractionSystem';
@@ -42,6 +40,24 @@ import { isMinionProtectedNonConsumable } from '../domain/ongoingEffects';
 import { filterProtectedDestroyEvents } from '../domain/reducer';
 
 /** 注册远古之物派系所有能力*/
+function getOrderedOpponentIds(state: SmashUpCore, playerId: string): string[] {
+    const self = String(playerId);
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+
+    for (const rawPid of state.turnOrder as unknown[]) {
+        const pid = String(rawPid);
+        if (pid === self) continue;
+        if (seen.has(pid)) continue;
+        if (!state.players[pid]) continue;
+        seen.add(pid);
+        ordered.push(pid);
+    }
+
+    if (ordered.length > 0) return ordered;
+    return Object.keys(state.players).filter(pid => pid !== self);
+}
+
 export function registerElderThingAbilities(): void {
     // 拜亚基?onPlay：如果其他玩家有随从在本基地，抽一张疯狂卡
     registerAbility('elder_thing_byakhee', 'onPlay', elderThingByakhee);
@@ -76,11 +92,14 @@ export function registerElderThingAbilities(): void {
     registerAbility('elder_thing_insanity_pod', 'onPlay', elderThingInsanityPod);
     registerAbility('elder_thing_power_of_madness_pod', 'onPlay', elderThingPowerOfMadnessPod);
     registerAbility('elder_thing_spreading_horror_pod', 'onPlay', elderThingSpreadingHorrorPod);
+    registerAbility('elder_thing_the_price_of_power_pod', 'special', elderThingPriceOfPowerPodSpecial);
     registerAbility('elder_thing_unfathomable_goals_pod', 'onPlay', elderThingUnfathomableGoalsPod);
     registerAbility('elder_thing_touch_of_madness_pod', 'onPlay', elderThingTouchOfMadnessPod);
 
     // Dunwich Horror POD：before scoring trigger (mandatory)
     registerTrigger('elder_thing_dunwich_horror_pod', 'beforeScoring', elderThingDunwichHorrorPodBeforeScoring, { mandatory: true });
+    // POD 版不会“回合结束自动消灭”，这里显式注册 no-op，阻止 alias 继承原版 onTurnEnd 触发。
+    registerTrigger('elder_thing_dunwich_horror_pod', 'onTurnEnd', elderThingDunwichHorrorPodOnTurnEndNoop);
 
     // 远古之物 POD：不受对手卡牌影响
     registerProtection('elder_thing_elder_thing_pod', 'destroy', elderThingPodProtectionChecker);
@@ -117,7 +136,7 @@ function elderThingByakhee(ctx: AbilityContext): AbilityResult {
  * "可以" → 每个对手需要选择是否抽疯狂卡，链式处理
  */
 function elderThingMiGo(ctx: AbilityContext): AbilityResult {
-    const opponents = ctx.state.turnOrder.filter(pid => pid !== ctx.playerId);
+    const opponents = getOrderedOpponentIds(ctx.state, ctx.playerId);
     if (opponents.length === 0) return { events: [] };
 
     // 链式处理：第一个对手选择
@@ -411,7 +430,7 @@ function elderThingByakheePod(ctx: AbilityContext): AbilityResult {
 type PodYesNoChoiceValue = { choice: 'yes' } | { choice: 'no' };
 
 function elderThingMiGoPod(ctx: AbilityContext): AbilityResult {
-    const opponents = ctx.state.turnOrder.filter(pid => pid !== ctx.playerId);
+    const opponents = getOrderedOpponentIds(ctx.state, ctx.playerId);
     if (opponents.length === 0) return { events: [] };
     const interaction = createSimpleChoice(
         `elder_thing_mi_go_pod_${opponents[0]}_${ctx.now}`,
@@ -435,7 +454,7 @@ function elderThingMiGoPod(ctx: AbilityContext): AbilityResult {
 }
 
 function elderThingShoggothPod(ctx: AbilityContext): AbilityResult {
-    const opponents = ctx.state.turnOrder.filter(pid => pid !== ctx.playerId);
+    const opponents = getOrderedOpponentIds(ctx.state, ctx.playerId);
     if (opponents.length === 0) return { events: [] };
     const interaction = createSimpleChoice(
         `elder_thing_shoggoth_pod_${opponents[0]}_${ctx.now}`,
@@ -503,17 +522,8 @@ function elderThingBeginTheSummoningPod(ctx: AbilityContext): AbilityResult {
 }
 
 function elderThingDunwichHorrorPodOnPlay(ctx: AbilityContext): AbilityResult {
-    // +5 power handled by ongoing modifiers elsewhere via card text; engine needs a permanent/ongoing modifier hook.
-    // We implement as a permanent +5 while attached (removed when detached) by using addPermanentPower now.
-    // NOTE: This is a simplification; we’ll keep the existing pattern used in this repo.
-    if (ctx.targetMinionUid) {
-        return { events: [addPermanentPower(ctx.targetMinionUid, ctx.baseIndex, 5, 'elder_thing_dunwich_horror_pod', ctx.now)] };
-    }
-    return { events: [] };
-}
-
-function elderThingDunwichHorrorPodSpecial(_ctx: AbilityContext): AbilityResult {
-    // Implemented via interaction handler / trigger chain later.
+    // POD：+5 仅来自 ongoing 修正；onPlay 不应再额外叠加永久力量，避免与 ongoing 叠加成 +10。
+    void ctx;
     return { events: [] };
 }
 
@@ -610,6 +620,54 @@ function elderThingTouchOfMadnessPod(ctx: AbilityContext): AbilityResult {
     return { events };
 }
 
+function elderThingPriceOfPowerPodSpecial(ctx: AbilityContext): AbilityResult {
+    const events: SmashUpEvent[] = [];
+    const scoringBase = ctx.state.bases[ctx.baseIndex];
+    const inBeforeScoringWindow = ctx.matchState.sys.phase === 'scoreBases'
+        || ctx.matchState.sys.responseWindow?.current?.windowType === 'meFirst';
+
+    const opponents = ctx.state.turnOrder.filter(pid => pid !== ctx.playerId).filter(pid => {
+        if (!inBeforeScoringWindow) return true;
+        return !!scoringBase?.minions.some(m => m.controller === pid);
+    });
+
+    const allRevealCards: { uid: string; defId: string }[] = [];
+    const revealTargetIds: string[] = [];
+    let totalMadness = 0;
+    for (const pid of opponents) {
+        const p = ctx.state.players[pid];
+        if (p.hand.length > 0) {
+            revealTargetIds.push(pid);
+            for (const c of p.hand) allRevealCards.push({ uid: c.uid, defId: c.defId });
+        }
+        totalMadness += p.hand.filter(c => c.defId === MADNESS_CARD_DEF_ID).length;
+    }
+
+    if (allRevealCards.length > 0) {
+        const targetIds = revealTargetIds.length === 1 ? revealTargetIds[0] : revealTargetIds;
+        events.push(revealHand(targetIds, 'all', allRevealCards, 'elder_thing_the_price_of_power_pod', ctx.now, ctx.playerId));
+    }
+
+    if (totalMadness === 0) return { events };
+
+    const myMinions: Array<{ uid: string; baseIndex: number }> = [];
+    for (let baseIndex = 0; baseIndex < ctx.state.bases.length; baseIndex++) {
+        for (const m of ctx.state.bases[baseIndex].minions) {
+            if (m.controller === ctx.playerId) {
+                myMinions.push({ uid: m.uid, baseIndex });
+            }
+        }
+    }
+    if (myMinions.length === 0) return { events };
+
+    // 目前沿用“自动分配”实现：按轮询分配每个 +1 指示物（后续可升级为逐次可选目标交互）。
+    for (let i = 0; i < totalMadness; i++) {
+        const target = myMinions[i % myMinions.length];
+        events.push(addPowerCounter(target.uid, target.baseIndex, 1, 'elder_thing_the_price_of_power_pod', ctx.now));
+    }
+    return { events };
+}
+
 function elderThingDunwichHorrorPodBeforeScoring(ctx: TriggerContext): SmashUpEvent[] | { events: SmashUpEvent[]; matchState?: any } {
     const { state, baseIndex, now } = ctx;
     if (baseIndex === undefined) return [];
@@ -640,6 +698,10 @@ function elderThingDunwichHorrorPodBeforeScoring(ctx: TriggerContext): SmashUpEv
     );
     (interaction.data as any).continuationContext = { baseIndex, ...t };
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
+}
+
+function elderThingDunwichHorrorPodOnTurnEndNoop(_ctx: TriggerContext): SmashUpEvent[] {
+    return [];
 }
 
 /** 远古之物 onPlay：消灭两个己方其他随从或将本随从放到牌库底 */
@@ -697,7 +759,7 @@ function elderThingShoggoth(ctx: AbilityContext): AbilityResult {
         if (playerPower < 6) return { events: [] };
     }
 
-    const opponents = ctx.state.turnOrder.filter(pid => pid !== ctx.playerId);
+    const opponents = getOrderedOpponentIds(ctx.state, ctx.playerId);
     if (opponents.length === 0) return { events: [] };
 
     const options = [
@@ -751,6 +813,40 @@ function shoggothContinueChain(
         return { state: queueInteraction(state, interaction), events };
     }
     return { state, events };
+}
+
+function queueSpreadingHorrorPodMayPlay(
+    state: any,
+    ctx: { casterPlayerId: string; remaining: number; usedBases: number[] },
+    timestamp: number,
+): { state: any; events: SmashUpEvent[] } {
+    if (ctx.remaining <= 0) return { state, events: [] };
+
+    const player = state.core.players[ctx.casterPlayerId];
+    const hasPlayableDiscardMinion = player.discard.some((c: any) => {
+        if (c.type !== 'minion') return false;
+        const def = getCardDef(c.defId) as any;
+        return def?.type === 'minion' && def.power <= 3;
+    });
+    const hasAvailableBase = state.core.bases.some((_b: any, i: number) => !ctx.usedBases.includes(i));
+
+    // 没有可打出的随从或没有可选基地：该次机会自动跳过，继续下一个“可选打出”机会。
+    if (!hasPlayableDiscardMinion || !hasAvailableBase) {
+        return queueSpreadingHorrorPodMayPlay(state, { ...ctx, remaining: ctx.remaining - 1 }, timestamp);
+    }
+
+    const interaction = createSimpleChoice(
+        `elder_thing_spreading_horror_pod_may_${timestamp}_${ctx.remaining}`,
+        ctx.casterPlayerId,
+        '散播恐怖：你可以从弃牌堆打出一个战斗力≤3的随从',
+        [
+            { id: 'yes', label: '打出一个随从', value: { choice: 'yes' }, displayMode: 'button' as const },
+            { id: 'no', label: '不打出', value: { choice: 'no' }, displayMode: 'button' as const },
+        ] as any[],
+        { sourceId: 'elder_thing_spreading_horror_pod_may_play', targetType: 'button' },
+    );
+    (interaction.data as any).continuationContext = ctx;
+    return { state: queueInteraction(state, interaction), events: [] };
 }
 
 /** 注册远古之物派系的交互解决处理函数 */
@@ -1412,18 +1508,45 @@ export function registerElderThingInteractionHandlers(): void {
         }
         // after all opponents, if decliners >0 start play-from-discard loop
         if (ctx.decliners.length > 0) {
-            const bases = state.core.bases.map((b: any, i: number) => ({ baseIndex: i, label: getBaseDef(b.defId)?.name ?? `基地 ${i + 1}` }));
-            const interaction = createSimpleChoice(
-                `elder_thing_spreading_horror_pod_play_${timestamp}`,
-                ctx.casterPlayerId,
-                '散播恐怖：选择要打出随从的基地（每次必须不同）',
-                buildBaseTargetOptions(bases, state.core),
-                { sourceId: 'elder_thing_spreading_horror_pod_choose_base', targetType: 'base' },
+            const next = queueSpreadingHorrorPodMayPlay(
+                state,
+                { casterPlayerId: ctx.casterPlayerId, remaining: ctx.decliners.length, usedBases: [] as number[] },
+                timestamp,
             );
-            (interaction.data as any).continuationContext = { casterPlayerId: ctx.casterPlayerId, remaining: ctx.decliners.length, usedBases: [] as number[] };
-            return { state: queueInteraction(state, interaction), events };
+            return { state: next.state, events: [...events, ...next.events] };
         }
         return { state, events };
+    });
+
+    registerInteractionHandler('elder_thing_spreading_horror_pod_may_play', (state, playerId, value, iData, _random, timestamp) => {
+        const ctx = (iData as any)?.continuationContext as { casterPlayerId: string; remaining: number; usedBases: number[] } | undefined;
+        const { choice } = value as { choice?: 'yes' | 'no' };
+        if (!ctx) return { state, events: [] };
+
+        if (choice !== 'yes') {
+            const nextCtx = { ...ctx, remaining: ctx.remaining - 1 };
+            if (nextCtx.remaining <= 0) return { state, events: [] };
+            return queueSpreadingHorrorPodMayPlay(state, nextCtx, timestamp);
+        }
+
+        const bases = state.core.bases
+            .map((b: any, i: number) => ({ baseIndex: i, label: getBaseDef(b.defId)?.name ?? `基地 ${i + 1}` }))
+            .filter((b: any) => !ctx.usedBases.includes(b.baseIndex));
+        if (bases.length === 0) {
+            const nextCtx = { ...ctx, remaining: ctx.remaining - 1 };
+            if (nextCtx.remaining <= 0) return { state, events: [] };
+            return queueSpreadingHorrorPodMayPlay(state, nextCtx, timestamp);
+        }
+
+        const interaction = createSimpleChoice(
+            `elder_thing_spreading_horror_pod_choose_base_${timestamp}_${ctx.remaining}`,
+            playerId,
+            '散播恐怖：选择要打出随从的基地（每次必须不同）',
+            buildBaseTargetOptions(bases, state.core),
+            { sourceId: 'elder_thing_spreading_horror_pod_choose_base', targetType: 'base' },
+        );
+        (interaction.data as any).continuationContext = ctx;
+        return { state: queueInteraction(state, interaction), events: [] };
     });
 
     registerInteractionHandler('elder_thing_spreading_horror_pod_choose_base', (state, playerId, value, iData, _random, timestamp) => {
@@ -1436,7 +1559,11 @@ export function registerElderThingInteractionHandlers(): void {
             const def = getCardDef(c.defId) as any;
             return def?.type === 'minion' && def.power <= 3;
         });
-        if (discardMinions.length === 0) return { state, events: [] };
+        if (discardMinions.length === 0) {
+            const nextCtx = { ...ctx, remaining: (ctx.remaining ?? 1) - 1 };
+            if (nextCtx.remaining <= 0) return { state, events: [] };
+            return queueSpreadingHorrorPodMayPlay(state, nextCtx, timestamp);
+        }
         const options = discardMinions.map((c: any, i: number) => ({ id: `m-${i}`, label: getCardDef(c.defId)?.name ?? c.defId, value: { cardUid: c.uid, defId: c.defId }, displayMode: 'card' as const, _source: 'discard' as const }));
         const interaction = createSimpleChoice(
             `elder_thing_spreading_horror_pod_choose_minion_${timestamp}`,
@@ -1463,18 +1590,12 @@ export function registerElderThingInteractionHandlers(): void {
         const remaining = (ctx.remaining ?? 1) - 1;
         const usedBases = [...ctx.usedBases, ctx.chosenBaseIndex];
         if (remaining > 0) {
-            const bases = state.core.bases.map((b: any, i: number) => ({ baseIndex: i, label: getBaseDef(b.defId)?.name ?? `基地 ${i + 1}` })).filter((b: any) => !usedBases.includes(b.baseIndex));
-            if (bases.length > 0) {
-                const interaction = createSimpleChoice(
-                    `elder_thing_spreading_horror_pod_play_${timestamp}_${remaining}`,
-                    playerId,
-                    '散播恐怖：选择要打出随从的基地（每次必须不同）',
-                    buildBaseTargetOptions(bases, state.core),
-                    { sourceId: 'elder_thing_spreading_horror_pod_choose_base', targetType: 'base' },
-                );
-                (interaction.data as any).continuationContext = { casterPlayerId: playerId, remaining, usedBases };
-                return { state: queueInteraction(state, interaction), events };
-            }
+            const next = queueSpreadingHorrorPodMayPlay(
+                state,
+                { casterPlayerId: playerId, remaining, usedBases },
+                timestamp,
+            );
+            return { state: next.state, events: [...events, ...next.events] };
         }
         return { state, events };
     });

--- a/src/games/smashup/abilities/miskatonic.ts
+++ b/src/games/smashup/abilities/miskatonic.ts
@@ -158,6 +158,74 @@ function buildMandatoryReadingDrawInteraction(
     };
 }
 
+function buildThingsBestNotKnownPodDrawInteraction(
+    matchState: MatchState<SmashUpCore>,
+    playerId: string,
+    minionUid: string,
+    minionDefId: string,
+    baseIndex: number,
+    timestamp: number,
+): AbilityResult {
+    const madnessDeckSize = (matchState.core as any).madnessDeck?.length ?? 0;
+    const maxDraw = Math.min(3, madnessDeckSize);
+    if (maxDraw === 0) return { events: [] };
+    const drawOptions: any[] = [];
+    for (let i = 1; i <= maxDraw; i++) {
+        drawOptions.push({
+            id: `draw-${i}`,
+            label: `抽 ${i} 张疯狂卡（该随从直到回合结束 +${i * 2} 战斗力）`,
+            value: { count: i },
+            displayMode: 'button' as const,
+        });
+    }
+    drawOptions.push({ id: 'skip', label: '不抽', value: { skip: true }, displayMode: 'button' as const });
+    const interaction = createSimpleChoice(
+        `miskatonic_things_best_not_known_pod_draw_${timestamp}`,
+        playerId,
+        'Things Best Not Known：选择抽取疯狂卡数量',
+        drawOptions,
+        { sourceId: 'miskatonic_things_best_not_known_pod_draw', targetType: 'button' },
+    );
+    return {
+        events: [],
+        matchState: queueInteraction(matchState, {
+            ...interaction,
+            data: {
+                ...interaction.data,
+                continuationContext: { minionUid, minionDefId, baseIndex },
+            },
+        }),
+    };
+}
+
+function miskatonicThingsBestNotKnownPod(ctx: AbilityContext): AbilityResult {
+    const baseIndex = ctx.baseIndex ?? 0;
+    const base = ctx.state.bases[baseIndex];
+    if (!base || base.minions.length === 0) return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.no_valid_targets', ctx.now)] };
+
+    const options = base.minions.map(m => {
+        const def = getCardDef(m.defId) as MinionCardDef | undefined;
+        const name = def?.name ?? m.defId;
+        const power = getMinionPower(ctx.state, m, baseIndex);
+        return { uid: m.uid, defId: m.defId, baseIndex, label: `${name} (力量 ${power})` };
+    });
+    return resolveOrPrompt(ctx, buildMinionTargetOptions(options, { state: ctx.state, sourcePlayerId: ctx.playerId, effectType: 'affect' }), {
+        id: 'miskatonic_things_best_not_known_pod',
+        title: 'Things Best Not Known：选择一个随从',
+        sourceId: 'miskatonic_things_best_not_known_pod',
+        targetType: 'minion',
+    }, (value) => {
+        return buildThingsBestNotKnownPodDrawInteraction(
+            ctx.matchState,
+            ctx.playerId,
+            value.minionUid,
+            value.minionDefId,
+            baseIndex,
+            ctx.now,
+        );
+    });
+}
+
 /**
  * 通往超凡的门 talent（ongoing 行动卡）：抽一张疯狂卡，你可以额外打出一个随从到这
  *
@@ -343,6 +411,27 @@ function miskatonicResearcherOnPlay(ctx: AbilityContext): AbilityResult {
             { id: 'skip', label: '跳过', value: { skip: true } , displayMode: 'button' as const },
         ],
         { sourceId: 'miskatonic_researcher', targetType: 'button' },
+    );
+    return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
+}
+
+function miskatonicResearcherPodOnPlay(ctx: AbilityContext): AbilityResult {
+    if (!ctx.state.madnessDeck || ctx.state.madnessDeck.length === 0) {
+        return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.condition_not_met', ctx.now)] };
+    }
+    const hasAnyMinion = ctx.state.bases.some(base => base.minions.length > 0);
+    if (!hasAnyMinion) {
+        return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.no_valid_targets', ctx.now)] };
+    }
+    const interaction = createSimpleChoice(
+        `miskatonic_researcher_pod_${ctx.now}`,
+        ctx.playerId,
+        '研究员：你可以抽一张疯狂卡。若如此做，在一个随从上放置一个 +1 战斗力标记。',
+        [
+            { id: 'draw', label: '抽疯狂卡并放置 +1 标记', value: { draw: true }, displayMode: 'button' as const },
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
+        ],
+        { sourceId: 'miskatonic_researcher_pod', targetType: 'button' },
     );
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
 }
@@ -533,6 +622,39 @@ function miskatonicFieldTrip(ctx: AbilityContext): AbilityResult {
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
 }
 
+function miskatonicFieldTripPod(ctx: AbilityContext): AbilityResult {
+    const player = ctx.state.players[ctx.playerId];
+    const handCards = player.hand.filter(c => c.uid !== ctx.cardUid);
+
+    // POD: placing 0 cards still draws 1 card.
+    if (handCards.length === 0) {
+        const drawCount = Math.min(1, player.deck.length);
+        if (drawCount <= 0) return { events: [] };
+        const drawnUids = player.deck.slice(0, drawCount).map(c => c.uid);
+        return {
+            events: [{
+                type: SU_EVENTS.CARDS_DRAWN,
+                payload: { playerId: ctx.playerId, count: drawCount, cardUids: drawnUids },
+                timestamp: ctx.now,
+            } as CardsDrawnEvent],
+        };
+    }
+
+    const options = handCards.map((c, i) => {
+        const def = getCardDef(c.defId);
+        const name = def?.name ?? c.defId;
+        return { id: `card-${i}`, label: name, value: { cardUid: c.uid, defId: c.defId }, _source: 'hand' as const, displayMode: 'card' as const };
+    });
+    const interaction = createSimpleChoice(
+        `miskatonic_field_trip_pod_${ctx.now}`,
+        ctx.playerId,
+        '选择要放到牌库底的卡牌（抽取所选数量 + 1）',
+        [...options, { id: 'skip', label: '不放置（仍抽 1）', value: { skip: true }, displayMode: 'button' as const }] as any[],
+        { sourceId: 'miskatonic_field_trip_pod', targetType: 'hand', multi: { min: 0, max: handCards.length } },
+    );
+    return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
+}
+
 /** 注册米斯卡塔尼克大学派系所有能力（放在所有函数定义之后，避免 Vite SSR 提升失效） */
 export function registerMiskatonicAbilities(): void {
     // === 行动卡 ===
@@ -544,7 +666,7 @@ export function registerMiskatonicAbilities(): void {
     registerAbility('miskatonic_thats_so_crazy_pod', 'onPlay', miskatonicPsychologicalProfiling);
     // 最好不知道的事：special，基地计分前选随从+抽疯狂卡+该随从+2力量/张
     registerAbility('miskatonic_mandatory_reading', 'special', miskatonicMandatoryReading);
-    registerAbility('miskatonic_things_best_not_known_pod', 'special', miskatonicMandatoryReading);
+    registerAbility('miskatonic_things_best_not_known_pod', 'special', miskatonicThingsBestNotKnownPod);
     // 失落的知识（通往超凡的门）：ongoing talent，抽疯狂卡+额外随从到此基地
     registerAbility('miskatonic_lost_knowledge', 'talent', miskatonicLostKnowledge);
     registerAbility('miskatonic_eldritch_gate_pod', 'talent', miskatonicLostKnowledge);
@@ -559,7 +681,7 @@ export function registerMiskatonicAbilities(): void {
     registerAbility('miskatonic_old_man_jenkins_pod', 'special', miskatonicThingOnTheDoorstep);
     // 实地考察：手牌放牌库底 + 抽等量牌
     registerAbility('miskatonic_field_trip', 'onPlay', miskatonicFieldTrip);
-    registerAbility('miskatonic_field_trip_pod', 'onPlay', miskatonicFieldTrip);
+    registerAbility('miskatonic_field_trip_pod', 'onPlay', miskatonicFieldTripPod);
 
     // === 随从 ===
     // 教授（power 5, talent）：弃1张疯狂卡 → 额外行动 + 额外随从
@@ -573,7 +695,7 @@ export function registerMiskatonicAbilities(): void {
     registerAbility('miskatonic_psychologist_pod', 'onPlay', miskatonicPsychologistPodOnPlay);
     // 研究员（power 2, onPlay）：抽1张疯狂卡
     registerAbility('miskatonic_researcher', 'onPlay', miskatonicResearcherOnPlay);
-    registerAbility('miskatonic_researcher_pod', 'onPlay', miskatonicResearcherOnPlay);
+    registerAbility('miskatonic_researcher_pod', 'onPlay', miskatonicResearcherPodOnPlay);
 }
 
 /** 注册米斯卡塔尼克大学的交互解决处理函数 */
@@ -674,9 +796,10 @@ export function registerMiskatonicInteractionHandlers(): void {
         return { state: result.matchState ?? state, events: result.events };
     });
 
-    registerInteractionHandler('miskatonic_things_best_not_known_pod', (state, playerId, value, iData, random, timestamp) => {
-        const handler = (getInteractionHandler('miskatonic_mandatory_reading') as any);
-        return handler ? handler(state, playerId, value, iData, random, timestamp) : { state, events: [] };
+    registerInteractionHandler('miskatonic_things_best_not_known_pod', (state, playerId, value, _iData, _random, timestamp) => {
+        const { minionUid, minionDefId, baseIndex } = value as { minionUid: string; minionDefId: string; baseIndex: number };
+        const result = buildThingsBestNotKnownPodDrawInteraction(state, playerId, minionUid, minionDefId, baseIndex, timestamp);
+        return { state: result.matchState ?? state, events: result.events };
     });
 
     // 最好不知道的事：选择抽取疯狂卡数量后，抽疯狂卡+给随从加力量
@@ -701,7 +824,24 @@ export function registerMiskatonicInteractionHandlers(): void {
         return { state, events };
     });
 
-    // NOTE: buildMandatoryReadingDrawInteraction uses sourceId 'miskatonic_mandatory_reading_draw' for both base and POD.
+    registerInteractionHandler('miskatonic_things_best_not_known_pod_draw', (state, playerId, value, _iData, _random, timestamp) => {
+        if (value && (value as any).skip) return { state, events: [] };
+        const { count, minionUid: legacyMinionUid, baseIndex: legacyBaseIndex } = value as {
+            count: number;
+            minionUid?: string;
+            baseIndex?: number;
+        };
+        const ctx = (_iData?.continuationContext as { minionUid: string; baseIndex: number } | undefined)
+            ?? (legacyMinionUid && legacyBaseIndex !== undefined
+                ? { minionUid: legacyMinionUid, baseIndex: legacyBaseIndex }
+                : undefined);
+        if (!ctx) return { state, events: [] };
+        const events: SmashUpEvent[] = [];
+        const madnessEvt = drawMadnessCards(playerId, count, state.core, 'miskatonic_things_best_not_known_pod', timestamp);
+        if (madnessEvt) events.push(madnessEvt);
+        events.push(addTempPower(ctx.minionUid, ctx.baseIndex, count * 2, 'miskatonic_things_best_not_known_pod', timestamp));
+        return { state, events };
+    });
 
     // 图书管理员 POD：抽疯狂卡 或 授予额外战术额度
     registerInteractionHandler('miskatonic_librarian_pod', (state, playerId, value, _iData, _random, timestamp) => {
@@ -711,9 +851,47 @@ export function registerMiskatonicInteractionHandlers(): void {
             return { state, events: evt ? [evt] : [] };
         }
         if (v.mode === 'extra') {
-            return { state, events: [grantExtraAction(playerId, 'miskatonic_librarian_pod', timestamp)] };
+            const player = state.core.players[playerId];
+            const madnessCards = player.hand.filter(c => c.defId === MADNESS_CARD_DEF_ID);
+            if (madnessCards.length === 0) return { state, events: [buildAbilityFeedback(playerId, 'feedback.hand_empty', timestamp)] };
+            const options = madnessCards.map((card, i) => {
+                const def = getCardDef(card.defId);
+                const name = def?.name ?? card.defId;
+                return {
+                    id: `madness-${i}`,
+                    label: name,
+                    value: { cardUid: card.uid, defId: card.defId },
+                    _source: 'hand' as const,
+                    displayMode: 'card' as const,
+                };
+            });
+            const next = createSimpleChoice(
+                `miskatonic_librarian_pod_play_madness_${timestamp}`,
+                playerId,
+                '图书管理员：选择一张疯狂卡，作为额外战术打出',
+                options as any[],
+                { sourceId: 'miskatonic_librarian_pod_play_madness', targetType: 'hand' },
+            );
+            return { state: queueInteraction(state, next), events: [] };
         }
         return { state, events: [] };
+    });
+
+    registerInteractionHandler('miskatonic_librarian_pod_play_madness', (state, playerId, value, _iData, _random, timestamp) => {
+        const selected = (Array.isArray(value) ? value[0] : value) as { cardUid?: string } | undefined;
+        const cardUid = selected?.cardUid;
+        if (!cardUid) return { state, events: [] };
+        const player = state.core.players[playerId];
+        const card = player.hand.find(c => c.uid === cardUid);
+        if (!card || card.defId !== MADNESS_CARD_DEF_ID) return { state, events: [] };
+        return {
+            state,
+            events: [{
+                type: SU_EVENTS.ACTION_PLAYED,
+                payload: { playerId, cardUid: card.uid, defId: card.defId, isExtraAction: true },
+                timestamp,
+            } as SmashUpEvent],
+        };
     });
 
     // Those Meddling Kids POD：模式选择
@@ -822,6 +1000,41 @@ export function registerMiskatonicInteractionHandlers(): void {
         return { state, events: madnessEvt ? [madnessEvt] : [] };
     });
 
+    registerInteractionHandler('miskatonic_researcher_pod', (state, playerId, value, _iData, _random, timestamp) => {
+        if (value && (value as any).skip) return { state, events: [] };
+        const allMinions: Array<{ uid: string; defId: string; baseIndex: number; label: string }> = [];
+        for (let i = 0; i < state.core.bases.length; i++) {
+            const base = state.core.bases[i];
+            for (const m of base.minions) {
+                const def = getCardDef(m.defId) as MinionCardDef | undefined;
+                const name = def?.name ?? m.defId;
+                const power = getMinionPower(state.core, m, i);
+                allMinions.push({ uid: m.uid, defId: m.defId, baseIndex: i, label: `${name} (力量 ${power})` });
+            }
+        }
+        if (allMinions.length === 0) return { state, events: [] };
+        const next = createSimpleChoice(
+            `miskatonic_researcher_pod_choose_minion_${timestamp}`,
+            playerId,
+            '研究员：选择一个随从放置 +1 战斗力标记',
+            buildMinionTargetOptions(allMinions, { state: state.core, sourcePlayerId: playerId, effectType: 'affect' }),
+            { sourceId: 'miskatonic_researcher_pod_choose_minion', targetType: 'minion' },
+        );
+        return { state: queueInteraction(state, next), events: [] };
+    });
+
+    registerInteractionHandler('miskatonic_researcher_pod_choose_minion', (state, playerId, value, _iData, _random, timestamp) => {
+        const { minionUid, baseIndex } = value as { minionUid?: string; baseIndex?: number };
+        if (!minionUid || baseIndex === undefined) return { state, events: [] };
+        const exists = state.core.bases[baseIndex]?.minions.some(m => m.uid === minionUid) ?? false;
+        if (!exists) return { state, events: [] };
+        const events: SmashUpEvent[] = [];
+        const madnessEvt = drawMadnessCards(playerId, 1, state.core, 'miskatonic_researcher_pod', timestamp);
+        if (madnessEvt) events.push(madnessEvt);
+        events.push(addPowerCounter(minionUid, baseIndex, 1, 'miskatonic_researcher_pod', timestamp));
+        return { state, events };
+    });
+
     // 实地考察：选择卡牌后放牌库底 + 抽等量牌
     registerInteractionHandler('miskatonic_field_trip', (state, playerId, value, _iData, _random, timestamp) => {
         const selectedCards = value as Array<{ cardUid?: string; defId?: string }>;
@@ -853,8 +1066,7 @@ export function registerMiskatonicInteractionHandlers(): void {
     });
 
     registerInteractionHandler('miskatonic_field_trip_pod', (state, playerId, value, iData, random, timestamp) => {
-        const selectedCards = value as Array<{ cardUid?: string; defId?: string }>;
-        if (!Array.isArray(selectedCards)) return { state, events: [] };
+        const selectedCards = (Array.isArray(value) ? value : []) as Array<{ cardUid?: string; defId?: string }>;
         const player = state.core.players[playerId];
         const events: SmashUpEvent[] = [];
         const cardUids = selectedCards.map(v => v.cardUid).filter(Boolean) as string[];

--- a/src/games/smashup/abilities/pirates.ts
+++ b/src/games/smashup/abilities/pirates.ts
@@ -930,7 +930,9 @@ export function registerPirateInteractionHandlers(): void {
         // 引擎层 resolveInteraction 已自动传递延迟事件，这里只需要在最后一个交互时补发
         const deferredEvents = (iData?.continuationContext as any)?._deferredPostScoringEvents as 
             { type: string; payload: unknown; timestamp: number }[] | undefined;
-        const hasNextInteraction = state.sys.interaction?.queue && state.sys.interaction.queue.length > 0;
+        const hasNextInteraction =
+            !!state.sys.interaction?.current
+            || (state.sys.interaction?.queue?.length ?? 0) > 0;
         
         if (selected.skip) {
             // 跳过时，如果这是最后一个交互，补发延迟事件

--- a/src/games/smashup/abilities/pirates.ts
+++ b/src/games/smashup/abilities/pirates.ts
@@ -281,13 +281,18 @@ function buccaneerMoveHandler(
         minionDefId: string;
         fromBaseIndex: number;
         toBaseIndex: number;
+        baseDefId?: string;
     };
+    const resolvedToBaseIndex = resolveLiveBaseIndex(state.core, selected.toBaseIndex, selected.baseDefId);
+    if (resolvedToBaseIndex === undefined) {
+        return { state, events: [] };
+    }
     const events: SmashUpEvent[] = [
         moveMinion(
             selected.minionUid,
             selected.minionDefId,
             selected.fromBaseIndex,
-            selected.toBaseIndex,
+            resolvedToBaseIndex,
             selected.minionDefId === 'pirate_buccaneer_pod' ? 'pirate_buccaneer_pod' : 'pirate_buccaneer',
             timestamp
         )
@@ -411,7 +416,7 @@ function pirateFirstMateAfterScoring(ctx: TriggerContext): SmashUpEvent[] | Trig
         const baseOptions = otherBases.map(b => {
             const baseDef = getBaseDef(b.defId);
             const baseName = baseDef?.name ?? `基地 ${b.index + 1}`;
-            return { id: `base-${b.index}`, label: baseName, value: { baseIndex: b.index }, _source: 'base' as const };
+            return { id: `base-${b.index}`, label: baseName, value: { baseIndex: b.index, baseDefId: b.defId }, _source: 'base' as const };
         });
         const allOptions = [
             { id: 'skip', label: '跳过（不移动大副）', value: { skip: true }, displayMode: 'button' as const },
@@ -573,6 +578,21 @@ function buildMoveToBaseInteraction(
 }
 
 /** 注册海盗派系的交互解决处理函数 */
+function resolveLiveBaseIndex(
+    state: SmashUpCore,
+    baseIndex: number | undefined,
+    baseDefId?: string,
+): number | undefined {
+    if (baseDefId) {
+        const liveIndex = state.bases.findIndex(base => base.defId === baseDefId);
+        if (liveIndex >= 0) return liveIndex;
+    }
+    if (baseIndex !== undefined && state.bases[baseIndex]) {
+        return baseIndex;
+    }
+    return undefined;
+}
+
 export function registerPirateInteractionHandlers(): void {
     // 粗鲁少妇：选择目标后消灭（支持跳过）
     registerInteractionHandler('pirate_saucy_wench', (state, playerId, value, _iData, _random, timestamp) => {
@@ -924,7 +944,7 @@ export function registerPirateInteractionHandlers(): void {
     // 大副：选择目标基地后移动大副自身
     // 注意：BASE_CLEARED 可能已 reduce，计分基地已从 bases 数组移除，随从已进弃牌堆
     registerInteractionHandler('pirate_first_mate_choose_base', (state, _playerId, value, iData, _random, timestamp) => {
-        const selected = value as { skip?: boolean; baseIndex?: number };
+        const selected = value as { skip?: boolean; baseIndex?: number; baseDefId?: string };
         
         // 【通用修复】检查是否有延迟事件需要补发
         // 引擎层 resolveInteraction 已自动传递延迟事件，这里只需要在最后一个交互时补发
@@ -946,11 +966,18 @@ export function registerPirateInteractionHandlers(): void {
         if (destBase === undefined) return undefined;
         const ctx = iData?.continuationContext as { mateUid: string; mateDefId: string; scoringBaseIndex: number } | undefined;
         if (!ctx) return undefined;
+        const resolvedDestBase = resolveLiveBaseIndex(state.core, destBase, selected.baseDefId);
+        if (resolvedDestBase === undefined) {
+            if (deferredEvents && deferredEvents.length > 0 && !hasNextInteraction) {
+                return { state, events: deferredEvents as any[] };
+            }
+            return { state, events: [] };
+        }
         const events: SmashUpEvent[] = [moveMinion(
             ctx.mateUid,
             ctx.mateDefId,
             ctx.scoringBaseIndex,
-            destBase,
+            resolvedDestBase,
             ctx.mateDefId === 'pirate_first_mate_pod' ? 'pirate_first_mate_pod' : 'pirate_first_mate',
             timestamp
         )];

--- a/src/games/smashup/abilities/tricksters.ts
+++ b/src/games/smashup/abilities/tricksters.ts
@@ -226,6 +226,7 @@ function registerTricksterPodAbilities(): void {
     registerAbility('trickster_enshrouding_mist_pod', 'talent', tricksterEnshroudingMistPodTalent);
     registerAbility('trickster_hideout_pod', 'talent', tricksterHideoutPodTalent);
     registerAbility('trickster_gnome_pod', 'special', tricksterGnomePodSpecial);
+    registerAbility('trickster_gremlin_pod', 'onDestroy', () => ({ events: [] }));
     registerTricksterPodOngoingEffects();
 }
 
@@ -979,6 +980,9 @@ function registerTricksterOngoingEffects(): void {
 }
 
 function registerTricksterPodOngoingEffects(): void {
+    registerTrigger('trickster_brownie_pod', 'onMinionAffected', () => []);
+    registerTrigger('trickster_enshrouding_mist_pod', 'onTurnStart', () => []);
+    registerProtection('trickster_hideout_pod', 'action', () => false);
     // Hideout POD：其他玩家不能将随从移动到此基地（用事件拦截器阻止移动）
     registerInterceptor('trickster_hideout_pod', (state, event) => {
         if (event.type !== SU_EVENTS.MINION_MOVED) return undefined;

--- a/src/games/smashup/data/factions/tricksters_pod.ts
+++ b/src/games/smashup/data/factions/tricksters_pod.ts
@@ -75,7 +75,7 @@ export const TRICKSTER_POD_ACTIONS: ActionCardDef[] = [
         faction: 'tricksters_pod',
         abilityTags: ['ongoing', 'talent'],
         ongoingTarget: 'base',
-        count: 1,
+        count: 2,
         previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.CARDS4, index: 28 },
     },
     {

--- a/src/games/smashup/domain/baseAbilities.ts
+++ b/src/games/smashup/domain/baseAbilities.ts
@@ -1430,7 +1430,10 @@ export function registerBaseInteractionHandlers(): void {
         }
 
         const deferredEvents = getDeferredPostScoringEvents(iData);
-        const isLastInteraction = !state.sys.interaction?.queue?.length;
+        const hasPendingInteraction =
+            !!state.sys.interaction?.current
+            || (state.sys.interaction?.queue?.length ?? 0) > 0;
+        const isLastInteraction = !hasPendingInteraction;
         if (deferredEvents && deferredEvents.length > 0 && isLastInteraction) {
             events.push(...deferredEvents as SmashUpEvent[]);
         }
@@ -1459,8 +1462,12 @@ export function registerBaseInteractionHandlers(): void {
         // InteractionSystem.resolveInteraction 会自动传递给下一个交互，最后一个交互解决时必须补发。
         const deferredEvents = getDeferredPostScoringEvents(iData);
         
-        // 检查是否是最后一个交互（队列为空）
-        const isLastInteraction = !state.sys.interaction?.queue?.length;
+        // 注意：RESOLVE_INTERACTION 进入 handler 前，当前交互已被弹出；
+        // 如果还有下一个交互，通常会出现在 interaction.current（queue 可能已空）。
+        const hasPendingInteraction =
+            !!state.sys.interaction?.current
+            || (state.sys.interaction?.queue?.length ?? 0) > 0;
+        const isLastInteraction = !hasPendingInteraction;
         
         if (deferredEvents && deferredEvents.length > 0 && isLastInteraction) {
             events.push(...deferredEvents as SmashUpEvent[]);

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -14,11 +14,53 @@ import {
 import { canPlayFromDiscard } from './discardPlayability';
 import { isSpecialLimitBlocked } from './abilityHelpers';
 import {
+    canUseBaseLimitedMinionQuota,
+    canUseSameNameMinionQuota,
     getMaxRemainingGlobalPowerLimitedQuota,
     mustUseBaseLimitedMinionQuota,
     mustUseGlobalPowerLimitedMinionQuota,
 } from './utils';
 import { isCardActionLike, isCardMinionLike } from './utils';
+
+function hasActiveBearNecessitiesPodRestriction(core: SmashUpCore, playerId: string): boolean {
+    for (const base of core.bases) {
+        const hasPlayerMinion = base.minions.some(minion => minion.controller === playerId);
+        if (!hasPlayerMinion) continue;
+        const hasOpponentActivePod = base.ongoingActions.some(ongoing =>
+            ongoing.defId === 'bear_cavalry_bear_necessities_pod'
+            && ongoing.ownerId !== playerId
+            && ongoing.talentUsed === true,
+        );
+        if (hasOpponentActivePod) return true;
+    }
+    return false;
+}
+
+function isExtraMinionPlayAttempt(
+    core: SmashUpCore,
+    playerId: string,
+    baseIndex: number,
+    cardDefId: string,
+    basePower: number,
+    fromDiscard: boolean,
+    consumesNormalLimit: boolean,
+): boolean {
+    const player = core.players[playerId];
+    if (!player) return false;
+    if (fromDiscard && consumesNormalLimit === false) return true;
+    if (player.minionsPlayed >= 1) return true;
+    if (canUseBaseLimitedMinionQuota(core, player, baseIndex, cardDefId, basePower)) return true;
+    if (canUseSameNameMinionQuota(player, cardDefId)) return true;
+    if (mustUseBaseLimitedMinionQuota(core, player, baseIndex, cardDefId, basePower)) return true;
+    if (mustUseGlobalPowerLimitedMinionQuota(core, player, baseIndex, cardDefId, basePower)) return true;
+    return false;
+}
+
+function isExtraActionPlayAttempt(core: SmashUpCore, playerId: string): boolean {
+    const player = core.players[playerId];
+    if (!player) return false;
+    return player.actionsPlayed >= 1;
+}
 
 export function validate(
     state: MatchState<SmashUpCore>,
@@ -103,6 +145,19 @@ export function validate(
                     return { valid: false, error: '弃牌堆中没有该随从' };
                 }
                 const basePower = getMinionLikePower(discardCard.defId) ?? 0;
+                const blockedByBearNecessitiesPod = hasActiveBearNecessitiesPodRestriction(core, command.playerId)
+                    && isExtraMinionPlayAttempt(
+                        core,
+                        command.playerId,
+                        baseIndex,
+                        discardCard.defId,
+                        basePower,
+                        true,
+                        discardCheck.consumesNormalLimit,
+                    );
+                if (blockedByBearNecessitiesPod) {
+                    return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
+                }
                 const usesBaseLimitedMinionQuota = discardCheck.consumesNormalLimit
                     && mustUseBaseLimitedMinionQuota(core, player, baseIndex, discardCard.defId, basePower);
                 if (isOperationRestricted(core, baseIndex, command.playerId, 'play_minion', {
@@ -128,6 +183,19 @@ export function validate(
             const minionDef = getMinionDef(card.defId);
             const fusionDef = getFusionDef(card.defId);
             const basePower = (minionDef?.power ?? fusionDef?.minionPower) ?? 0;
+            const blockedByBearNecessitiesPod = hasActiveBearNecessitiesPodRestriction(core, command.playerId)
+                && isExtraMinionPlayAttempt(
+                    core,
+                    command.playerId,
+                    baseIndex,
+                    card.defId,
+                    basePower,
+                    false,
+                    true,
+                );
+            if (blockedByBearNecessitiesPod) {
+                return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
+            }
             const usesBaseLimitedMinionQuota = mustUseBaseLimitedMinionQuota(core, player, baseIndex, card.defId, basePower);
             // 同名额度检查：全局额度用完后，如果只剩同名额度，必须匹配已锁定的 defId
             if (globalQuotaRemaining <= 0 && sameNameRemaining > 0 && baseQuota <= 0) {
@@ -310,6 +378,9 @@ export function validate(
             }
             const player = core.players[command.playerId];
             if (!player) return { valid: false, error: '玩家不存在' };
+            if (hasActiveBearNecessitiesPodRestriction(core, command.playerId) && isExtraActionPlayAttempt(core, command.playerId)) {
+                return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
+            }
             if (player.actionsPlayed >= player.actionLimit) {
                 return { valid: false, error: '本回合行动额度已用完' };
             }

--- a/src/games/smashup/domain/ongoingEffects.ts
+++ b/src/games/smashup/domain/ongoingEffects.ts
@@ -365,12 +365,25 @@ export function registerPodOngoingAliases(): void {
         if (alreadyRegistered) continue;
         
         // 添加到待注册列表
-        triggersToAdd.push({ sourceDefId: podDefId, timing, callback });
+        triggersToAdd.push({
+            sourceDefId: podDefId,
+            timing,
+            callback,
+            optional: entry.optional,
+            phase: entry.phase,
+            global: entry.global,
+        });
         mappedCount++;
     }
     
     // 批量添加（避免在遍历时修改数组）
-    triggerRegistry.push(...triggersToAdd);
+    for (const entry of triggersToAdd) {
+        registerTrigger(entry.sourceDefId, entry.timing, entry.callback, {
+            optional: entry.optional,
+            phase: entry.phase,
+            global: entry.global,
+        });
+    }
     
     // 2. 映射 Restriction
     const restrictionsToAdd: RestrictionEntry[] = [];


### PR DESCRIPTION
## 变更背景

本次修复聚焦 Smash Up 小精怪 POD（`tricksters_pod`）的两类问题：

1. **卡池数量异常**
   - `Enshrouding Mist` 数量配置错误，导致小精怪 POD 实际为 19 张，和其他 POD 组合时出现“空白牌/缺牌”现象。

2. **POD 与旧版能力串味**
   - 小精怪 POD 已有独立实现，但仍被 `registerPodAbilityAliases` / `registerPodOngoingAliases` 自动继承了部分旧版逻辑，造成行为不符合 POD 文本。

---

## 主要修改

### 1) 修复卡池数量
- `src/games/smashup/data/factions/tricksters_pod.ts`
- 将 `trickster_enshrouding_mist_pod` 的 `count` 修正为 `2`，确保 `tricksters_pod` 总数为 20 张。

### 2) 阻断 POD 串味（显式覆盖 alias）
- `src/games/smashup/abilities/tricksters.ts`
- 新增显式注册，避免自动 alias 复制旧版逻辑：
  - `trickster_gremlin_pod::onDestroy` 注册空执行器（避免继承旧版 onDestroy）
  - `trickster_brownie_pod::onMinionAffected` 注册空触发（避免继承旧版 affected 触发）
  - `trickster_enshrouding_mist_pod::onTurnStart` 注册空触发（POD 版应为 talent，不是回合开始自动触发）
  - `trickster_hideout_pod::action` 注册 `false` 保护（避免继承旧版 action 保护）

### 3) 补充回归测试（在现有文件中补）
- `src/games/smashup/__tests__/abilityBehaviorAudit.test.ts`
  - 新增断言：`tricksters_pod` 牌组总数保持 20 张
- `src/games/smashup/__tests__/baseFactionOngoing.test.ts`
  - `Brownie POD` 不沿用旧版 `onMinionAffected`
  - `Hideout POD` 不沿用旧版行动牌保护
  - `Enshrouding Mist POD` 不在 `onTurnStart` 自动给额度
- `src/games/smashup/__tests__/onDestroyAbilities.test.ts`
  - `Gremlin POD` 被消灭时仅结算一次抽牌与弃牌

---

## 验证结果

已通过以下测试：

- `npx vitest run src/games/smashup/__tests__/baseFactionOngoing.test.ts src/games/smashup/__tests__/onDestroyAbilities.test.ts src/games/smashup/__tests__/ongoingEffects.test.ts`
  - 结果：`101 passed`
- `npx vitest run src/games/smashup/__tests__/abilityBehaviorAudit.test.ts --config vitest.config.audit.ts -t "tricksters_pod"`
  - 结果：目标用例通过

---

## 影响范围

仅涉及 `tricksters_pod` 相关数据与能力注册，以及对应回归测试；不改变其他派系规则逻辑。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive tests covering Tricksters, Elder Things, Bear/Pirate PODs, interaction edge cases, scoring/deferred flows, and choice/move behaviors.

* **Gameplay Changes**
  * Several PODs no longer auto-trigger protections or ongoing effects; some destroy/play flows now produce specific draw/discard and prompt outcomes.
  * Bear Necessities POD blocks certain “extra” minion/action plays; bear-related interactions refined.

* **Interaction/UX**
  * More robust player ID handling and choice resolution; move/choose prompts reliably resolve to live bases and valid options.

* **Data Updates**
  * Adjusted Tricksters POD action card counts to correct deck composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->