### PR TITLE
fix(smashup): 保留计分前 special 激活窗口

### DIFF
--- a/src/games/smashup/__tests__/scoreBases-auto-continue.test.ts
+++ b/src/games/smashup/__tests__/scoreBases-auto-continue.test.ts
@@ -234,4 +234,33 @@ describe('scoreBases 阶段自动推进', () => {
         expect(result?.autoContinue).toBe(true);
         expect(result?.playerId).toBe('0');
     });
+
+    it('达标基地上有可激活的侏儒 POD special 时不应该自动推进', () => {
+        const core = makeMinimalCore({
+            bases: [makeBase('base_pirate_cove', [
+                makeMinion('0', 'trickster_gnome_pod', 3),
+                makeMinion('0', 'robot_hoverbot', 4),
+                makeMinion('1', 'robot_microbot_guard', 3),
+            ])],
+            scoringEligibleBaseIndices: [0],
+        });
+
+        const state: MatchState<SmashUpCore> = {
+            core,
+            sys: {
+                phase: 'scoreBases',
+                flowHalted: false,
+                interaction: { current: null, queue: [] },
+                responseWindow: { current: null, history: [] },
+            } as any,
+        };
+
+        const result = smashUpFlowHooks.onAutoContinueCheck!({
+            state,
+            events: [],
+            random: { next: () => 0.5 },
+        });
+
+        expect(result).toBeUndefined();
+    });
 });

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -28,6 +28,7 @@ import {
     PHASE_ORDER,
     SU_EVENTS,
     SU_EVENT_TYPES,
+    SU_COMMANDS,
     DRAW_PER_TURN,
     HAND_LIMIT,
     VP_TO_WIN,
@@ -74,6 +75,27 @@ function collectQualifiedPlayerPowers(
     }
 
     return playerPowers;
+}
+
+function hasPendingScoreBasesSpecialActivation(state: MatchState<SmashUpCore>): boolean {
+    const playerId = getCurrentPlayerId(state.core);
+    if (!playerId) return false;
+
+    for (const baseIndex of getScoringEligibleBaseIndices(state.core)) {
+        const base = state.core.bases[baseIndex];
+        if (!base) continue;
+
+        for (const minion of base.minions) {
+            const result = validate(state, {
+                type: SU_COMMANDS.ACTIVATE_SPECIAL,
+                playerId,
+                payload: { minionUid: minion.uid, baseIndex },
+            });
+            if (result.valid) return true;
+        }
+    }
+
+    return false;
 }
 
 function buildBaseRankings(
@@ -1569,6 +1591,11 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
             if (eligibleIndices.length === 0) {
                 console.log('[onAutoContinueCheck] scoreBases: 无 eligible 基地，自动推进');
                 return { autoContinue: true, playerId: pid };
+            }
+
+            if (hasPendingScoreBasesSpecialActivation(state)) {
+                console.log('[onAutoContinueCheck] scoreBases: 当前玩家还有可激活的 special，暂停自动推进');
+                return undefined;
             }
 
             console.log('[onAutoContinueCheck] scoreBases: 响应窗口已关闭，自动推进触发计分');


### PR DESCRIPTION
## 背景

修复 Smash Up 中 `scoreBases` 阶段的一个时序问题。

用户反馈场景：
- `trickster_gnome_pod` 在基地达标后，点击“回合结束”
- 按规则此时应该还能在计分前点击侏儒，消灭一个符合条件的随从
- 实际流程却直接跳过，没有给出激活机会

## 根因

`scoreBases` 阶段在 `Me First!` 响应窗口关闭后，会立即自动推进到后续计分流程。

这会导致一类“场上可手动点击触发的计分前 special”没有操作窗口：
- 响应窗口已经结束
- 但当前玩家在达标基地上其实仍有合法的 `special` 可激活
- 自动推进过早发生，玩家来不及点击

`trickster_gnome_pod` 正好属于这类能力，所以会被直接跳过。

## 修复

在 `scoreBases` 的自动推进检查中增加一层守卫：

- 如果当前玩家在任一达标基地上仍有合法可激活的场上 `special`
- 则暂停自动推进，继续停留在 `scoreBases`
- 等待玩家手动点击触发
- 只有在没有可激活 `special` 时，才继续自动推进到正常计分流程

这次修复做在流程层，不是只给侏儒单独打补丁，因此同类“计分前手动 special”也能一起受益。

## 测试

新增回归用例，覆盖：
- `scoreBases` 阶段有可激活的 `trickster_gnome_pod special` 时，不应自动推进

并验证未回归：
- `scoreBases-auto-continue.test.ts`
- `meFirst.test.ts`
- `turnCycle.test.ts`

本地已通过：

- `npx vitest run src/games/smashup/__tests__/scoreBases-auto-continue.test.ts`
- `npx vitest run src/games/smashup/__tests__/meFirst.test.ts`
- `npx vitest run src/games/smashup/__tests__/turnCycle.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed auto-progression during base scoring to pause when you have special abilities available to activate on minions, ensuring you can use them before the phase advances automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->