### PR TITLE
fix(smashup): 修复熊骑兵POD压制与委任额度问题

### DIFF
--- a/e2e/dicethrone-watch-out-spotlight.e2e.ts
+++ b/e2e/dicethrone-watch-out-spotlight.e2e.ts
@@ -169,7 +169,7 @@ test('self watch out should show bonus die spotlight', async ({ page, game }, te
     expect(afterClickState.lastEventTypes).toContain('BONUS_DIE_ROLLED');
 });
 
-test('bonus die spotlight should not block confirm button interaction', async ({ page, game }, testInfo) => {
+test('bonus die spotlight should close on backdrop click before confirm interaction', async ({ page, game }, testInfo) => {
     test.setTimeout(DICETHRONE_TEST_TIMEOUT_MS);
 
     await game.openTestGame('dicethrone', {}, DICETHRONE_OPEN_TIMEOUT_MS);
@@ -222,6 +222,9 @@ test('bonus die spotlight should not block confirm button interaction', async ({
     const bonusDieOverlay = page.locator('[data-testid="bonus-die-overlay"]');
     await expect(bonusDieOverlay).toBeVisible({ timeout: 3000 });
 
+    await page.mouse.click(40, 40);
+    await expect(bonusDieOverlay).toBeHidden({ timeout: 5000 });
+
     const confirmButton = page.locator('[data-tutorial-id="dice-confirm-button"]');
     await expect(confirmButton).toBeEnabled({ timeout: 5000 });
     await confirmButton.click();
@@ -231,7 +234,7 @@ test('bonus die spotlight should not block confirm button interaction', async ({
         return state?.core?.rollConfirmed === true;
     }, { timeout: 5000 });
 
-    await game.screenshot('04-bonus-die-spotlight-non-blocking', testInfo);
+    await game.screenshot('04-bonus-die-spotlight-backdrop-close-then-confirm', testInfo);
 });
 
 test('bonus die spotlight should close on content click in display mode', async ({ page, game }, testInfo) => {

--- a/evidence/merge-conflict-pr31-2026-03-22.md
+++ b/evidence/merge-conflict-pr31-2026-03-22.md
@@ -1,0 +1,50 @@
+# 冲突解决汇报：PR #31
+
+## 1. 背景
+- base: `origin/main` at `4640832e`
+- head: `pr/31` (`codex/smashup-pod-target-fixes-upstream`) at `ce0362c7`
+- 触发命令: `git merge pr/31 --no-commit --no-ff`
+
+## 2. 冲突文件
+- `src/games/smashup/domain/reducer.ts`
+
+## 3. 解决策略
+### `src/games/smashup/domain/reducer.ts`
+- 策略：以 PR 版本为主，保留主线后续两个修复点，再补充低风险逻辑修正。
+- 合并要点：
+  - 保留 PR 的 `hasPlayerTurnRestriction` / `PERMANENT_POWER_ADDED` / Move 过滤逻辑。
+  - 补回主线 `actionTargetType` 透传。
+  - 保留主线 `destroyerId` 触发链上下文。
+  - 将 `move_minion` 限制判定改为基于 `effectiveSource`，避免 `base_*` 原因误套用命令发起者限制。
+- 原因：主线只比 PR 多两处独立修复；其余冲突集中在同一文件的大块重叠，直接保留 PR 主体实现更稳定。
+
+## 4. 额外修复
+- `src/games/smashup/abilities/tricksters.ts`
+  - `Pay the Piper` 动态手牌选项改为稳定 `card.uid`。
+  - `睡眠印记 POD` 追加限制时按 `restrictionType` 去重，避免不同限制互相覆盖。
+- `src/games/smashup/domain/types.ts`
+  - 提取共享 `PlayerTurnRestrictionType` / `PlayerTurnRestriction`。
+- `src/games/smashup/domain/ongoingEffects.ts`
+  - 复用共享限制类型，避免状态定义与查询助手漂移。
+- `src/games/smashup/domain/commands.ts`
+- `src/games/smashup/domain/playLegality.ts`
+- `src/games/smashup/domain/reduce.ts`
+  - `sleepMarkedPlayers` 改为在目标回合结束时清除，且在目标自己的回合内持续阻止打出战术，避免额外行动重新放开。
+- `src/games/smashup/__tests__/trickster-mark-of-sleep-self-target.test.ts`
+  - 补 3 个回归用例覆盖限制叠加、沉睡印记整回合锁定、`base_*` 移动原因。
+
+## 5. 风险与验证
+- 风险点：
+  - `sleepMarkedPlayers` 的清理时机从 `TURN_STARTED` 挪到 `TURN_ENDED`，需要确认不会误伤非当前回合 special。
+  - `move_minion` 仍然依赖现有事件契约，没有新增 `actorId` 字段；当前只对 `base_*` 原因做了收敛。
+- 验证命令：
+  - `npx vitest run src/games/smashup/__tests__/trickster-mark-of-sleep-self-target.test.ts`
+  - `npx vitest run src/games/smashup/__tests__/newFactionAbilities.test.ts`
+  - `npx vitest run src/games/smashup/__tests__/baseFactionOngoing.test.ts`
+  - `npx vitest run src/games/smashup/__tests__/specialInteractionChain.test.ts`
+  - `npx tsc --noEmit`
+- 验证结果：全部通过。
+
+## 6. 结果
+- 提交：`f938ed49 merge: resolve PR #31 trickster POD restrictions`
+- 推送：目标 `deathcats4/codex/smashup-pod-target-fixes-upstream`

--- a/public/locales/en/game-smashup.json
+++ b/public/locales/en/game-smashup.json
@@ -1209,6 +1209,45 @@
       "name": "Wizard Academy",
       "abilityText": "After this base scores, the winner looks at the top three cards of the base deck. They may choose one of those bases to replace this one, then place the other two on top of the base deck in any order."
     },
+    "base_central_brain_pod": {
+      "name": "The Central Brain",
+      "abilityText": "Each minion here has +1 power."
+    },
+    "base_the_factory_pod": {
+      "name": "Factory 436-1337",
+      "abilityText": "When this base scores, the winner gains 1 VP for every 5 power they have here."
+    },
+    "base_ninja_dojo_pod": {
+      "name": "Ninja Dojo"
+    },
+    "base_temple_of_goju_pod": {
+      "name": "Temple of Goju",
+      "abilityText": "After each time a minion is destroyed here, place it on the bottom of its owner's deck."
+    },
+    "base_cave_of_shinies_pod": {
+      "name": "Cave of Shinies",
+      "abilityText": "Once per turn, after a minion here you own is destroyed, gain 1 VP."
+    },
+    "base_mushroom_kingdom_pod": {
+      "name": "Mushroom Kingdom",
+      "abilityText": "At the start of your turn, if you have more cards in your hand than any other player, you may move a minion to or from this base."
+    },
+    "base_wizard_academy_pod": {
+      "name": "School of Wizardry",
+      "abilityText": "After this base scores, the winner looks at the top three cards of the base deck, chooses one to replace this base, and returns the others in any order."
+    },
+    "base_great_library_pod": {
+      "name": "The Great Library",
+      "abilityText": "After this base scores, all players with minions here may draw one card."
+    },
+    "base_haunted_house_pod": {
+      "name": "Evans City Cemetery",
+      "abilityText": "After this base scores, the winner discards their hand and draws five cards."
+    },
+    "base_rhodes_plaza_pod": {
+      "name": "Rhodes Plaza Mall",
+      "abilityText": "When this base scores, each player gains 1 VP for each minion that player has here."
+    },
     "base_dread_lookout": {
       "name": "Dread Lookout",
       "abilityText": "Actions cannot be played on this base."

--- a/public/locales/en/game-smashup.json
+++ b/public/locales/en/game-smashup.json
@@ -2278,7 +2278,7 @@
     },
     "trickster_mark_of_sleep_pod": {
       "name": "Mark of Sleep",
-      "effectText": "Choose one for each other player: until the start of your turn, either they cannot play actions OR they cannot move minions."
+      "effectText": "For each other player, choose one: until the start of your turn, that player either cannot play actions or cannot move minions."
     },
     "trickster_flame_trap_pod": {
       "name": "Flame Trap",

--- a/public/locales/en/lobby.json
+++ b/public/locales/en/lobby.json
@@ -58,6 +58,7 @@
     "return": "Return to match (#{{id}})"
   },
   "rooms": {
+    "loading": "Loading rooms...",
     "empty": "No active rooms",
     "matchTitle": "Match #{{id}}",
     "mine": "Mine",

--- a/public/locales/zh-CN/game-smashup.json
+++ b/public/locales/zh-CN/game-smashup.json
@@ -1209,6 +1209,45 @@
       "name": "巫师学院",
       "abilityText": "在这个基地计分后，冠军查看基地牌库顶的3张牌。选择一张替换这个基地，然后以任意顺序将其余的放回。"
     },
+    "base_central_brain_pod": {
+      "name": "中央大脑",
+      "abilityText": "这里的每个随从都获得+1力量。"
+    },
+    "base_the_factory_pod": {
+      "name": "436-1337工厂",
+      "abilityText": "当该基地计分时，冠军在此每有5点力量便获得1VP。"
+    },
+    "base_ninja_dojo_pod": {
+      "name": "忍者道场"
+    },
+    "base_temple_of_goju_pod": {
+      "name": "刚柔流寺庙",
+      "abilityText": "每当有随从在这里被消灭后，将其置于其拥有者牌库底。"
+    },
+    "base_cave_of_shinies_pod": {
+      "name": "闪光洞穴",
+      "abilityText": "每回合一次：当一张你拥有的、在这里的随从被消灭后，获得1VP。"
+    },
+    "base_mushroom_kingdom_pod": {
+      "name": "蘑菇王国",
+      "abilityText": "在你的回合开始时，若你手牌数严格多于任意其他玩家，你可以将一个随从移入或移出该基地。"
+    },
+    "base_wizard_academy_pod": {
+      "name": "巫术学院",
+      "abilityText": "当该基地计分后，冠军查看基地牌库顶三张，选择一张替换该基地，其余按任意顺序放回。"
+    },
+    "base_great_library_pod": {
+      "name": "大图书馆",
+      "abilityText": "当该基地计分后，所有在此有随从的玩家各摸1张牌。"
+    },
+    "base_haunted_house_pod": {
+      "name": "伊万斯城公墓",
+      "abilityText": "当该基地计分后，冠军弃掉其手牌并摸五张牌。"
+    },
+    "base_rhodes_plaza_pod": {
+      "name": "罗德百货商场",
+      "abilityText": "当该基地计分时，每位玩家在此每有一个随从便获得1VP。"
+    },
     "base_dread_lookout": {
       "name": "恐怖眺望台",
       "abilityText": "玩家不能打出战术到这个基地上。"
@@ -2562,6 +2601,115 @@
     "base_the_workshop_pod": {
       "name": "工坊",
       "abilityText": "(20, VP 4-2-1) 每当有一名玩家将战术打出到该基地时，该玩家可以额外打出一个战术。"
+    }
+    ,
+    "base_the_homeworld_pod": {
+      "name": "家园"
+    },
+    "base_the_mothership_pod": {
+      "name": "母舰"
+    },
+    "base_the_jungle_pod": {
+      "name": "绿洲丛林"
+    },
+    "base_tar_pits_pod": {
+      "name": "焦油坑"
+    },
+    "base_pirate_cove_pod": {
+      "name": "灰色猫眼石"
+    },
+    "base_dread_lookout_pod": {
+      "name": "恐怖眺望台"
+    },
+    "base_haunted_house_al9000_pod": {
+      "name": "鬼屋"
+    },
+    "base_the_field_of_honor_pod": {
+      "name": "荣誉之地"
+    },
+    "base_tsars_palace_pod": {
+      "name": "沙皇宫殿"
+    },
+    "base_greenhouse_pod": {
+      "name": "温室"
+    },
+    "base_secret_garden_pod": {
+      "name": "神秘花园"
+    },
+    "base_cat_fanciers_alley_pod": {
+      "name": "诡猫巷"
+    },
+    "base_house_of_nine_lives_pod": {
+      "name": "九命之家"
+    },
+    "base_enchanted_glade_pod": {
+      "name": "迷人峡谷"
+    },
+    "base_fairy_ring_pod": {
+      "name": "仙灵圈"
+    },
+    "base_beautiful_castle_pod": {
+      "name": "美丽城堡"
+    },
+    "base_castle_of_ice_pod": {
+      "name": "冰之城堡"
+    },
+    "base_land_of_balance_pod": {
+      "name": "平衡之地"
+    },
+    "base_pony_paradise_pod": {
+      "name": "小马乐园"
+    },
+    "base_north_pole_pod": {
+      "name": "北极基地"
+    },
+    "base_antarctic_base_pod": {
+      "name": "南极基地"
+    },
+    "base_ritual_site_pod": {
+      "name": "仪式场所"
+    },
+    "base_rlyeh_pod": {
+      "name": "拉莱耶"
+    },
+    "base_innsmouth_base_pod": {
+      "name": "印斯茅斯"
+    },
+    "base_mountains_of_madness_pod": {
+      "name": "疯狂山脉"
+    },
+    "base_plateau_of_leng_pod": {
+      "name": "伦格高原"
+    },
+    "base_the_pasture_pod": {
+      "name": "牧场"
+    },
+    "base_sheep_shrine_pod": {
+      "name": "绵羊神社"
+    },
+    "base_castle_blood_pod": {
+      "name": "血堡"
+    },
+    "base_crypt_pod": {
+      "name": "地窖"
+    },
+    "base_laboratorium_pod": {
+      "name": "实验工坊"
+    },
+    "base_golem_schloss_pod": {
+      "name": "魔像城堡"
+    },
+    "base_moot_site_pod": {
+      "name": "集会场"
+    },
+    "base_standing_stones_pod": {
+      "name": "巨石阵"
+    },
+    "base_egg_chamber_pod": {
+      "name": "卵室"
+    },
+    "base_the_hill_pod": {
+      "name": "蚁丘"
     }
   },
   "endgame": {

--- a/public/locales/zh-CN/lobby.json
+++ b/public/locales/zh-CN/lobby.json
@@ -58,6 +58,7 @@
     "return": "返回当前对局 (#{{id}})"
   },
   "rooms": {
+    "loading": "正在加载房间...",
     "empty": "暂无活跃房间",
     "matchTitle": "对局 #{{id}}",
     "mine": "我的",

--- a/src/components/lobby/GameDetailsModal.tsx
+++ b/src/components/lobby/GameDetailsModal.tsx
@@ -65,6 +65,7 @@ export const GameDetailsModal = ({ isOpen, onClose, gameId, titleKey, descriptio
     // 房间列表状态
     const [rooms, setRooms] = useState<Room[]>([]);
     const [isLoading, setIsLoading] = useState(false);
+    const [isLobbyLoading, setIsLobbyLoading] = useState(false);
     const [localStorageTick, setLocalStorageTick] = useState(0);
     const [pendingAction, setPendingAction] = useState<PendingRoomAction | null>(null);
     const [isConfirmingAction, setIsConfirmingAction] = useState(false);
@@ -138,59 +139,67 @@ export const GameDetailsModal = ({ isOpen, onClose, gameId, titleKey, descriptio
 
     // 使用 socket 订阅房间列表更新（替代轮询）
     useEffect(() => {
-        if (isOpen) {
-            let storageTimeout: NodeJS.Timeout;
-            const handleStorage = () => {
-                clearTimeout(storageTimeout);
-                storageTimeout = setTimeout(() => {
-                    setLocalStorageTick(t => t + 1);
-                }, 150);
-            };
-            window.addEventListener('storage', handleStorage);
-            const handleOwnerActive = () => handleStorage();
-            window.addEventListener('owner-active-match-changed', handleOwnerActive);
-            window.addEventListener('match-credentials-changed', handleStorage);
-
-            // 订阅大厅更新（仅当前游戏）
-            const unsubscribeMatches = lobbySocket.subscribe(normalizedGameId, (matches: LobbyMatch[]) => {
-                // 转换为房间格式
-                const roomList: Room[] = matches.map(m => ({
-                    matchID: m.matchID,
-                    players: m.players,
-                    totalSeats: m.totalSeats,
-                    gameName: m.gameName,
-                    roomName: m.roomName,
-                    ownerKey: m.ownerKey,
-                    ownerType: m.ownerType,
-                    isLocked: m.isLocked,
-                }));
-                setRooms(roomList);
-            });
-
-            // 订阅连接状态
-            const unsubscribeStatus = lobbySocket.subscribeStatus((status) => {
-                if (status.lastError) {
-                    // 将后端连接问题提示给用户
-                    toast.error(
-                        { kind: 'i18n', key: 'error.serviceUnavailable.desc', ns: 'lobby' },
-                        { kind: 'i18n', key: 'error.serviceUnavailable.title', ns: 'lobby' },
-                        { dedupeKey: 'lobbySocket.connectError' }
-                    );
-                }
-            });
-
-            // subscribe() 已自动向服务端发送订阅请求并获取快照，无需额外 requestRefresh
-
-            return () => {
-                clearTimeout(storageTimeout);
-                window.removeEventListener('storage', handleStorage);
-                window.removeEventListener('owner-active-match-changed', handleOwnerActive);
-                window.removeEventListener('match-credentials-changed', handleStorage);
-                unsubscribeMatches();
-                unsubscribeStatus();
-            };
+        if (!isOpen) {
+            setIsLobbyLoading(false);
+            return;
         }
-    }, [isOpen, normalizedGameId]);
+
+        let storageTimeout: NodeJS.Timeout;
+        const handleStorage = () => {
+            clearTimeout(storageTimeout);
+            storageTimeout = setTimeout(() => {
+                setLocalStorageTick(t => t + 1);
+            }, 150);
+        };
+
+        setRooms([]);
+        setIsLobbyLoading(true);
+        window.addEventListener('storage', handleStorage);
+        const handleOwnerActive = () => handleStorage();
+        window.addEventListener('owner-active-match-changed', handleOwnerActive);
+        window.addEventListener('match-credentials-changed', handleStorage);
+
+        // 订阅大厅更新（仅当前游戏）
+        const unsubscribeMatches = lobbySocket.subscribe(normalizedGameId, (matches: LobbyMatch[]) => {
+            // 转换为房间格式
+            const roomList: Room[] = matches.map(m => ({
+                matchID: m.matchID,
+                players: m.players,
+                totalSeats: m.totalSeats,
+                gameName: m.gameName,
+                roomName: m.roomName,
+                ownerKey: m.ownerKey,
+                ownerType: m.ownerType,
+                isLocked: m.isLocked,
+            }));
+            setRooms(roomList);
+            setIsLobbyLoading(false);
+        });
+
+        // 订阅连接状态
+        const unsubscribeStatus = lobbySocket.subscribeStatus((status) => {
+            if (status.lastError) {
+                // 将后端连接问题提示给用户
+                toast.error(
+                    { kind: 'i18n', key: 'error.serviceUnavailable.desc', ns: 'lobby' },
+                    { kind: 'i18n', key: 'error.serviceUnavailable.title', ns: 'lobby' },
+                    { dedupeKey: 'lobbySocket.connectError' }
+                );
+            }
+        });
+
+        // subscribe() 已自动向服务端发送订阅请求并获取快照，无需额外 requestRefresh
+
+        return () => {
+            clearTimeout(storageTimeout);
+            setIsLobbyLoading(false);
+            window.removeEventListener('storage', handleStorage);
+            window.removeEventListener('owner-active-match-changed', handleOwnerActive);
+            window.removeEventListener('match-credentials-changed', handleStorage);
+            unsubscribeMatches();
+            unsubscribeStatus();
+        };
+    }, [isOpen, normalizedGameId, toast]);
 
     // 检测用户当前活跃的房间（本地存有凭证的任意房间，可能跨游戏）
     const myActiveRoomMatchID = useMemo(() => {
@@ -1029,7 +1038,8 @@ export const GameDetailsModal = ({ isOpen, onClose, gameId, titleKey, descriptio
                             <RoomList
                                 roomItems={roomItems}
                                 activeMatch={activeMatch}
-                                isLoading={isLoading}
+                                isActionLoading={isLoading}
+                                isLobbyLoading={isLobbyLoading}
                                 onJoinRoom={handleJoinRoom}
                                 onJoinRequest={handleJoinRequest}
                                 onAction={handleAction}

--- a/src/components/lobby/RoomList.tsx
+++ b/src/components/lobby/RoomList.tsx
@@ -5,7 +5,8 @@ import type { RoomItem, ActiveMatchInfo } from './roomActions';
 interface RoomListProps {
     roomItems: RoomItem[];
     activeMatch: ActiveMatchInfo | null;
-    isLoading: boolean;
+    isActionLoading: boolean;
+    isLobbyLoading: boolean;
     onJoinRoom: (matchID: string, gameName?: string) => void;
     onJoinRequest: (matchID: string, gameName?: string) => void;
     onAction: (matchID: string, playerID: string, credentials: string, isHost: boolean) => void;
@@ -17,7 +18,8 @@ interface RoomListProps {
 export const RoomList = ({
     roomItems,
     activeMatch,
-    isLoading,
+    isActionLoading,
+    isLobbyLoading,
     onJoinRoom,
     onJoinRequest,
     onAction,
@@ -78,10 +80,10 @@ export const RoomList = ({
                     return (
                         <button
                             onClick={onOpenCreateRoom}
-                            disabled={isLoading}
+                            disabled={isActionLoading}
                             className="w-full py-3 bg-parchment-base-text hover:bg-parchment-brown text-parchment-card-bg font-bold rounded-[4px] shadow-md hover:shadow-lg active:scale-[0.98] transition-all flex items-center justify-center gap-2 disabled:opacity-50 cursor-pointer text-sm uppercase tracking-widest"
                         >
-                            {isLoading ? t('button.processing') : t('actions.createRoom')}
+                            {isActionLoading ? t('button.processing') : t('actions.createRoom')}
                         </button>
                     );
                 })()}
@@ -89,7 +91,18 @@ export const RoomList = ({
 
             {/* 房间列表 */}
             <div className="flex-1 overflow-y-auto space-y-2 pr-2 custom-scrollbar">
-                {roomItems.length === 0 ? (
+                {isLobbyLoading ? (
+                    <div
+                        role="status"
+                        aria-live="polite"
+                        className="flex h-40 flex-col items-center justify-center gap-3 rounded-[6px] border border-dashed border-parchment-card-border/30 bg-parchment-base-bg/35"
+                    >
+                        <div className="h-8 w-8 animate-spin rounded-full border-2 border-parchment-brown/20 border-t-parchment-brown" />
+                        <p className="text-xs italic tracking-wider text-parchment-light-text">
+                            {t('rooms.loading')}
+                        </p>
+                    </div>
+                ) : roomItems.length === 0 ? (
                     <div className="text-center text-parchment-light-text py-10 italic text-sm border border-dashed border-parchment-card-border/30 rounded-[4px]">
                         {t('rooms.empty')}
                     </div>

--- a/src/components/lobby/__tests__/GameDetailsModalJoinConfirm.test.ts
+++ b/src/components/lobby/__tests__/GameDetailsModalJoinConfirm.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest';
+/* @vitest-environment happy-dom */
+import { createElement } from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveActiveMatchExitPayload, shouldPromptExitActiveMatch } from '../roomActions';
+import { RoomList } from '../RoomList';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => key,
+    }),
+}));
 
 const buildStored = (override: Partial<{ matchID: string; playerID: string; credentials: string; gameName: string }> = {}) => ({
     matchID: 'match-1',
@@ -7,6 +17,10 @@ const buildStored = (override: Partial<{ matchID: string; playerID: string; cred
     credentials: 'creds',
     gameName: 'tictactoe',
     ...override,
+});
+
+afterEach(() => {
+    cleanup();
 });
 
 describe('GameDetailsModal join confirm helpers', () => {
@@ -43,5 +57,34 @@ describe('GameDetailsModal join confirm helpers', () => {
             'dicethrone'
         );
         expect(result?.gameName).toBe('summonerwars');
+    });
+});
+
+describe('RoomList lobby loading state', () => {
+    const baseProps = {
+        roomItems: [],
+        activeMatch: null,
+        isActionLoading: false,
+        isLobbyLoading: false,
+        onJoinRoom: vi.fn(),
+        onJoinRequest: vi.fn(),
+        onAction: vi.fn(),
+        onForceExitLocal: vi.fn(),
+        onOpenCreateRoom: vi.fn(),
+        onSpectate: vi.fn(),
+    };
+
+    it('首帧加载期间显示加载态而不是空状态', () => {
+        render(createElement(RoomList, { ...baseProps, isLobbyLoading: true }));
+
+        expect(screen.getByText('rooms.loading')).toBeInTheDocument();
+        expect(screen.queryByText('rooms.empty')).toBeNull();
+    });
+
+    it('加载完成后空列表显示暂无房间', () => {
+        render(createElement(RoomList, baseProps));
+
+        expect(screen.getByText('rooms.empty')).toBeInTheDocument();
+        expect(screen.queryByText('rooms.loading')).toBeNull();
     });
 });

--- a/src/games/dicethrone/__tests__/BonusDieOverlay.test.tsx
+++ b/src/games/dicethrone/__tests__/BonusDieOverlay.test.tsx
@@ -709,6 +709,24 @@ describe('BonusDieOverlay', () => {
         expect(onClose).toHaveBeenCalledTimes(1);
     });
 
+    it('展示态特写默认支持点空白关闭', () => {
+        const onClose = vi.fn();
+        render(
+            <SpotlightContainer
+                id="bonus-die-backdrop-close"
+                isVisible
+                onClose={onClose}
+                autoCloseDelay={10000}
+                closeClickGuardMs={0}
+            >
+                <button type="button">内容</button>
+            </SpotlightContainer>
+        );
+
+        fireEvent.click(document.querySelector('.fixed.inset-0') as Element);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
     it('闈炰氦浜掔壒鍐欓粯璁や笉搴旀嫤鎴暣灞忕偣鍑?', () => {
         const html = renderToStaticMarkup(
             <SpotlightContainer
@@ -720,7 +738,7 @@ describe('BonusDieOverlay', () => {
             </SpotlightContainer>
         );
 
-        expect(html).toContain('pointer-events-none');
+        expect(html).toContain('pointer-events-auto');
     });
 
     it('闈炰氦浜掔壒鍐欓粯璁ゆ敮鎸佺偣鍐呭鍏抽棴', async () => {

--- a/src/games/dicethrone/ui/SpotlightContainer.tsx
+++ b/src/games/dicethrone/ui/SpotlightContainer.tsx
@@ -71,6 +71,7 @@ export const SpotlightContainer: React.FC<SpotlightContainerProps> = ({
     closeClickGuardMs = 180,
 }) => {
     const visibleSinceRef = React.useRef<number>(0);
+    const shouldCaptureBackdropClick = !disableBackdropClose;
 
     React.useEffect(() => {
         if (isVisible) {
@@ -121,13 +122,13 @@ export const SpotlightContainer: React.FC<SpotlightContainerProps> = ({
         <AnimatePresence mode="wait">
             <motion.div
                 key={id}
-                className={`fixed inset-0 flex items-center justify-center ${blockPointerEvents ? 'pointer-events-auto' : 'pointer-events-none'}`}
+                className={`fixed inset-0 flex items-center justify-center ${(blockPointerEvents || shouldCaptureBackdropClick) ? 'pointer-events-auto' : 'pointer-events-none'}`}
                 style={{ zIndex }}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.3 }}
-                onClick={(!blockPointerEvents || disableBackdropClose)
+                onClick={!shouldCaptureBackdropClick
                     ? undefined
                     : () => {
                         const guardActive = isCloseClickGuardActive();

--- a/src/games/smashup/__tests__/afterscoring-response-window-execution.test.ts
+++ b/src/games/smashup/__tests__/afterscoring-response-window-execution.test.ts
@@ -33,13 +33,25 @@ describe('afterScoring 响应窗口中打出卡牌的执行', () => {
                     minions: [
                         {
                             uid: 'm1',
-                            defId: 'alien_invader',
+                            defId: 'innsmouth_the_locals',
                             owner: '0',
                             controller: '0',
-                            basePower: 3,
+                            basePower: 2,
                             powerModifier: 0,
                             tempPowerModifier: 0,
-                            powerCounters: 20,  // 总力量 23 > 20
+                            powerCounters: 10,
+                            attachedActions: [],
+                            talentUsed: false,
+                        },
+                        {
+                            uid: 'm2',
+                            defId: 'innsmouth_the_locals',
+                            owner: '0',
+                            controller: '0',
+                            basePower: 2,
+                            powerModifier: 0,
+                            tempPowerModifier: 0,
+                            powerCounters: 10,
                             attachedActions: [],
                             talentUsed: false,
                         },
@@ -88,11 +100,11 @@ describe('afterScoring 响应窗口中打出卡牌的执行', () => {
         const armedEvent = events.find(e => e.type === SU_EVENT_TYPES.SPECIAL_AFTER_SCORING_ARMED);
         expect(armedEvent).toBeUndefined();
 
-        // 验证：应该生成 ABILITY_FEEDBACK（没有同名随从可以返回）
-        // 注意：innsmouthReturnToTheSea 在没有同名随从时返回空事件，不生成 ABILITY_FEEDBACK
-        // 这是正确的行为，因为能力本身没有前置条件检查
-        const hasFeedback = events.some(e => e.type === SU_EVENT_TYPES.ABILITY_FEEDBACK);
-        expect(hasFeedback).toBe(false); // 修正：应该是 false
+        // 验证：应该立即创建交互，而不是静默无效果
+        const interactionState = (result.finalState?.sys as any)?.interaction;
+        const interaction = interactionState?.current ?? interactionState?.queue?.[0];
+        expect(interaction?.data?.sourceId).toBe('innsmouth_return_to_the_sea');
+        expect(interaction?.data?.options?.some((entry: any) => entry.value?.minionDefId === 'innsmouth_the_locals')).toBe(true);
     });
 
     it('在 afterScoring 响应窗口中打出"我们乃最强"应该立即执行能力', () => {

--- a/src/games/smashup/__tests__/baseAbilitiesPrompt.test.ts
+++ b/src/games/smashup/__tests__/baseAbilitiesPrompt.test.ts
@@ -127,6 +127,43 @@ describe('base_the_homeworld: 随从入场额外随从额度', () => {
         expect(payload.limitType).toBe('minion');
         expect(payload.delta).toBe(1);
     });
+
+    it('每回合只触发一次：当回合第二次及之后不再给额外额度', () => {
+        const { events } = triggerBaseAbility('base_the_homeworld', 'onMinionPlayed', makeCtx({
+            state: makeState({
+                players: {
+                    '0': makePlayer('0', { minionsPlayedPerBase: { 0: 2 } }),
+                    '1': makePlayer('1'),
+                },
+                bases: [makeBase('base_the_homeworld')],
+            }),
+            baseDefId: 'base_the_homeworld',
+            minionUid: 'm1',
+            minionDefId: 'alien_collector',
+            minionPower: 2,
+        }));
+
+        expect(events).toHaveLength(0);
+    });
+
+    it('POD 版本母星应复用同一能力', () => {
+        const { events } = triggerBaseAbility('base_the_homeworld_pod', 'onMinionPlayed', makeCtx({
+            state: makeState({
+                players: {
+                    '0': makePlayer('0', { minionsPlayedPerBase: { 0: 1 } }),
+                    '1': makePlayer('1'),
+                },
+                bases: [makeBase('base_the_homeworld_pod')],
+            }),
+            baseDefId: 'base_the_homeworld_pod',
+            minionUid: 'm1',
+            minionDefId: 'alien_collector_pod',
+            minionPower: 2,
+        }));
+
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe(SU_EVENTS.LIMIT_MODIFIED);
+    });
 });
 
 // ============================================================================
@@ -184,6 +221,22 @@ describe('base_the_mothership: 计分后冠军收回随从', () => {
         }));
 
         expect(events).toHaveLength(0);
+    });
+
+    it('POD 版本母舰也应生成收回交互', () => {
+        const result = triggerBaseAbilityWithMS('base_the_mothership_pod', 'afterScoring', makeCtx({
+            state: makeState({
+                bases: [makeBase('base_the_mothership_pod', {
+                    minions: [makeMinion('m1', '0', 2)],
+                })],
+            }),
+            baseDefId: 'base_the_mothership_pod',
+            rankings: [{ playerId: '0', power: 2, vp: 4 }],
+        }));
+
+        const interactions = getInteractionsFromResult(result);
+        expect(interactions).toHaveLength(1);
+        expect(interactions[0].playerId).toBe('0');
     });
 });
 

--- a/src/games/smashup/__tests__/baseAbilityIntegration.test.ts
+++ b/src/games/smashup/__tests__/baseAbilityIntegration.test.ts
@@ -19,14 +19,24 @@ import type { SmashUpCore, SmashUpCommand, SmashUpEvent } from '../domain/types'
 import { SU_COMMANDS, SU_EVENTS, getCurrentPlayerId } from '../domain/types';
 import { initAllAbilities } from '../abilities';
 import { SMASHUP_FACTION_IDS } from '../domain/ids';
+import { getInteractionHandler } from '../domain/abilityInteractionHandlers';
 import {
     triggerBaseAbility,
     triggerExtendedBaseAbility,
 } from '../domain/baseAbilities';
 import type { BaseAbilityContext } from '../domain/baseAbilities';
 import { getEffectivePower } from '../domain/ongoingModifiers';
+import { triggerBaseAbilityWithMS, getInteractionsFromResult, makeMatchState } from './helpers';
+import { reduce } from '../domain/reduce';
+import type { RandomFn } from '../../../engine/types';
 
 const PLAYER_IDS = ['0', '1'];
+const dummyRandom: RandomFn = {
+    shuffle: (arr: any[]) => [...arr],
+    random: () => 0.5,
+    d: (_max: number) => 1,
+    range: (_min: number, _max: number) => _min,
+};
 
 beforeAll(() => {
     initAllAbilities();
@@ -615,5 +625,358 @@ describe('base_the_homeworld: 母星 E2E Pipeline 额外出牌', () => {
         expect(result.steps[1]?.error).toBe('本回合随从额度已用完');
         // minionLimit 未增加
         expect(result.finalState.core.players['0'].minionLimit).toBe(1);
+    });
+
+    it('每回合一次：同回合第三次随从打出应失败', () => {
+        const core: SmashUpCore = {
+            players: {
+                '0': {
+                    id: '0', vp: 0,
+                    hand: [
+                        { uid: 'c1', defId: 'alien_invader', type: 'minion', owner: '0' },
+                        { uid: 'c2', defId: 'alien_collector', type: 'minion', owner: '0' },
+                        { uid: 'c3', defId: 'dino_armor_stego', type: 'minion', owner: '0' },
+                    ],
+                    deck: [], discard: [],
+                    minionsPlayed: 0, minionLimit: 1,
+                    actionsPlayed: 0, actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.ALIENS, SMASHUP_FACTION_IDS.DINOSAURS] as [string, string],
+                },
+                '1': {
+                    id: '1', vp: 0,
+                    hand: [], deck: [], discard: [],
+                    minionsPlayed: 0, minionLimit: 1,
+                    actionsPlayed: 0, actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.PIRATES, SMASHUP_FACTION_IDS.NINJAS] as [string, string],
+                },
+            },
+            turnOrder: ['0', '1'],
+            currentPlayerIndex: 0,
+            bases: [
+                { defId: 'base_the_homeworld', minions: [], ongoingActions: [] },
+                { defId: 'base_the_jungle', minions: [], ongoingActions: [] },
+                { defId: 'base_tar_pits', minions: [], ongoingActions: [] },
+            ],
+            baseDeck: [],
+            turnNumber: 1,
+            nextUid: 100,
+        } as SmashUpCore;
+
+        const runner = createCustomRunner(makeFullMatchState(core));
+        const result = runner.run({
+            name: '母星每回合一次额外随从',
+            commands: [
+                { type: SU_COMMANDS.PLAY_MINION, playerId: '0', payload: { cardUid: 'c1', baseIndex: 0 } },
+                { type: SU_COMMANDS.PLAY_MINION, playerId: '0', payload: { cardUid: 'c2', baseIndex: 0 } },
+                { type: SU_COMMANDS.PLAY_MINION, playerId: '0', payload: { cardUid: 'c3', baseIndex: 0 } },
+            ],
+            expect: {
+                expectError: { command: SU_COMMANDS.PLAY_MINION, error: '鏈洖鍚堥殢浠庨搴﹀凡鐢ㄥ畬' },
+            },
+        });
+
+        expect(result.steps[0]?.success).toBe(true);
+        expect(result.steps[1]?.success).toBe(true);
+        expect(result.steps[2]?.success).toBe(false);
+    });
+
+    it('POD 母星走完整 Pipeline 时也应授予一次额外随从额度', () => {
+        const core: SmashUpCore = {
+            players: {
+                '0': {
+                    id: '0', vp: 0,
+                    hand: [
+                        { uid: 'c1', defId: 'alien_invader_pod', type: 'minion', owner: '0' },
+                        { uid: 'c2', defId: 'alien_collector_pod', type: 'minion', owner: '0' },
+                    ],
+                    deck: [], discard: [],
+                    minionsPlayed: 0, minionLimit: 1,
+                    actionsPlayed: 0, actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.ALIENS_POD, SMASHUP_FACTION_IDS.DINOSAURS_POD] as [string, string],
+                },
+                '1': {
+                    id: '1', vp: 0,
+                    hand: [], deck: [], discard: [],
+                    minionsPlayed: 0, minionLimit: 1,
+                    actionsPlayed: 0, actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.PIRATES, SMASHUP_FACTION_IDS.NINJAS] as [string, string],
+                },
+            },
+            turnOrder: ['0', '1'],
+            currentPlayerIndex: 0,
+            bases: [
+                { defId: 'base_the_homeworld_pod', minions: [], ongoingActions: [] },
+                { defId: 'base_the_jungle_pod', minions: [], ongoingActions: [] },
+                { defId: 'base_tar_pits_pod', minions: [], ongoingActions: [] },
+            ],
+            baseDeck: [],
+            turnNumber: 1,
+            nextUid: 100,
+        } as SmashUpCore;
+
+        const runner = createCustomRunner(makeFullMatchState(core));
+        const result = runner.run({
+            name: 'POD 母星额外出牌',
+            commands: [
+                { type: SU_COMMANDS.PLAY_MINION, playerId: '0', payload: { cardUid: 'c1', baseIndex: 0 } },
+                { type: SU_COMMANDS.PLAY_MINION, playerId: '0', payload: { cardUid: 'c2', baseIndex: 0 } },
+            ],
+        });
+
+        expect(result.steps[0]?.success).toBe(true);
+        expect(result.steps[1]?.success).toBe(true);
+        expect(result.finalState.core.bases[0].minions.length).toBe(2);
+    });
+});
+
+describe('base_cave_of_shinies_pod: 每回合一次触发门槛', () => {
+    it('本回合首次在该基地有己方随从被消灭时，获得 1VP', () => {
+        const ctx: BaseAbilityContext = {
+            state: {
+                bases: [{
+                    defId: 'base_cave_of_shinies_pod',
+                    minions: [],
+                    ongoingActions: [],
+                }],
+                players: {},
+                turnOrder: ['0', '1'],
+                currentPlayerIndex: 0,
+                baseDeck: [],
+                turnNumber: 1,
+                nextUid: 100,
+                turnDestroyedMinions: [],
+            } as SmashUpCore,
+            baseIndex: 0,
+            baseDefId: 'base_cave_of_shinies_pod',
+            playerId: '0',
+            now: 2000,
+        };
+
+        const { events } = triggerExtendedBaseAbility('base_cave_of_shinies_pod', 'onMinionDestroyed', ctx);
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe(SU_EVENTS.VP_AWARDED);
+        expect((events[0] as any).payload.playerId).toBe('0');
+        expect((events[0] as any).payload.amount).toBe(1);
+    });
+
+    it('本回合该基地已有消灭记录时，不再重复给 VP', () => {
+        const ctx: BaseAbilityContext = {
+            state: {
+                bases: [{
+                    defId: 'base_cave_of_shinies_pod',
+                    minions: [],
+                    ongoingActions: [],
+                }],
+                players: {},
+                turnOrder: ['0', '1'],
+                currentPlayerIndex: 0,
+                baseDeck: [],
+                turnNumber: 1,
+                nextUid: 100,
+                turnDestroyedMinions: [{ uid: 'm_prev', defId: 'd_prev', baseIndex: 0, owner: '0' }],
+            } as SmashUpCore,
+            baseIndex: 0,
+            baseDefId: 'base_cave_of_shinies_pod',
+            playerId: '0',
+            now: 2001,
+        };
+
+        const { events } = triggerExtendedBaseAbility('base_cave_of_shinies_pod', 'onMinionDestroyed', ctx);
+        expect(events).toHaveLength(0);
+    });
+});
+
+describe('POD 基地专项行为', () => {
+    const makeMinion = (uid: string, controller: string, power = 3, defId = 'd1') => ({
+        uid,
+        defId,
+        controller,
+        owner: controller,
+        basePower: power,
+        powerCounters: 0,
+        powerModifier: 0,
+        tempPowerModifier: 0,
+        talentUsed: false,
+        attachedActions: [],
+    });
+
+    const makeHand = (owner: string, count: number) =>
+        Array.from({ length: count }, (_, i) => ({
+            uid: `${owner}_h${i}`,
+            defId: 'd1',
+            type: 'minion' as const,
+            owner,
+        }));
+
+    it('base_ninja_dojo_pod: afterScoring 为 no-op（无 Prompt）', () => {
+        const { events } = triggerBaseAbility('base_ninja_dojo_pod', 'afterScoring', {
+            state: {
+                players: {},
+                turnOrder: ['0', '1'],
+                currentPlayerIndex: 0,
+                baseDeck: [],
+                turnNumber: 1,
+                nextUid: 100,
+                bases: [{
+                    defId: 'base_ninja_dojo_pod',
+                    minions: [makeMinion('m1', '0'), makeMinion('m2', '1')],
+                    ongoingActions: [],
+                }],
+            } as SmashUpCore,
+            baseIndex: 0,
+            baseDefId: 'base_ninja_dojo_pod',
+            playerId: '0',
+            rankings: [{ playerId: '0', power: 3, vp: 2 }],
+            now: 3000,
+        });
+        expect(events).toHaveLength(0);
+    });
+
+    it('base_temple_of_goju_pod: 同基地同回合已销毁过，也应继续置牌库底', () => {
+        const state = {
+            players: {
+                '0': { id: '0', vp: 0, hand: [], discard: [], deck: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: [] },
+            },
+            turnOrder: ['0'],
+            currentPlayerIndex: 0,
+            baseDeck: [],
+            turnNumber: 1,
+            nextUid: 100,
+            turnDestroyedMinions: [{ uid: 'm_prev', defId: 'd_prev', baseIndex: 0, owner: '0' }],
+            bases: [{
+                defId: 'base_temple_of_goju_pod',
+                minions: [makeMinion('m4', '0', 3, 'test_minion')],
+                ongoingActions: [],
+            }],
+        } as unknown as SmashUpCore;
+
+        const next = reduce(state, {
+            type: SU_EVENTS.MINION_DESTROYED,
+            payload: { minionUid: 'm4', minionDefId: 'test_minion', fromBaseIndex: 0, ownerId: '0', reason: 'test' },
+            timestamp: 3001,
+        } as any);
+
+        expect(next.players['0'].discard).toHaveLength(0);
+        expect(next.players['0'].deck.map((c: any) => c.uid)).toEqual(['m4']);
+    });
+
+    it('base_tar_pits: 同基地同回合第二次销毁应进入弃牌堆（once per turn）', () => {
+        const state = {
+            players: {
+                '0': { id: '0', vp: 0, hand: [], discard: [], deck: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: [] },
+            },
+            turnOrder: ['0'],
+            currentPlayerIndex: 0,
+            baseDeck: [],
+            turnNumber: 1,
+            nextUid: 100,
+            turnDestroyedMinions: [{ uid: 'm_prev', defId: 'd_prev', baseIndex: 0, owner: '0' }],
+            bases: [{
+                defId: 'base_tar_pits',
+                minions: [makeMinion('m5', '0', 3, 'test_minion')],
+                ongoingActions: [],
+            }],
+        } as unknown as SmashUpCore;
+        const next = reduce(state, {
+            type: SU_EVENTS.MINION_DESTROYED,
+            payload: { minionUid: 'm5', minionDefId: 'test_minion', fromBaseIndex: 0, ownerId: '0', reason: 'test' },
+            timestamp: 3002,
+        } as any);
+        expect(next.players['0'].deck).toHaveLength(0);
+        expect(next.players['0'].discard.map((c: any) => c.uid)).toEqual(['m5']);
+    });
+
+    it('base_mushroom_kingdom_pod: 手牌严格大于对手时才触发', () => {
+        const state = {
+            players: {
+                '0': { id: '0', vp: 0, hand: makeHand('0', 3), discard: [], deck: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: [] },
+                '1': { id: '1', vp: 0, hand: makeHand('1', 2), discard: [], deck: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: [] },
+            },
+            turnOrder: ['0', '1'],
+            currentPlayerIndex: 0,
+            baseDeck: [],
+            turnNumber: 1,
+            nextUid: 100,
+            bases: [
+                { defId: 'base_mushroom_kingdom_pod', minions: [], ongoingActions: [] },
+                { defId: 'base_other', minions: [makeMinion('m1', '1')], ongoingActions: [] },
+            ],
+        } as unknown as SmashUpCore;
+
+        const yes = triggerBaseAbilityWithMS('base_mushroom_kingdom_pod', 'onTurnStart', {
+            state,
+            baseIndex: 0,
+            baseDefId: 'base_mushroom_kingdom_pod',
+            playerId: '0',
+            now: 3002,
+        });
+        expect(getInteractionsFromResult(yes)).toHaveLength(1);
+
+        const no = triggerBaseAbility('base_mushroom_kingdom_pod', 'onTurnStart', {
+            state: {
+                ...state,
+                players: {
+                    ...state.players,
+                    '0': { ...state.players['0'], hand: makeHand('0', 2) },
+                },
+            } as SmashUpCore,
+            baseIndex: 0,
+            baseDefId: 'base_mushroom_kingdom_pod',
+            playerId: '0',
+            now: 3003,
+        });
+        expect(no.events).toHaveLength(0);
+    });
+
+    it('base_mushroom_kingdom_pod: 选中本基地随从时，应进入二段选基地并移出', () => {
+        const state = {
+            players: {
+                '0': { id: '0', vp: 0, hand: makeHand('0', 3), discard: [], deck: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: [] },
+                '1': { id: '1', vp: 0, hand: makeHand('1', 1), discard: [], deck: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: [] },
+            },
+            turnOrder: ['0', '1'],
+            currentPlayerIndex: 0,
+            baseDeck: [],
+            turnNumber: 1,
+            nextUid: 100,
+            bases: [
+                { defId: 'base_mushroom_kingdom_pod', minions: [makeMinion('m1', '0')], ongoingActions: [] },
+                { defId: 'base_other_1', minions: [], ongoingActions: [] },
+                { defId: 'base_other_2', minions: [], ongoingActions: [] },
+            ],
+        } as unknown as SmashUpCore;
+
+        const result = triggerBaseAbilityWithMS('base_mushroom_kingdom_pod', 'onTurnStart', {
+            state,
+            matchState: makeMatchState(state),
+            baseIndex: 0,
+            baseDefId: 'base_mushroom_kingdom_pod',
+            playerId: '0',
+            now: 3004,
+        });
+        const interaction = getInteractionsFromResult(result)[0];
+        const selected = interaction.data.options.find((o: any) => o.value?.minionUid === 'm1');
+        const step1 = getInteractionHandler('base_mushroom_kingdom_pod')!(
+            result.matchState!,
+            '0',
+            selected.value,
+            interaction.data,
+            dummyRandom,
+            3005,
+        );
+        const chooseBaseInteraction = (step1.state.sys as any).interaction?.queue?.[0];
+        expect(chooseBaseInteraction?.data?.sourceId).toBe('base_mushroom_kingdom_pod_choose_base');
+
+        const step2 = getInteractionHandler('base_mushroom_kingdom_pod_choose_base')!(
+            step1.state,
+            '0',
+            { baseIndex: 1 },
+            chooseBaseInteraction.data,
+            dummyRandom,
+            3006,
+        );
+        const moveEvent = (step2.events ?? []).find((e: any) => e.type === SU_EVENTS.MINION_MOVED) as any;
+        expect(moveEvent.payload.fromBaseIndex).toBe(0);
+        expect(moveEvent.payload.toBaseIndex).toBe(1);
     });
 });

--- a/src/games/smashup/__tests__/baseAbilityIntegration.test.ts
+++ b/src/games/smashup/__tests__/baseAbilityIntegration.test.ts
@@ -125,6 +125,26 @@ describe('base_central_brain: 持续被动 +1 力量', () => {
         expect(getEffectivePower(state, m1, 0)).toBe(6); // 5 + 0 + 1
         expect(getEffectivePower(state, m2, 0)).toBe(3); // 2 + 0 + 1
     });
+
+    it('中央大脑被压制时，持续 +1 力量失效', () => {
+        const minion = {
+            uid: 'm1', defId: 'd1', controller: '0', owner: '0',
+            basePower: 3, powerCounters: 0, powerModifier: 0, tempPowerModifier: 0, talentUsed: false, attachedActions: [],
+        };
+        const state = {
+            bases: [{
+                defId: 'base_central_brain',
+                minions: [minion],
+                ongoingActions: [],
+            }],
+            suppressedBasesUntilTurnStart: [{ baseIndex: 0, suppressorPlayerId: '0' }],
+            players: { '0': { hand: [], deck: [], discard: [] } },
+            turnOrder: ['0', '1'],
+            currentPlayerIndex: 0,
+        } as any;
+
+        expect(getEffectivePower(state, minion, 0)).toBe(3);
+    });
 });
 
 // ============================================================================

--- a/src/games/smashup/__tests__/baseFactionOngoing.test.ts
+++ b/src/games/smashup/__tests__/baseFactionOngoing.test.ts
@@ -31,6 +31,7 @@ import { resolveAbility } from '../domain/abilityRegistry';
 import { reduce } from '../domain/reduce';
 import { clearInteractionHandlers, getInteractionHandler } from '../domain/abilityInteractionHandlers';
 import { getMinionDef } from '../data/cards';
+import { asSimpleChoice } from '../../../engine/systems/InteractionSystem';
 
 // ============================================================================
 // 测试辅助
@@ -1334,9 +1335,11 @@ describe('诡术师 ongoing 能力', () => {
                 ongoingActions: [{ uid: 'pp-1', defId: 'trickster_pay_the_piper', ownerId: '0' }],
             });
             const state = makeState([base]);
+            const matchState = makeMatchState(state);
 
-            const { events } = fireTriggers(state, 'onMinionPlayed', {
+            const result = fireTriggers(state, 'onMinionPlayed', {
                 state,
+                matchState,
                 playerId: '1',
                 baseIndex: 0,
                 triggerMinionUid: 'new-m',
@@ -1345,9 +1348,12 @@ describe('诡术师 ongoing 能力', () => {
                 now: 1000,
             });
 
-            expect(events).toHaveLength(1);
-            expect(events[0].type).toBe(SU_EVENTS.CARDS_DISCARDED);
-            expect((events[0] as any).payload.playerId).toBe('1');
+            expect(result.events).toHaveLength(0);
+            const choice = asSimpleChoice(result.matchState?.sys.interaction.current);
+            expect(choice).toBeDefined();
+            expect(choice?.playerId).toBe('1');
+            expect(choice?.options).toHaveLength(3);
+            expect(choice?.options.map((option: any) => option.value?.cardUid)).toEqual(['oh1', 'oh2', 'oh3']);
         });
     });
 

--- a/src/games/smashup/__tests__/bearCavalry-youre-screwed-pod-breakpoint.test.ts
+++ b/src/games/smashup/__tests__/bearCavalry-youre-screwed-pod-breakpoint.test.ts
@@ -42,5 +42,28 @@ describe('bear_cavalry_bearing_down_pod: 动态爆破点修正', () => {
 
         expect(getEffectiveBreakpoint(state, 0)).toBe(baseBreakpoint - 4);
     });
+
+    it('被压制的 bearing_down_pod 不再修改爆破点', () => {
+        const base = makeBase('base_the_jungle', [
+            makeMinion('m0', 'test_minion', '0', 3),
+            makeMinion('m1', 'test_minion', '1', 3),
+        ]);
+        base.ongoingActions = [{ uid: 'oa1', defId: 'bear_cavalry_bearing_down_pod', ownerId: '0' } as any];
+
+        const state = makeStateWithBases([base], {
+            suppressedCardsUntilTurnStart: [{
+                cardUid: 'oa1',
+                baseIndex: 0,
+                suppressorPlayerId: '0',
+                cardType: 'ongoing',
+            }],
+        } as any);
+        const baseBreakpoint = getEffectiveBreakpoint(
+            makeStateWithBases([makeBase('base_the_jungle')]),
+            0,
+        );
+
+        expect(getEffectiveBreakpoint(state, 0)).toBe(baseBreakpoint);
+    });
 });
 

--- a/src/games/smashup/__tests__/expansionOngoing.test.ts
+++ b/src/games/smashup/__tests__/expansionOngoing.test.ts
@@ -932,7 +932,7 @@ describe('印斯茅斯 ongoing 能力', () => {
             expect(executor).toBeDefined();
         });
 
-        test('交互响应会保留原基地索引，且目标失效时不再重复回手', () => {
+        test('真实行动牌触发路径会先选同名组，再返回所选随从', () => {
             const executor = resolveAbility('innsmouth_return_to_the_sea', 'special')!;
             const triggerMinion = makeMinion({
                 uid: 'inn-1',
@@ -959,25 +959,39 @@ describe('印斯茅斯 ongoing 能力', () => {
                 state,
                 matchState: ms,
                 playerId: '0',
-                cardUid: 'inn-1',
+                cardUid: 'return-action-1',
                 defId: 'innsmouth_return_to_the_sea',
                 baseIndex: 0,
                 random: dummyRandom,
                 now: 1000,
             });
 
-            const interaction = (result.matchState?.sys as any)?.interaction?.current;
-            expect(interaction?.data?.sourceId).toBe('innsmouth_return_to_the_sea');
-            const firstOption = interaction?.data?.options?.find((entry: any) => entry.value?.minionUid === 'inn-1');
-            expect(firstOption?.value?.baseIndex).toBe(0);
+            const chooseGroup = (result.matchState?.sys as any)?.interaction?.current;
+            expect(chooseGroup?.data?.sourceId).toBe('innsmouth_return_to_the_sea');
+            const firstGroup = chooseGroup?.data?.options?.find((entry: any) => entry.value?.minionDefId === 'innsmouth_the_locals');
+            expect(firstGroup?.value?.baseIndex).toBe(0);
 
             const handler = getInteractionHandler('innsmouth_return_to_the_sea');
             expect(handler).toBeDefined();
 
+            const chooseMinionResult = handler!(
+                result.matchState as any,
+                '0',
+                firstGroup.value,
+                undefined,
+                dummyRandom,
+                1001,
+            );
+            const chooseMinion = (chooseMinionResult?.state?.sys as any)?.interaction?.queue?.[0]
+                ?? (chooseMinionResult?.state?.sys as any)?.interaction?.current;
+            expect(chooseMinion?.data?.sourceId).toBe('innsmouth_return_to_the_sea');
+            const firstMinion = chooseMinion?.data?.options?.find((entry: any) => entry.value?.minionUid === 'inn-1');
+            expect(firstMinion?.value?.baseIndex).toBe(0);
+
             const liveEvents = callHandler(handler!, {
                 state,
                 playerId: '0',
-                selectedValue: [firstOption.value],
+                selectedValue: [firstMinion.value],
                 random: dummyRandom,
                 now: 1001,
             });
@@ -1000,7 +1014,7 @@ describe('印斯茅斯 ongoing 能力', () => {
             const staleEvents = callHandler(handler!, {
                 state: staleState,
                 playerId: '0',
-                selectedValue: [firstOption.value],
+                selectedValue: [firstMinion.value],
                 random: dummyRandom,
                 now: 1002,
             });

--- a/src/games/smashup/__tests__/interactionChainE2E.test.ts
+++ b/src/games/smashup/__tests__/interactionChainE2E.test.ts
@@ -520,6 +520,64 @@ describe('P0: bear_cavalry_commission（委任）4步链', () => {
         expect(fc.bases[0].minions.find(m => m.uid === 'enemy-m1')).toBeUndefined();
         expect(fc.bases[1].minions.some(m => m.uid === 'enemy-m1')).toBe(true);
     });
+
+    it('随从额度已用完时，委任打出的额外随从会消耗刚授予的额度', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [
+                        makeCard('comm-pod-1', 'bear_cavalry_commission_pod', '0', 'action'),
+                        makeCard('hand-m1', 'bear_cavalry_cub_scout', '0', 'minion'),
+                    ],
+                    minionsPlayed: 1,
+                    minionLimit: 1,
+                    factions: ['bear_cavalry', 'pirates'] as [string, string],
+                }),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                makeBase('test_base_1'),
+                makeBase('test_base_2', [
+                    makeMinion('enemy-m1', 'test_minion', '1', 3),
+                ]),
+                makeBase('test_base_3'),
+            ],
+        });
+
+        const state = makeFullMatchState(core);
+
+        const r1 = runCommand(state, {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '0',
+            payload: { cardUid: 'comm-pod-1' },
+        }, 'commission pod quota step1');
+        expect(r1.steps[0]?.success).toBe(true);
+        expect(r1.finalState.core.players['0'].minionsPlayed).toBe(1);
+        expect(r1.finalState.core.players['0'].minionLimit).toBe(2);
+
+        const chooseMinion = asSimpleChoice(r1.finalState.sys.interaction.current)!;
+        const handOpt = findOption(chooseMinion, (o: any) => o.value?.cardUid === 'hand-m1');
+        const r2 = respond(r1.finalState, '0', handOpt, 'commission pod quota step2');
+
+        const chooseBase = asSimpleChoice(r2.finalState.sys.interaction.current)!;
+        const baseOpt = findOption(chooseBase, (o: any) => o.value?.baseIndex === 1);
+        const r3 = respond(r2.finalState, '0', baseOpt, 'commission pod quota step3');
+
+        const chooseMove = asSimpleChoice(r3.finalState.sys.interaction.current)!;
+        const enemyOpt = findOption(chooseMove, (o: any) => o.value?.minionUid === 'enemy-m1');
+        const r4 = respond(r3.finalState, '0', enemyOpt, 'commission pod quota step4');
+
+        const chooseDest = asSimpleChoice(r4.finalState.sys.interaction.current)!;
+        const destOpt = findOption(chooseDest, (o: any) => o.value?.baseIndex === 0);
+        const r5 = respond(r4.finalState, '0', destOpt, 'commission pod quota step5');
+
+        expect(r5.steps[0]?.success).toBe(true);
+        expect(r5.finalState.sys.interaction.current).toBeUndefined();
+        expect(r5.finalState.core.players['0'].minionsPlayed).toBe(2);
+        expect(r5.finalState.core.players['0'].minionLimit).toBe(2);
+        expect(r5.finalState.core.bases[1].minions.some(m => m.uid === 'hand-m1')).toBe(true);
+        expect(r5.finalState.core.bases[0].minions.some(m => m.uid === 'enemy-m1')).toBe(true);
+    });
 });
 
 // ============================================================================
@@ -2497,5 +2555,50 @@ describe('stale move regression: bear cavalry interaction chains', () => {
         expect(handler).toBeDefined();
         const resolved = handler!(makeFullMatchState(staleCore), '0', { baseIndex: 1 }, (chooseBase as any).data, handlerRandom, 3003);
         expect(resolved?.events ?? []).toHaveLength(0);
+    });
+
+    it('bear_cavalry_bear_rides_you_pod_choose_base: 压制选项包含新基地上的基地牌与随从牌', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('bry-pod-1', 'bear_cavalry_bear_rides_you_pod', '0', 'action')],
+                    factions: ['bear_cavalry', 'miskatonic_university'] as [string, string],
+                }),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                makeBase('test_base_1', [makeMinion('my-m1', 'bear_cavalry_cub_scout', '0', 3)]),
+                makeBase('base_central_brain', [makeMinion('enemy-lib', 'miskatonic_librarian', '1', 4)]),
+            ],
+        });
+        const state = makeFullMatchState(core);
+
+        const r1 = runCommand(state, {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '0',
+            payload: { cardUid: 'bry-pod-1' },
+        }, 'bear_rides_you_pod step1');
+        const chooseMinion = asSimpleChoice(r1.finalState.sys.interaction.current)!;
+        const r2 = respond(r1.finalState, '0', findOption(chooseMinion, (o: any) => o.value?.minionUid === 'my-m1'), 'bear_rides_you_pod step2');
+        const chooseBase = asSimpleChoice(r2.finalState.sys.interaction.current)!;
+        const r3 = respond(r2.finalState, '0', findOption(chooseBase, (o: any) => o.value?.baseIndex === 1), 'bear_rides_you_pod step3');
+
+        expect(r3.steps[0]?.success).toBe(true);
+        const chooseSuppress = asSimpleChoice(r3.finalState.sys.interaction.current)!;
+        expect(chooseSuppress.sourceId).toBe('bear_cavalry_bear_rides_you_pod_choose_suppress');
+
+        const baseOption = chooseSuppress.options.find((o: any) => o.value?.kind === 'base');
+        expect(baseOption?.value?.baseDefId).toBe('base_central_brain');
+        expect(baseOption?.displayMode).toBe('card');
+
+        const enemyOption = chooseSuppress.options.find((o: any) => o.value?.kind === 'minion' && o.value?.minionUid === 'enemy-lib');
+        expect(enemyOption?.value?.minionDefId).toBe('miskatonic_librarian');
+        expect(enemyOption?.displayMode).toBe('card');
+
+        const movedMinionOption = chooseSuppress.options.find((o: any) => o.value?.kind === 'minion' && o.value?.minionUid === 'my-m1');
+        expect(movedMinionOption?.value?.minionDefId).toBe('bear_cavalry_cub_scout');
+
+        const skipOption = chooseSuppress.options.find((o: any) => o.value?.kind === 'skip');
+        expect(skipOption?.displayMode).toBe('button');
     });
 });

--- a/src/games/smashup/__tests__/newBaseAbilities.test.ts
+++ b/src/games/smashup/__tests__/newBaseAbilities.test.ts
@@ -202,6 +202,55 @@ describe('base_the_field_of_honor: 消灭者获1VP', () => {
         expect(vpEvents[0].payload.playerId).toBe('0');
         expect(vpEvents[0].payload.amount).toBe(1);
     });
+
+    it('base_the_field_of_honor: destroy 自己的随从时不应得分', () => {
+        const ctx: BaseAbilityContext = {
+            state: makeState({
+                bases: [{
+                    defId: 'base_the_field_of_honor',
+                    minions: [],
+                    ongoingActions: [],
+                }],
+            }),
+            baseIndex: 0,
+            baseDefId: 'base_the_field_of_honor',
+            playerId: '0',
+            controllerId: '0',
+            destroyerId: '0',
+            now: 1000,
+        };
+
+        const { events } = triggerExtendedBaseAbility('base_the_field_of_honor', 'onMinionDestroyed', ctx);
+        expect(events).toHaveLength(0);
+    });
+
+    it('base_the_field_of_honor: 同回合同基地同一 destroyer 只触发一次', () => {
+        const ctx: BaseAbilityContext = {
+            state: makeState({
+                bases: [{
+                    defId: 'base_the_field_of_honor',
+                    minions: [],
+                    ongoingActions: [],
+                }],
+                turnDestroyedMinions: [{
+                    uid: 'prev',
+                    defId: 'test_minion',
+                    baseIndex: 0,
+                    owner: '1',
+                    destroyer: '0',
+                }],
+            }),
+            baseIndex: 0,
+            baseDefId: 'base_the_field_of_honor',
+            playerId: '1',
+            controllerId: '1',
+            destroyerId: '0',
+            now: 1001,
+        };
+
+        const { events } = triggerExtendedBaseAbility('base_the_field_of_honor', 'onMinionDestroyed', ctx);
+        expect(events).toHaveLength(0);
+    });
 });
 
 // ============================================================================
@@ -374,6 +423,7 @@ describe('base_tar_pits: 被消灭随从放入牌库底', () => {
         expect(next.bases[0].minions.length).toBe(0);
         expect((next.turnDestroyedMinions ?? []).some((r: any) => r.uid === 'm1')).toBe(true);
     });
+
 });
 
 // ============================================================================

--- a/src/games/smashup/__tests__/newFactionAbilities.test.ts
+++ b/src/games/smashup/__tests__/newFactionAbilities.test.ts
@@ -78,6 +78,49 @@ describe('bear cavalry interaction regressions', () => {
         expect((destroyEvt as any).payload.minionUid).toBe('m1');
         expect(respondResult.finalState.core.bases[0].minions.some(m => m.uid === 'm1')).toBe(false);
     });
+
+    it('bear_cavalry_polar_commando_pod talent 可以选择敌方低战力随从', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [
+                        makeMinion('pc1', 'bear_cavalry_polar_commando_pod', '0', 4, { powerModifier: 0 }),
+                        makeMinion('ally5', 'ally_big', '0', 5, { powerModifier: 0 }),
+                    ],
+                    ongoingActions: [],
+                },
+                {
+                    defId: 'base_b',
+                    minions: [
+                        makeMinion('enemy3', 'enemy_small', '1', 3, { powerModifier: 0 }),
+                        makeMinion('enemy4', 'enemy_equal', '1', 4, { powerModifier: 0 }),
+                    ],
+                    ongoingActions: [],
+                },
+            ],
+        });
+
+        const talentResult = runCommand(
+            makeMatchState(core),
+            { type: SU_COMMANDS.USE_TALENT, playerId: '0', payload: { minionUid: 'pc1', baseIndex: 0 } },
+            defaultTestRandom,
+        );
+
+        expect(talentResult.success).toBe(true);
+        const prompt = getInteractionsFromMS(talentResult.finalState)[0] as any;
+        expect(prompt?.data?.sourceId).toBe('bear_cavalry_polar_commando_pod');
+
+        const optionValues = prompt?.data?.options?.map((option: any) => option?.value?.minionUid) ?? [];
+        expect(optionValues).toContain('pc1');
+        expect(optionValues).toContain('enemy3');
+        expect(optionValues).not.toContain('enemy4');
+        expect(optionValues).not.toContain('ally5');
+    });
 });
 
 describe('stale destroy regression: 交互提示能力', () => {

--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -1855,9 +1855,20 @@ describe('base_rlyeh 拉莱耶 onTurnStart', () => {
         expect(handler).toBeDefined();
         const ms = { core: state, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
         const result = handler!(ms, '0', { minionUid: 'm1', baseIndex: 0 }, undefined, dummyRandom, 0);
-        expect(result.events.length).toBe(2);
+        expect(result.events.length).toBe(1);
         expect(result.events[0].type).toBe(SU_EVENTS.MINION_DESTROYED);
-        expect(result.events[1].type).toBe(SU_EVENTS.VP_AWARDED);
+        const followup = triggerExtendedBaseAbility('base_rlyeh', 'onMinionDestroyed', {
+            state,
+            baseIndex: 0,
+            baseDefId: 'base_rlyeh',
+            playerId: '0',
+            destroyerId: '0',
+            controllerId: '0',
+            reason: 'base_rlyeh',
+            now: 1,
+        });
+        expect(followup.events).toHaveLength(1);
+        expect(followup.events[0].type).toBe(SU_EVENTS.VP_AWARDED);
     });
 
     it('handler 选择不消灭→不产生事件', () => {

--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -2404,9 +2404,9 @@ describe('bear_cavalry_bear_rides_you_pod 交互选项', () => {
             .filter((kind: unknown) => typeof kind === 'string');
 
         expect(kinds).toContain('base');
+        expect(kinds).toContain('minion');
+        expect(kinds).toContain('ongoing');
         expect(kinds).toContain('skip');
-        expect(kinds).not.toContain('minion');
-        expect(kinds).not.toContain('ongoing');
         expect(kinds).not.toContain('attached');
         expect(kinds).not.toContain('titan');
     });

--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -47,6 +47,67 @@ function makeMinion(uid: string, defId: string, controller: string, power: numbe
     };
 }
 
+describe('suppressed source triggers', () => {
+    it('suppressed bear_cavalry_cub_scout should not destroy moved minion', () => {
+        const scout = makeMinion('scout', 'bear_cavalry_cub_scout', '0', 3, { powerModifier: 0 });
+        const moved = makeMinion('moved', 'test_minion', '1', 2, { powerModifier: 0 });
+        const destBase = makeBase({ minions: [scout] });
+        const srcBase = makeBase({ minions: [moved] });
+        const state = makeState({
+            bases: [destBase, srcBase],
+            suppressedCardsUntilTurnStart: [{
+                cardUid: 'scout',
+                baseIndex: 0,
+                suppressorPlayerId: '0',
+                cardType: 'minion',
+            }],
+        });
+
+        const { events } = fireTriggers(state, 'onMinionMoved', {
+            state,
+            playerId: '0',
+            baseIndex: 0,
+            triggerMinionUid: 'moved',
+            triggerMinionDefId: 'test_minion',
+            random: dummyRandom,
+            now: 0,
+        });
+
+        expect(events.some(e => e.type === SU_EVENTS.MINION_DESTROYED)).toBe(false);
+    });
+
+    it('suppressed bear_cavalry_high_ground should not destroy moved minion', () => {
+        const myMinion = makeMinion('my', 'test_minion', '0', 3, { powerModifier: 0 });
+        const moved = makeMinion('moved', 'test_minion', '1', 5, { powerModifier: 0 });
+        const destBase = makeBase({
+            minions: [myMinion],
+            ongoingActions: [{ uid: 'hg-1', defId: 'bear_cavalry_high_ground', ownerId: '0' }],
+        });
+        const srcBase = makeBase({ minions: [moved] });
+        const state = makeState({
+            bases: [destBase, srcBase],
+            suppressedCardsUntilTurnStart: [{
+                cardUid: 'hg-1',
+                baseIndex: 0,
+                suppressorPlayerId: '0',
+                cardType: 'ongoing',
+            }],
+        });
+
+        const { events } = fireTriggers(state, 'onMinionMoved', {
+            state,
+            playerId: '0',
+            baseIndex: 0,
+            triggerMinionUid: 'moved',
+            triggerMinionDefId: 'test_minion',
+            random: dummyRandom,
+            now: 0,
+        });
+
+        expect(events.some(e => e.type === SU_EVENTS.MINION_DESTROYED)).toBe(false);
+    });
+});
+
 function makePlayer(id: string, overrides?: Partial<PlayerState>): PlayerState {
     return {
         id, vp: 0, hand: [], deck: [], discard: [],

--- a/src/games/smashup/__tests__/ongoingModifiers.test.ts
+++ b/src/games/smashup/__tests__/ongoingModifiers.test.ts
@@ -72,6 +72,46 @@ describe('持续力量修正基础设施', () => {
     });
 });
 
+describe('suppressed source modifiers', () => {
+    it('suppressed steampunk_aggromotive should not grant base power bonus', () => {
+        const m1 = makeMinion('m1', 'test_a', '0', 2, { powerModifier: 0 });
+        const base = {
+            defId: 'base_a',
+            minions: [m1],
+            ongoingActions: [{ uid: 'ag1', defId: 'steampunk_aggromotive', ownerId: '0' }],
+        };
+        const state = makeState({
+            bases: [base],
+            suppressedCardsUntilTurnStart: [{
+                cardUid: 'ag1',
+                baseIndex: 0,
+                suppressorPlayerId: '0',
+                cardType: 'ongoing',
+            }],
+        } as any);
+
+        expect(getPlayerEffectivePowerOnBase(state, base, 0, '0')).toBe(2);
+    });
+
+    it('suppressed dino_upgrade should not grant attached +2 power', () => {
+        const minion = makeMinion('m1', 'test_minion', '0', 3, {
+            attachedActions: [{ uid: 'up-1', defId: 'dino_upgrade', ownerId: '0' }],
+        });
+        const base = { defId: 'base_a', minions: [minion], ongoingActions: [] };
+        const state = makeState({
+            bases: [base],
+            suppressedCardsUntilTurnStart: [{
+                cardUid: 'up-1',
+                baseIndex: 0,
+                suppressorPlayerId: '0',
+                cardType: 'attached',
+            }],
+        } as any);
+
+        expect(getEffectivePower(state, minion, 0)).toBe(3);
+    });
+});
+
 // ============================================================================
 // 恐龙：重装剑龙
 // ============================================================================

--- a/src/games/smashup/__tests__/ongoingTalent.test.ts
+++ b/src/games/smashup/__tests__/ongoingTalent.test.ts
@@ -138,6 +138,30 @@ describe('ongoing 行动卡天赋 - 验证层', () => {
         } as any);
         expect(result.valid).toBe(false);
     });
+
+    it('被压制的持续行动卡不能发动天赋', () => {
+        const core = makeState({
+            suppressedCardsUntilTurnStart: [{
+                cardUid: 'oa1',
+                baseIndex: 0,
+                suppressorPlayerId: '1',
+                cardType: 'ongoing',
+            }],
+            bases: [{
+                defId: 'base_a',
+                minions: [],
+                ongoingActions: [makeOngoing('oa1', 'miskatonic_lost_knowledge', '0')],
+            }],
+        });
+        const ms = makeMatchState(core);
+        const result = validate(ms, {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { ongoingCardUid: 'oa1', baseIndex: 0 },
+        } as any);
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('该卡牌能力已被压制');
+    });
 });
 
 // ============================================================================

--- a/src/games/smashup/__tests__/scoreBases-auto-continue.test.ts
+++ b/src/games/smashup/__tests__/scoreBases-auto-continue.test.ts
@@ -234,4 +234,33 @@ describe('scoreBases 阶段自动推进', () => {
         expect(result?.autoContinue).toBe(true);
         expect(result?.playerId).toBe('0');
     });
+
+    it('达标基地上有可激活的侏儒 POD special 时不应该自动推进', () => {
+        const core = makeMinimalCore({
+            bases: [makeBase('base_pirate_cove', [
+                makeMinion('0', 'trickster_gnome_pod', 3),
+                makeMinion('0', 'robot_hoverbot', 4),
+                makeMinion('1', 'robot_microbot_guard', 3),
+            ])],
+            scoringEligibleBaseIndices: [0],
+        });
+
+        const state: MatchState<SmashUpCore> = {
+            core,
+            sys: {
+                phase: 'scoreBases',
+                flowHalted: false,
+                interaction: { current: null, queue: [] },
+                responseWindow: { current: null, history: [] },
+            } as any,
+        };
+
+        const result = smashUpFlowHooks.onAutoContinueCheck!({
+            state,
+            events: [],
+            random: { next: () => 0.5 },
+        });
+
+        expect(result).toBeUndefined();
+    });
 });

--- a/src/games/smashup/__tests__/specialInteractionChain.test.ts
+++ b/src/games/smashup/__tests__/specialInteractionChain.test.ts
@@ -620,10 +620,21 @@ describe('onMinionPlayed trigger: trickster_pay_the_piper', () => {
             payload: { cardUid: 'm1', baseIndex: 0 },
         }, 'pay_the_piper: 对手打出随从');
         expect(r1.steps[0]?.success).toBe(true);
+        const choice = asSimpleChoice(r1.finalState.sys.interaction.current)!;
+        expect(choice).toBeDefined();
+        expect(choice.playerId).toBe('0');
+        expect(choice.options).toHaveLength(2);
+
+        const discardH2 = findOption(choice, (option: any) => option.value?.cardUid === 'h2');
+        const r2 = respond(r1.finalState, '0', discardH2, 'pay_the_piper: 选择弃牌');
+        expect(r2.steps[0]?.success).toBe(true);
+
         // P0 手牌减少：打出1张 + 被迫弃1张 = 减少2张
-        const p0 = r1.finalState.core.players['0'];
+        const p0 = r2.finalState.core.players['0'];
         expect(p0.hand.length).toBe(handBefore - 2);
-        expect(p0.discard.length).toBeGreaterThan(0);
+        expect(p0.hand.some(card => card.uid === 'h1')).toBe(true);
+        expect(p0.hand.some(card => card.uid === 'h2')).toBe(false);
+        expect(p0.discard.some(card => card.uid === 'h2')).toBe(true);
     });
 });
 

--- a/src/games/smashup/__tests__/talentAbilities.test.ts
+++ b/src/games/smashup/__tests__/talentAbilities.test.ts
@@ -609,4 +609,34 @@ describe('天赋基础设施', () => {
         expect(result.valid).toBe(false);
         expect(result.error).toBe('本回合天赋已使用');
     });
+
+    it('被压制的随从不能发动天赋', () => {
+        const core = makeState({
+            suppressedCardsUntilTurnStart: [{
+                cardUid: 'm1',
+                baseIndex: 0,
+                suppressorPlayerId: '1',
+                cardType: 'minion',
+            }],
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [makeMinion('m1', 'miskatonic_librarian', '0', 4)],
+                    ongoingActions: [],
+                },
+            ],
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+        });
+
+        const result = validate(makeMatchState(core), {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { minionUid: 'm1', baseIndex: 0 },
+        });
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('该卡牌能力已被压制');
+    });
 });

--- a/src/games/smashup/__tests__/trickster-mark-of-sleep-self-target.test.ts
+++ b/src/games/smashup/__tests__/trickster-mark-of-sleep-self-target.test.ts
@@ -11,7 +11,11 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initAllAbilities } from '../abilities';
 import { runCommand } from './testRunner';
 import { makeState, makePlayer, makeCard, makeMatchState } from './helpers';
-import { SU_COMMANDS } from '../domain/types';
+import { SU_COMMANDS, SU_EVENTS } from '../domain/types';
+import { validate } from '../domain/commands';
+import { reduce } from '../domain/reduce';
+import { filterProtectedMoveEvents } from '../domain/reducer';
+import { moveMinion } from '../domain/abilityHelpers';
 import type { RandomFn } from '../../../engine/types';
 
 beforeAll(() => {
@@ -135,5 +139,290 @@ describe('睡眠印记可以选择自己', () => {
         const options = (interaction?.data as any)?.options;
         const opponentOption = options.find((opt: any) => opt.value?.pid === '1');
         expect(opponentOption).toBeDefined();
+    });
+});
+
+describe('睡眠印记 POD', () => {
+    it('会为每个其他玩家依次创建“禁战术/禁移动”选择', () => {
+        const state = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('mark-pod', 'trickster_mark_of_sleep_pod', 'action', '0')],
+                }),
+                '1': makePlayer('1'),
+                '2': makePlayer('2'),
+            },
+            turnOrder: ['0', '1', '2'],
+        });
+
+        let ms = makeMatchState(state);
+        const played = runCommand(ms, {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '0',
+            payload: { cardUid: 'mark-pod' },
+            timestamp: 1000,
+        } as any, defaultRandom);
+        ms = played.finalState;
+
+        const firstInteraction = ms.sys.interaction?.current;
+        expect(firstInteraction?.data?.sourceId).toBe('trickster_mark_of_sleep_pod');
+        expect((firstInteraction?.data as any)?.continuationContext?.targetPlayerId).toBe('1');
+        const firstOptions = (firstInteraction?.data as any)?.options ?? [];
+        expect(firstOptions.map((opt: any) => opt.label)).toEqual(['不能打出战术', '不能移动随从']);
+
+        const firstNoAction = firstOptions.find((opt: any) => opt.value?.restrictionType === 'play_action');
+        expect(firstNoAction).toBeDefined();
+
+        const afterFirstChoice = runCommand(ms, {
+            type: 'SYS_INTERACTION_RESPOND',
+            playerId: '0',
+            payload: { optionId: firstNoAction.id },
+            timestamp: 1001,
+        } as any, defaultRandom);
+
+        const secondInteraction = afterFirstChoice.finalState.sys.interaction?.current;
+        expect(secondInteraction?.data?.sourceId).toBe('trickster_mark_of_sleep_pod');
+        expect((secondInteraction?.data as any)?.continuationContext?.targetPlayerId).toBe('2');
+    });
+
+    it('选择“不能打出战术”后，会阻止目标玩家打出行动卡', () => {
+        const state = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('mark-pod', 'trickster_mark_of_sleep_pod', 'action', '0')],
+                }),
+                '1': makePlayer('1', {
+                    hand: [makeCard('action-1', 'trickster_take_the_shinies', 'action', '1')],
+                }),
+            },
+        });
+
+        let ms = makeMatchState(state);
+        const played = runCommand(ms, {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '0',
+            payload: { cardUid: 'mark-pod' },
+            timestamp: 1100,
+        } as any, defaultRandom);
+        ms = played.finalState;
+
+        const interaction = ms.sys.interaction?.current;
+        const options = (interaction?.data as any)?.options ?? [];
+        const noAction = options.find((opt: any) => opt.value?.restrictionType === 'play_action');
+        expect(noAction).toBeDefined();
+
+        const resolved = runCommand(ms, {
+            type: 'SYS_INTERACTION_RESPOND',
+            playerId: '0',
+            payload: { optionId: noAction.id },
+            timestamp: 1101,
+        } as any, defaultRandom);
+
+        const restrictedCore = {
+            ...resolved.finalState.core,
+            currentPlayerIndex: 1,
+        };
+        const restrictedState = makeMatchState(restrictedCore);
+        const validation = validate(restrictedState, {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '1',
+            payload: { cardUid: 'action-1' },
+            timestamp: 1102,
+        } as any);
+
+        expect(validation.valid).toBe(false);
+        expect(validation.error).toContain('战术');
+    });
+
+    it('选择“不能移动随从”后，会过滤掉该玩家产生的移动事件', () => {
+        const state = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [
+                        {
+                            uid: 'm1',
+                            defId: 'test_minion',
+                            controller: '1',
+                            owner: '1',
+                            basePower: 3,
+                            powerModifier: 0,
+                            talentUsed: false,
+                            attachedActions: [],
+                        },
+                    ],
+                    ongoingActions: [],
+                },
+                {
+                    defId: 'base_b',
+                    minions: [],
+                    ongoingActions: [],
+                },
+            ],
+            playerRestrictionsUntilTurnStart: [
+                {
+                    sourcePlayerId: '0',
+                    targetPlayerId: '1',
+                    restrictionType: 'move_minion',
+                },
+            ],
+        });
+
+        const moveEvents = [
+            moveMinion('m1', 'test_minion', 0, 1, 'test_move', 1200),
+        ];
+
+        expect(filterProtectedMoveEvents(moveEvents, state, '1')).toHaveLength(0);
+        expect(filterProtectedMoveEvents(moveEvents, state, '0')).toHaveLength(1);
+    });
+
+    it('同一目标已存在不能打出战术时，再选择不能移动随从会保留两种限制', () => {
+        const state = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('mark-pod', 'trickster_mark_of_sleep_pod', 'action', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+            playerRestrictionsUntilTurnStart: [
+                {
+                    sourcePlayerId: '0',
+                    targetPlayerId: '1',
+                    restrictionType: 'play_action',
+                },
+            ],
+        });
+
+        const played = runCommand(makeMatchState(state), {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '0',
+            payload: { cardUid: 'mark-pod' },
+            timestamp: 1300,
+        } as any, defaultRandom);
+
+        const interaction = played.finalState.sys.interaction?.current;
+        const options = (interaction?.data as any)?.options ?? [];
+        const noMove = options.find((opt: any) => opt.value?.restrictionType === 'move_minion');
+        expect(noMove).toBeDefined();
+
+        const resolved = runCommand(played.finalState, {
+            type: 'SYS_INTERACTION_RESPOND',
+            playerId: '0',
+            payload: { optionId: noMove.id },
+            timestamp: 1301,
+        } as any, defaultRandom);
+
+        expect(resolved.finalState.core.playerRestrictionsUntilTurnStart).toEqual([
+            {
+                sourcePlayerId: '0',
+                targetPlayerId: '1',
+                restrictionType: 'play_action',
+            },
+            {
+                sourcePlayerId: '0',
+                targetPlayerId: '1',
+                restrictionType: 'move_minion',
+            },
+        ]);
+    });
+
+    it('沉睡印记在目标回合内即使获得额外行动也仍然禁止打出战术，并在回合结束后清除', () => {
+        const state = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1', {
+                    hand: [makeCard('action-1', 'trickster_take_the_shinies', 'action', '1')],
+                    actionLimit: 2,
+                }),
+            },
+            currentPlayerIndex: 1,
+            sleepMarkedPlayers: ['1'],
+        });
+
+        const startedCore = reduce(state, {
+            type: SU_EVENTS.TURN_STARTED,
+            payload: { playerId: '1', turnNumber: 2 },
+            timestamp: 1400,
+        } as any);
+
+        expect(startedCore.players['1'].actionLimit).toBe(0);
+        expect(startedCore.sleepMarkedPlayers).toEqual(['1']);
+
+        const boostedCore = {
+            ...startedCore,
+            players: {
+                ...startedCore.players,
+                '1': {
+                    ...startedCore.players['1'],
+                    actionLimit: 2,
+                },
+            },
+        };
+        const validation = validate(makeMatchState(boostedCore), {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '1',
+            payload: { cardUid: 'action-1' },
+            timestamp: 1401,
+        } as any);
+
+        expect(validation.valid).toBe(false);
+        expect(validation.error).toContain('战术');
+
+        const endedCore = reduce(startedCore, {
+            type: SU_EVENTS.TURN_ENDED,
+            payload: { playerId: '1', nextPlayerIndex: 0 },
+            timestamp: 1402,
+        } as any);
+
+        expect(endedCore.sleepMarkedPlayers).toBeUndefined();
+    });
+
+    it('基地原因触发的移动不会错误套用命令发起者的不能移动随从限制', () => {
+        const state = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [
+                        {
+                            uid: 'm1',
+                            defId: 'test_minion',
+                            controller: '1',
+                            owner: '1',
+                            basePower: 3,
+                            powerModifier: 0,
+                            talentUsed: false,
+                            attachedActions: [],
+                        },
+                    ],
+                    ongoingActions: [],
+                },
+                {
+                    defId: 'base_b',
+                    minions: [],
+                    ongoingActions: [],
+                },
+            ],
+            playerRestrictionsUntilTurnStart: [
+                {
+                    sourcePlayerId: '9',
+                    targetPlayerId: '0',
+                    restrictionType: 'move_minion',
+                },
+            ],
+        });
+
+        const moveEvents = [
+            moveMinion('m1', 'test_minion', 0, 1, 'base_auto_move', 1500),
+        ];
+
+        expect(filterProtectedMoveEvents(moveEvents, state, '0')).toHaveLength(1);
     });
 });

--- a/src/games/smashup/__tests__/vampiresPod.test.ts
+++ b/src/games/smashup/__tests__/vampiresPod.test.ts
@@ -308,7 +308,7 @@ describe('vampires_pod: Nightstalker POD', () => {
 });
 
 describe('vampires_pod: Buffet POD', () => {
-    it('cannot be played as a normal action', () => {
+    it('can be played as a normal action and draws two cards', () => {
         const core = makeState({
             players: {
                 '0': makePlayer('0', {
@@ -332,8 +332,13 @@ describe('vampires_pod: Buffet POD', () => {
             defaultTestRandom,
         );
 
-        expect(played.success).toBe(false);
-        expect(played.error).toContain('该特殊行动卡只能在基地计分后的响应窗口中打出');
+        expect(played.success).toBe(true);
+        expect(played.events.some(e => e.type === SU_EVENTS.ACTION_PLAYED)).toBe(true);
+        expect(played.events.some(e => e.type === SU_EVENTS.CARDS_DRAWN)).toBe(true);
+        expect(played.finalState.core.players['0'].hand.map(c => c.uid)).toEqual(
+            expect.arrayContaining(['draw-1', 'draw-2']),
+        );
+        expect(played.finalState.core.players['0'].discard.some(c => c.uid === 'bf')).toBe(true);
     });
 });
 
@@ -603,67 +608,3 @@ describe('vampires_pod: Wolf Pact POD', () => {
     });
 });
 
-describe('vampires_pod: Cull The Weak POD', () => {
-    it('searches the deck for up to two minions, mills them, then places counters afterward', () => {
-        const core = makeState({
-            players: {
-                '0': makePlayer('0', {
-                    hand: [
-                        makeCard('a1', 'vampire_cull_the_weak_pod', 'action', '0'),
-                    ],
-                    deck: [
-                        makeCard('d1', 'test_minion', 'minion', '0'),
-                        makeCard('d2', 'test_minion_2', 'minion', '0'),
-                        makeCard('d3', 'test_action', 'action', '0'),
-                    ],
-                }),
-                '1': makePlayer('1'),
-            },
-            bases: [{
-                defId: 'base_a',
-                minions: [
-                    makeMinion('m1', 'vampire_nightstalker_pod', '0', 4),
-                    makeMinion('m2', 'vampire_fledgling_vampire_pod', '0', 2),
-                ],
-                ongoingActions: [],
-            }],
-        });
-
-        const played = runCommand(
-            makeMatchState(core),
-            { type: SU_COMMANDS.PLAY_ACTION, playerId: '0', payload: { cardUid: 'a1' } },
-            defaultTestRandom,
-        );
-
-        const counterPrompt = getInteractionsFromMS(played.finalState)[0];
-        expect(counterPrompt?.data?.sourceId).toBe('vampire_cull_the_weak_pod');
-        expect(counterPrompt?.data?.options).toHaveLength(2);
-        expect(counterPrompt?.data?.continuationContext?.discardedCount).toBe(2);
-        expect(counterPrompt?.data?.continuationContext?.discardUids).toEqual(['d1', 'd2']);
-
-        const firstTarget = counterPrompt?.data?.options?.find((o: any) => o?.value?.minionUid === 'm1');
-        expect(firstTarget).toBeDefined();
-
-        const afterSearch = runCommand(
-            played.finalState,
-            { type: INTERACTION_COMMANDS.RESPOND, playerId: '0', payload: { optionId: firstTarget.id } } as any,
-            defaultTestRandom,
-        );
-
-        expect(afterSearch.events.some(e => e.type === SU_EVENTS.CARDS_MILLED)).toBe(true);
-        expect(afterSearch.events.some(e => e.type === SU_EVENTS.CARDS_DISCARDED)).toBe(false);
-        expect(afterSearch.finalState.core.players['0'].discard.map(c => c.uid)).toEqual(
-            expect.arrayContaining(['d1', 'd2']),
-        );
-        expect(afterSearch.finalState.core.players['0'].deck.map(c => c.uid)).toEqual(['d3']);
-
-        const afterCounter = runCommand(
-            afterSearch.finalState,
-            { type: INTERACTION_COMMANDS.RESPOND, playerId: '0', payload: { optionId: firstTarget.id } } as any,
-            defaultTestRandom,
-        );
-
-        expect(getInteractionsFromMS(afterCounter.finalState)).toHaveLength(0);
-        expect(afterCounter.finalState.core.bases[0].minions.find(m => m.uid === 'm1')?.powerCounters).toBe(2);
-    });
-});

--- a/src/games/smashup/abilities/bear_cavalry.ts
+++ b/src/games/smashup/abilities/bear_cavalry.ts
@@ -352,12 +352,11 @@ function bearCavalryPolarCommandoPodTalent(ctx: AbilityContext): AbilityResult {
     const commandoPower = getMinionPower(ctx.state, commando, ctx.baseIndex);
 
     // POD 文本：this minion 或 “a minion with less power than this minion”
-    // 目标范围：任意基地上的己方随从（不限同基地）
+    // 目标范围：任意基地上的任意随从（不限控制者、也不限同基地）
     const targets: Array<{ minion: MinionOnBase; baseIndex: number; power: number }> = [];
     for (let i = 0; i < ctx.state.bases.length; i++) {
         const b = ctx.state.bases[i];
         for (const m of b.minions) {
-            if (m.controller !== ctx.playerId) continue;
             if (m.uid === ctx.cardUid) {
                 targets.push({ minion: m, baseIndex: i, power: commandoPower });
                 continue;
@@ -1089,7 +1088,7 @@ export function registerBearCavalryInteractionHandlers(): void {
             const baseIndex = baseCandidates[0].baseIndex;
             const playedEvt: MinionPlayedEvent = {
                 type: SU_EVENTS.MINION_PLAYED,
-                payload: { playerId, cardUid, defId, baseIndex, baseDefId: state.core.bases[baseIndex].defId, power, consumesNormalLimit: false },
+                payload: { playerId, cardUid, defId, baseIndex, baseDefId: state.core.bases[baseIndex].defId, power },
                 timestamp,
             };
             // 检查该基地是否有对手随从可移动（保护检查在 buildMinionTargetOptions 中）
@@ -1151,7 +1150,7 @@ export function registerBearCavalryInteractionHandlers(): void {
         if (!ctx) return undefined;
         const playedEvt: MinionPlayedEvent = {
             type: SU_EVENTS.MINION_PLAYED,
-            payload: { playerId, cardUid: ctx.cardUid, defId: ctx.defId, baseIndex, baseDefId: state.core.bases[baseIndex].defId, power: ctx.power, consumesNormalLimit: false },
+            payload: { playerId, cardUid: ctx.cardUid, defId: ctx.defId, baseIndex, baseDefId: state.core.bases[baseIndex].defId, power: ctx.power },
             timestamp,
         };
         // 检查该基地是否有对手随从可移动（保护检查在 buildMinionTargetOptions 中）

--- a/src/games/smashup/abilities/bear_cavalry.ts
+++ b/src/games/smashup/abilities/bear_cavalry.ts
@@ -24,7 +24,7 @@ import {
 } from '../domain/abilityHelpers';
 import { SU_EVENT_TYPES } from '../domain/events';
 import { SU_EVENTS } from '../domain/types';
-import type { SmashUpEvent, MinionOnBase, OngoingDetachedEvent, MinionPlayedEvent } from '../domain/types';
+import type { SmashUpEvent, MinionOnBase, OngoingDetachedEvent, MinionPlayedEvent, BaseInPlay } from '../domain/types';
 import type { MinionCardDef } from '../domain/types';
 import { getCardDef, getBaseDef } from '../data/cards';
 import { registerProtection, registerTrigger, isMinionProtected } from '../domain/ongoingEffects';
@@ -877,7 +877,86 @@ function bearCavalryBearRidesYouPod(ctx: AbilityContext): AbilityResult {
 
 type BearRidesYouPodSuppressTarget =
     | { kind: 'skip' }
-    | { kind: 'base'; baseIndex: number };
+    | { kind: 'base'; baseIndex: number; baseDefId: string }
+    | { kind: 'minion'; minionUid: string; baseIndex: number; minionDefId: string }
+    | { kind: 'ongoing'; cardUid: string; baseIndex: number; defId: string }
+    | { kind: 'attached'; cardUid: string; baseIndex: number; defId: string }
+    | { kind: 'titan'; titanUid: string; baseIndex: number; ownerId: PlayerId; minionDefId: string };
+
+type BearRidesYouPodSuppressOption = {
+    id: string;
+    label: string;
+    value: BearRidesYouPodSuppressTarget;
+    displayMode?: 'card' | 'button';
+};
+
+function buildBearRidesYouPodPostMoveBase(base: BaseInPlay, movedMinion: MinionOnBase): BaseInPlay {
+    return {
+        ...base,
+        minions: [...base.minions.filter(m => m.uid !== movedMinion.uid), movedMinion],
+    };
+}
+
+function buildBearRidesYouPodSuppressOptions(
+    turnOrder: PlayerId[],
+    players: Record<string, any>,
+    base: BaseInPlay,
+    baseIndex: number,
+): BearRidesYouPodSuppressOption[] {
+    const suppressOptions: BearRidesYouPodSuppressOption[] = [];
+    const baseDef = getBaseDef(base.defId);
+    suppressOptions.push({
+        id: 'base',
+        label: `[基地] ${baseDef?.name ?? base.defId}`,
+        value: { kind: 'base', baseIndex, baseDefId: base.defId },
+        displayMode: 'card',
+    });
+
+    for (const m of base.minions) {
+        const def = getCardDef(m.defId) as MinionCardDef | undefined;
+        suppressOptions.push({
+            id: `minion-${m.uid}`,
+            label: `[随从] ${def?.name ?? m.defId}`,
+            value: { kind: 'minion', minionUid: m.uid, baseIndex, minionDefId: m.defId },
+            displayMode: 'card',
+        });
+        for (const a of m.attachedActions ?? []) {
+            const aDef = getCardDef(a.defId);
+            suppressOptions.push({
+                id: `attached-${a.uid}`,
+                label: `[附着行动] ${aDef?.name ?? a.defId}`,
+                value: { kind: 'attached', cardUid: a.uid, baseIndex, defId: a.defId },
+                displayMode: 'card',
+            });
+        }
+    }
+
+    for (const oa of base.ongoingActions) {
+        const oDef = getCardDef(oa.defId);
+        suppressOptions.push({
+            id: `ongoing-${oa.uid}`,
+            label: `[持续行动] ${oDef?.name ?? oa.defId}`,
+            value: { kind: 'ongoing', cardUid: oa.uid, baseIndex, defId: oa.defId },
+            displayMode: 'card',
+        });
+    }
+
+    for (const pid of turnOrder) {
+        const p = players[pid];
+        const t = (p as any)?.activeTitan as { titanUid: string; baseIndex: number; defId: string } | undefined;
+        if (!t || t.baseIndex !== baseIndex) continue;
+        const tDef = getCardDef(t.defId);
+        suppressOptions.push({
+            id: `titan-${t.titanUid}`,
+            label: `[泰坦] ${tDef?.name ?? t.defId}`,
+            value: { kind: 'titan', titanUid: t.titanUid, baseIndex, ownerId: pid, minionDefId: t.defId },
+            displayMode: 'card',
+        });
+    }
+
+    suppressOptions.push({ id: 'skip', label: '跳过（不压制）', value: { kind: 'skip' }, displayMode: 'button' });
+    return suppressOptions;
+}
 
 /** 你们都是美食 onPlay：选择有己方随从的基地→选择目标基地，移动所有对手随从*/
 function bearCavalryYourePrettyMuchBorscht(ctx: AbilityContext): AbilityResult {
@@ -1604,7 +1683,10 @@ export function registerBearCavalryInteractionHandlers(): void {
         const { baseIndex: toBase } = value as { baseIndex: number };
         const ctx = (iData as any)?.continuationContext as { minionUid: string; minionDefId: string; fromBase: number; isMyMinion: boolean };
         if (!ctx) return undefined;
-        
+        const sourceBase = state.core.bases[ctx.fromBase];
+        const movedMinion = sourceBase?.minions.find(m => m.uid === ctx.minionUid);
+        if (!movedMinion) return { state, events: [] };
+
         const events: SmashUpEvent[] = [moveMinion(ctx.minionUid, ctx.minionDefId, ctx.fromBase, toBase, 'bear_cavalry_bear_rides_you_pod', timestamp)];
 
         // 如果移动的是己方随从：可选择压制新基地上一张卡牌能力（含基地本身）
@@ -1612,71 +1694,19 @@ export function registerBearCavalryInteractionHandlers(): void {
 
         const base = state.core.bases[toBase];
         if (!base) return { state, events };
-
-        const suppressOptions: Array<{ id: string; label: string; value: BearRidesYouPodSuppressTarget }> = [];
-        const baseDef = getBaseDef(base.defId);
-        suppressOptions.push({
-            id: 'base',
-            label: `[基地] ${baseDef?.name ?? base.defId}`,
-            value: { kind: 'base', baseIndex: toBase, baseDefId: base.defId },
-            displayMode: 'card' as const,
-        });
-
-        for (const m of base.minions) {
-            const def = getCardDef(m.defId) as MinionCardDef | undefined;
-            suppressOptions.push({
-                id: `minion-${m.uid}`,
-                label: `[随从] ${def?.name ?? m.defId}`,
-                value: { kind: 'minion', minionUid: m.uid, minionDefId: m.defId, baseIndex: toBase },
-                displayMode: 'card' as const,
-            });
-            for (const a of m.attachedActions ?? []) {
-                const aDef = getCardDef(a.defId);
-                suppressOptions.push({
-                    id: `attached-${a.uid}`,
-                    label: `[附着行动] ${aDef?.name ?? a.defId}`,
-                    value: { kind: 'attached', cardUid: a.uid, defId: a.defId, baseIndex: toBase },
-                    displayMode: 'card' as const,
-                });
-            }
-        }
-
-        for (const oa of base.ongoingActions) {
-            const oDef = getCardDef(oa.defId);
-            suppressOptions.push({
-                id: `ongoing-${oa.uid}`,
-                label: `[持续行动] ${oDef?.name ?? oa.defId}`,
-                value: { kind: 'ongoing', cardUid: oa.uid, defId: oa.defId, baseIndex: toBase },
-                displayMode: 'card' as const,
-            });
-        }
-
-        // 泰坦：检查所有玩家的 activeTitan 是否在该基地
-        for (const pid of state.core.turnOrder) {
-            const p = state.core.players[pid];
-            const t = (p as any)?.activeTitan as { titanUid: string; baseIndex: number; defId: string } | undefined;
-            if (!t) continue;
-            if (t.baseIndex !== toBase) continue;
-            const tDef = getCardDef(t.defId);
-            suppressOptions.push({
-                id: `titan-${t.titanUid}`,
-                label: `[泰坦] ${tDef?.name ?? t.defId}`,
-                value: { kind: 'titan', titanUid: t.titanUid, defId: t.defId, baseIndex: toBase, ownerId: pid },
-                displayMode: 'card' as const,
-            });
-        }
-
-        suppressOptions.push({ id: 'skip', label: '跳过（不压制）', value: { kind: 'skip' }, displayMode: 'button' as const });
-
-        const visibleSuppressOptions = suppressOptions.filter(option =>
-            option.value.kind === 'base' || option.value.kind === 'skip'
+        const postMoveBase = buildBearRidesYouPodPostMoveBase(base, movedMinion);
+        const suppressOptions = buildBearRidesYouPodSuppressOptions(
+            state.core.turnOrder,
+            state.core.players,
+            postMoveBase,
+            toBase,
         );
 
         const next = createSimpleChoice(
             `bear_cavalry_bear_rides_you_pod_choose_suppress_${timestamp}`,
             playerId,
             '与熊同行：选择要压制能力的卡牌（到你下回合开始）',
-            visibleSuppressOptions as any[],
+            suppressOptions,
             { sourceId: 'bear_cavalry_bear_rides_you_pod_choose_suppress', targetType: 'generic', autoCancelOption: true }
         );
         (next.data as any).continuationContext = { toBase };
@@ -1700,7 +1730,20 @@ export function registerBearCavalryInteractionHandlers(): void {
             };
         }
 
-        return { state, events: [] };
+        return {
+            state,
+            events: [{
+                type: SU_EVENTS.CARD_SUPPRESSED,
+                payload: {
+                    cardUid: chosen.kind === 'minion' ? chosen.minionUid : chosen.kind === 'titan' ? chosen.titanUid : chosen.cardUid,
+                    suppressorPlayerId: playerId,
+                    cardType: chosen.kind,
+                    baseIndex: chosen.baseIndex,
+                    reason: 'bear_cavalry_bear_rides_you_pod',
+                },
+                timestamp,
+            } as any],
+        };
     });
     
     // 全面优势 POD 天赋：摸牌或保护

--- a/src/games/smashup/abilities/bear_cavalry.ts
+++ b/src/games/smashup/abilities/bear_cavalry.ts
@@ -1168,7 +1168,7 @@ export function registerBearCavalryInteractionHandlers(): void {
             const baseIndex = baseCandidates[0].baseIndex;
             const playedEvt: MinionPlayedEvent = {
                 type: SU_EVENTS.MINION_PLAYED,
-                payload: { playerId, cardUid, defId, baseIndex, baseDefId: state.core.bases[baseIndex].defId, power, consumesNormalLimit: false },
+                payload: { playerId, cardUid, defId, baseIndex, baseDefId: state.core.bases[baseIndex].defId, power },
                 timestamp,
             };
             // 检查该基地是否有对手随从可移动（保护检查在 buildMinionTargetOptions 中）
@@ -1230,7 +1230,7 @@ export function registerBearCavalryInteractionHandlers(): void {
         if (!ctx) return undefined;
         const playedEvt: MinionPlayedEvent = {
             type: SU_EVENTS.MINION_PLAYED,
-            payload: { playerId, cardUid: ctx.cardUid, defId: ctx.defId, baseIndex, baseDefId: state.core.bases[baseIndex].defId, power: ctx.power, consumesNormalLimit: false },
+            payload: { playerId, cardUid: ctx.cardUid, defId: ctx.defId, baseIndex, baseDefId: state.core.bases[baseIndex].defId, power: ctx.power },
             timestamp,
         };
         // 检查该基地是否有对手随从可移动（保护检查在 buildMinionTargetOptions 中）

--- a/src/games/smashup/abilities/ongoing_modifiers.ts
+++ b/src/games/smashup/abilities/ongoing_modifiers.ts
@@ -12,6 +12,7 @@ import { getBaseDef } from '../data/cards';
 import { isMicrobot } from '../domain/utils';
 import type { PlayerId } from '../../../engine/types';
 import { registerKillerPlantModifiers as registerKillerPlantAbilitiesModifiers } from './killer_plants';
+import { isBaseAbilitySuppressed } from '../domain/ongoingEffects';
 
 // ============================================================================
 // 辅助函数
@@ -252,6 +253,9 @@ function registerVampireModifiers(): void {
 function registerBaseModifiers(): void {
     // 通用基地持续力量加成：从 BaseCardDef.minionPowerBonus 数据驱动
     registerPowerModifier('base_minionPowerBonus', (ctx: PowerModifierContext) => {
+        if (isBaseAbilitySuppressed(ctx.state, ctx.baseIndex)) {
+            return 0;
+        }
         const baseDef = getBaseDef(ctx.base.defId);
         return baseDef?.minionPowerBonus ?? 0;
     }, { handlesPodInternally: true }); // 标记已处理 POD（通用修正器，不需要 POD 别名）

--- a/src/games/smashup/abilities/pirates.ts
+++ b/src/games/smashup/abilities/pirates.ts
@@ -602,6 +602,21 @@ function buildMoveToBaseInteraction(
 }
 
 /** 注册海盗派系的交互解决处理函数 */
+function resolveLiveBaseIndex(
+    state: SmashUpCore,
+    baseIndex: number | undefined,
+    baseDefId?: string,
+): number | undefined {
+    if (baseDefId) {
+        const liveIndex = state.bases.findIndex(base => base.defId === baseDefId);
+        if (liveIndex >= 0) return liveIndex;
+    }
+    if (baseIndex !== undefined && state.bases[baseIndex]) {
+        return baseIndex;
+    }
+    return undefined;
+}
+
 export function registerPirateInteractionHandlers(): void {
     // 粗鲁少妇：选择目标后消灭（支持跳过）
     registerInteractionHandler('pirate_saucy_wench', (state, playerId, value, _iData, _random, timestamp) => {

--- a/src/games/smashup/abilities/tricksters.ts
+++ b/src/games/smashup/abilities/tricksters.ts
@@ -1,7 +1,7 @@
 /**
- * 大杀四方 - 诡术师派系能力
+ * 澶ф潃鍥涙柟 - 璇℃湳甯堟淳绯昏兘鍔?
  *
- * 主题：陷阱、干扰对手、消灭随从
+ * 涓婚锛氶櫡闃便€佸共鎵板鎵嬨€佹秷鐏殢浠?
  */
 
 import { registerAbility } from '../domain/abilityRegistry';
@@ -25,16 +25,82 @@ import type {
     PowerCounterAddedEvent,
     BreakpointModifiedEvent,
 } from '../domain/types';
-import type { MinionCardDef } from '../domain/types';
+import type { MinionCardDef, PlayerTurnRestrictionType, SmashUpCore } from '../domain/types';
 import { matchesDefId } from '../domain/utils';
 import { registerInterceptor, registerProtection, registerRestriction, registerTrigger } from '../domain/ongoingEffects';
+import type { TriggerContext, TriggerResult } from '../domain/ongoingEffects';
 import { getCardDef, getBaseDef } from '../data/cards';
 import { createSimpleChoice, queueInteraction } from '../../../engine/systems/InteractionSystem';
+import type { MatchState } from '../../../engine/types';
 import { registerInteractionHandler } from '../domain/abilityInteractionHandlers';
 import { FACTION_DISPLAY_NAMES } from '../domain/ids';
 import { getOpponentLabel } from '../domain/utils';
 
-/** 侏儒 onPlay：消灭力量低于己方随从数量的随从 */
+type PayThePiperChoiceValue = { cardUid: string; defId: string };
+type TricksterMarkOfSleepPodChoiceValue = { restrictionType: PlayerTurnRestrictionType };
+type TricksterMarkOfSleepPodContext = {
+    sourcePlayerId: string;
+    targetPlayerId: string;
+    remainingTargetPlayerIds: string[];
+};
+
+function buildPayThePiperDiscardOptions(core: SmashUpCore, playerId: string) {
+    const player = core.players[playerId];
+    if (!player) return [];
+    return player.hand.map((card) => {
+        const def = getCardDef(card.defId);
+        return {
+            id: `card-${card.uid}`,
+            label: def?.name ?? card.defId,
+            value: { cardUid: card.uid, defId: card.defId },
+            _source: 'hand' as const,
+            displayMode: 'card' as const,
+        };
+    });
+}
+
+function queuePayThePiperDiscardChoice(
+    matchState: MatchState<SmashUpCore>,
+    playerId: string,
+    now: number,
+): MatchState<SmashUpCore> {
+    const interaction = createSimpleChoice<PayThePiperChoiceValue>(
+        `trickster_pay_the_piper_${playerId}_${now}`,
+        playerId,
+        '留下买路财：选择 1 张手牌弃掉',
+        buildPayThePiperDiscardOptions(matchState.core, playerId),
+        { sourceId: 'trickster_pay_the_piper', targetType: 'hand' },
+    );
+    (interaction.data as any).optionsGenerator = (state: MatchState<SmashUpCore>) =>
+        buildPayThePiperDiscardOptions(state.core, playerId);
+    return queueInteraction(matchState, interaction);
+}
+
+function createTricksterMarkOfSleepPodInteraction(
+    sourcePlayerId: string,
+    targetPlayerId: string,
+    remainingTargetPlayerIds: string[],
+    now: number,
+) {
+    const interaction = createSimpleChoice<TricksterMarkOfSleepPodChoiceValue>(
+        `trickster_mark_of_sleep_pod_${targetPlayerId}_${now}`,
+        sourcePlayerId,
+        '睡眠印记：为' + getOpponentLabel(targetPlayerId) + '选择一项',
+        [
+            { id: 'no-action', label: '不能打出战术', value: { restrictionType: 'play_action' } },
+            { id: 'no-move', label: '不能移动随从', value: { restrictionType: 'move_minion' } },
+        ],
+        { sourceId: 'trickster_mark_of_sleep_pod', targetType: 'generic' },
+    );
+    (interaction.data as any).continuationContext = {
+        sourcePlayerId,
+        targetPlayerId,
+        remainingTargetPlayerIds,
+    } satisfies TricksterMarkOfSleepPodContext;
+    return interaction;
+}
+
+/** 渚忓剴 onPlay锛氭秷鐏姏閲忎綆浜庡繁鏂归殢浠庢暟閲忕殑闅忎粠 */
 function tricksterGnome(ctx: AbilityContext): AbilityResult {
     const base = ctx.state.bases[ctx.baseIndex];
     if (!base) return { events: [] };
@@ -46,19 +112,19 @@ function tricksterGnome(ctx: AbilityContext): AbilityResult {
         const def = getCardDef(t.defId) as MinionCardDef | undefined;
         const name = def?.name ?? t.defId;
         const power = getMinionPower(ctx.state, t, ctx.baseIndex);
-        return { uid: t.uid, defId: t.defId, baseIndex: ctx.baseIndex, label: `${name} (力量 ${power})` };
+        return { uid: t.uid, defId: t.defId, baseIndex: ctx.baseIndex, label: name + ' (力量 ' + power + ')' };
     });
-    // "你可以"效果：添加跳过选项
+    // "浣犲彲浠?鏁堟灉锛氭坊鍔犺烦杩囬€夐」
     const minionOptions = buildMinionTargetOptions(options, { state: ctx.state, sourcePlayerId: ctx.playerId, effectType: 'destroy' });
     minionOptions.push(createSkipOption());
     return resolveOrPrompt(ctx, minionOptions, {
         id: 'trickster_gnome',
-        title: '选择要消灭的随从（力量低于己方随从数量），或跳过',
+        title: '閫夋嫨瑕佹秷鐏殑闅忎粠锛堝姏閲忎綆浜庡繁鏂归殢浠庢暟閲忥級锛屾垨璺宠繃',
         sourceId: 'trickster_gnome',
         targetType: 'minion',
         autoResolveIfSingle: false,
     }, (value) => {
-        // 检查 skip 标记
+        // 妫€鏌?skip 鏍囪
         if ((value as any).skip) return { events: [] };
         
         const { minionUid } = value as { minionUid?: string };
@@ -70,7 +136,134 @@ function tricksterGnome(ctx: AbilityContext): AbilityResult {
     });
 }
 
-/** 带走宝物 onPlay：每个其他玩家随机弃两张手牌 */
+type TricksterGnomePodPending = {
+    gnomeUid: string;
+    controller: string;
+    baseIndex: number;
+};
+
+function countTitansOnBase(state: SmashUpCore, baseIndex: number): number {
+    let titanCount = 0;
+    for (const pid of state.turnOrder) {
+        const titan = (state.players[pid] as any)?.activeTitan as { baseIndex?: number } | undefined;
+        if (titan?.baseIndex === baseIndex) titanCount += 1;
+    }
+    return titanCount;
+}
+
+function buildTricksterGnomePodOptions(
+    state: SmashUpCore,
+    baseIndex: number,
+    sourcePlayerId: string,
+) {
+    const base = state.bases[baseIndex];
+    if (!base) return [createSkipOption()];
+
+    const destroyThreshold = base.minions.length + countTitansOnBase(state, baseIndex);
+    const targets = base.minions.filter(m => getMinionPower(state, m, baseIndex) < destroyThreshold);
+    const options = targets.map(target => {
+        const def = getCardDef(target.defId) as MinionCardDef | undefined;
+        const power = getMinionPower(state, target, baseIndex);
+        return {
+            uid: target.uid,
+            defId: target.defId,
+            baseIndex,
+            label: (def?.name ?? target.defId) + ' (力量 ' + power + ')',
+        };
+    });
+
+    const minionOptions = buildMinionTargetOptions(options, {
+        state,
+        sourcePlayerId,
+        effectType: 'destroy',
+    });
+    minionOptions.push(createSkipOption());
+    return minionOptions;
+}
+
+function createTricksterGnomePodInteraction(
+    state: SmashUpCore,
+    pending: TricksterGnomePodPending,
+    remaining: TricksterGnomePodPending[],
+    now: number,
+) {
+    const base = state.bases[pending.baseIndex];
+    if (!base?.minions.some(m => m.uid === pending.gnomeUid && m.defId === 'trickster_gnome_pod')) {
+        return null;
+    }
+
+    const options = buildTricksterGnomePodOptions(state, pending.baseIndex, pending.controller);
+    if (options.length === 1 && (options[0].value as any)?.skip) {
+        return null;
+    }
+
+    const interaction = createSimpleChoice(
+        `trickster_gnome_pod_${pending.gnomeUid}_${now}`,
+        pending.controller,
+        '侏儒：你可以消灭此基地一个力量低于这里随从与泰坦总数的随从',
+        options as any[],
+        { sourceId: 'trickster_gnome_pod', targetType: 'minion', autoResolveIfSingle: false },
+    );
+    (interaction.data as any).continuationContext = {
+        baseIndex: pending.baseIndex,
+        gnomeUid: pending.gnomeUid,
+        controller: pending.controller,
+        remaining,
+    };
+    (interaction.data as any).optionsGenerator = (nextState: MatchState<SmashUpCore>, data: any) => {
+        const continuation = data?.continuationContext as TricksterGnomePodPending & { remaining?: TricksterGnomePodPending[] } | undefined;
+        if (!continuation) return [createSkipOption()];
+        const nextBase = nextState.core.bases[continuation.baseIndex];
+        if (!nextBase?.minions.some(m => m.uid === continuation.gnomeUid && m.defId === 'trickster_gnome_pod')) {
+            return [createSkipOption()];
+        }
+        return buildTricksterGnomePodOptions(nextState.core, continuation.baseIndex, continuation.controller);
+    };
+    return interaction;
+}
+
+function queueNextTricksterGnomePodInteraction(
+    matchState: MatchState<SmashUpCore>,
+    pendingList: TricksterGnomePodPending[],
+    now: number,
+): MatchState<SmashUpCore> | undefined {
+    for (let index = 0; index < pendingList.length; index++) {
+        const pending = pendingList[index];
+        const remaining = pendingList.slice(index + 1);
+        const interaction = createTricksterGnomePodInteraction(matchState.core, pending, remaining, now);
+        if (!interaction) continue;
+        return queueInteraction(matchState, interaction);
+    }
+    return undefined;
+}
+
+/**
+ * 渚忓剴 POD beforeScoring锛?
+ * 鍦ㄥ熀鍦拌鍒嗗墠锛屼綘鍙互娑堢伃姝ゅ熀鍦颁竴涓姏閲忎綆浜庤繖閲岄殢浠庡拰娉板潶鎬绘暟鐨勯殢浠庛€?
+ * 杩欐槸鍦轰笂鑷姩瑙﹀彂鐨?beforeScoring 浜や簰锛屼笉搴旂户鎵垮熀纭€鐗堢殑 onPlay 閫昏緫銆?
+ */
+function tricksterGnomePodBeforeScoring(ctx: TriggerContext): TriggerResult {
+    if (ctx.baseIndex === undefined || !ctx.matchState) return { events: [] };
+
+    const base = ctx.state.bases[ctx.baseIndex];
+    if (!base) return { events: [] };
+
+    const pending = base.minions
+        .filter(m => m.defId === 'trickster_gnome_pod')
+        .map(m => ({ gnomeUid: m.uid, controller: m.controller, baseIndex: ctx.baseIndex! }));
+    if (pending.length === 0) return { events: [] };
+
+    const nextState = queueNextTricksterGnomePodInteraction(ctx.matchState, pending, ctx.now);
+    return nextState ? { events: [], matchState: nextState } : { events: [] };
+}
+
+function tricksterGnomePodOnPlay(): AbilityResult {
+    // POD 鐗堜緩鍎掔殑鐪熷疄鏁堟灉鍦?beforeScoring trigger 涓鐞嗐€?
+    // 杩欓噷鏄惧紡娉ㄥ唽绌?onPlay锛岄樆姝㈣嚜鍔ㄥ埆鍚嶆妸鍩虹鐗堝叆鍦烘晥鏋滈敊璇鍒惰繃鏉ャ€?
+    return { events: [] };
+}
+
+/** 甯﹁蛋瀹濈墿 onPlay锛氭瘡涓叾浠栫帺瀹堕殢鏈哄純涓ゅ紶鎵嬬墝 */
 function tricksterTakeTheShinies(ctx: AbilityContext): AbilityResult {
     const events: SmashUpEvent[] = [];
     for (const pid of ctx.state.turnOrder) {
@@ -78,7 +271,7 @@ function tricksterTakeTheShinies(ctx: AbilityContext): AbilityResult {
         const player = ctx.state.players[pid];
         if (player.hand.length === 0) continue;
 
-        // 随机选择至多2?
+        // 闅忔満閫夋嫨鑷冲2?
         const handCopy = [...player.hand];
         const discardUids: string[] = [];
         const count = Math.min(2, handCopy.length);
@@ -98,22 +291,22 @@ function tricksterTakeTheShinies(ctx: AbilityContext): AbilityResult {
     return { events };
 }
 
-/** 幻想破碎 onPlay：消灭一个已打出到随从或基地上的行动?*/
+/** 骞绘兂鐮寸 onPlay锛氭秷鐏竴涓凡鎵撳嚭鍒伴殢浠庢垨鍩哄湴涓婄殑琛屽姩?*/
 function tricksterDisenchant(ctx: AbilityContext): AbilityResult {
-    // 收集所有已打出的持续行动卡（描述无"对手"限定，包含自己的）
+    // 鏀堕泦鎵€鏈夊凡鎵撳嚭鐨勬寔缁鍔ㄥ崱锛堟弿杩版棤"瀵规墜"闄愬畾锛屽寘鍚嚜宸辩殑锛?
     const targets: { uid: string; defId: string; ownerId: string; label: string }[] = [];
     for (let i = 0; i < ctx.state.bases.length; i++) {
         const base = ctx.state.bases[i];
         for (const ongoing of base.ongoingActions) {
             const def = getCardDef(ongoing.defId);
             const name = def?.name ?? ongoing.defId;
-            targets.push({ uid: ongoing.uid, defId: ongoing.defId, ownerId: ongoing.ownerId, label: `${name} (基地行动)` });
+            targets.push({ uid: ongoing.uid, defId: ongoing.defId, ownerId: ongoing.ownerId, label: `${name} (鍩哄湴琛屽姩)` });
         }
         for (const m of base.minions) {
             for (const attached of m.attachedActions) {
                 const def = getCardDef(attached.defId);
                 const name = def?.name ?? attached.defId;
-                targets.push({ uid: attached.uid, defId: attached.defId, ownerId: attached.ownerId, label: `${name} (附着行动)` });
+                targets.push({ uid: attached.uid, defId: attached.defId, ownerId: attached.ownerId, label: `${name} (闄勭潃琛屽姩)` });
             }
         }
     }
@@ -130,9 +323,9 @@ function tricksterDisenchant(ctx: AbilityContext): AbilityResult {
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
 }
 
-/** 隐蔽迷雾 onPlay：打出当回合给予额外随从（与大法师同理，ongoing 能力在进入场上时生效） */
+/** 闅愯斀杩烽浘 onPlay锛氭墦鍑哄綋鍥炲悎缁欎簣棰濆闅忎粠锛堜笌澶ф硶甯堝悓鐞嗭紝ongoing 鑳藉姏鍦ㄨ繘鍏ュ満涓婃椂鐢熸晥锛?*/
 function tricksterEnshroudingMistOnPlay(ctx: AbilityContext): AbilityResult {
-    // 打出当回合立即给予额外随从（限定到此基地）
+    // 鎵撳嚭褰撳洖鍚堢珛鍗崇粰浜堥澶栭殢浠庯紙闄愬畾鍒版鍩哄湴锛?
     return {
         events: [{
             type: SU_EVENTS.LIMIT_MODIFIED,
@@ -148,23 +341,25 @@ function tricksterEnshroudingMistOnPlay(ctx: AbilityContext): AbilityResult {
     };
 }
 
-/** 注册诡术师派系所有能力*/
+/** 注册诡术师派系所有能力 */
 export function registerTricksterAbilities(): void {
     registerAbility('trickster_gnome', 'onPlay', tricksterGnome);
-    // 带走宝物（行动卡）：每个对手随机弃两张手牌
+    registerAbility('trickster_gnome_pod', 'onPlay', tricksterGnomePodOnPlay);
+    // 甯﹁蛋瀹濈墿锛堣鍔ㄥ崱锛夛細姣忎釜瀵规墜闅忔満寮冧袱寮犳墜鐗?
     registerAbility('trickster_take_the_shinies', 'onPlay', tricksterTakeTheShinies);
-    // 幻想破碎（行动卡）：消灭一个已打出的行动卡
+    // 骞绘兂鐮寸锛堣鍔ㄥ崱锛夛細娑堢伃涓€涓凡鎵撳嚭鐨勮鍔ㄥ崱
     registerAbility('trickster_disenchant', 'onPlay', tricksterDisenchant);
-    // 小妖精?onDestroy：被消灭后抽1张牌 + 对手随机?张牌
+    // 灏忓绮?onDestroy锛氳娑堢伃鍚庢娊1寮犵墝 + 瀵规墜闅忔満?寮犵墝
     registerAbility('trickster_gremlin', 'onDestroy', tricksterGremlinOnDestroy);
-    // 沉睡印记（行动卡）：对手下回合不能打行动
+    // 娌夌潯鍗拌锛堣鍔ㄥ崱锛夛細瀵规墜涓嬪洖鍚堜笉鑳芥墦琛屽姩
     registerAbility('trickster_mark_of_sleep', 'onPlay', tricksterMarkOfSleep);
-    // 封路（ongoing）：打出时选择一个派系
+    registerAbility('trickster_mark_of_sleep_pod', 'onPlay', tricksterMarkOfSleepPod);
+    // 灏佽矾锛坥ngoing锛夛細鎵撳嚭鏃堕€夋嫨涓€涓淳绯?
     registerAbility('trickster_block_the_path', 'onPlay', tricksterBlockThePath);
-    // 隐蔽迷雾（ongoing）：打出当回合也给予额外随从（与大法师同理）
+    // 闅愯斀杩烽浘锛坥ngoing锛夛細鎵撳嚭褰撳洖鍚堜篃缁欎簣棰濆闅忎粠锛堜笌澶ф硶甯堝悓鐞嗭級
     registerAbility('trickster_enshrouding_mist', 'onPlay', tricksterEnshroudingMistOnPlay);
 
-    // 注册 ongoing 拦截?
+    // 娉ㄥ唽 ongoing 鎷︽埅?
     registerTricksterOngoingEffects();
     registerTricksterPodAbilities();
 }
@@ -198,14 +393,14 @@ function tricksterGnomePodSpecial(ctx: AbilityContext): AbilityResult {
         const def = getCardDef(t.defId) as MinionCardDef | undefined;
         const name = def?.name ?? t.defId;
         const power = getMinionPower(ctx.state, t, ctx.baseIndex);
-        return { uid: t.uid, defId: t.defId, baseIndex: ctx.baseIndex, label: `${name} (力量 ${power})` };
+        return { uid: t.uid, defId: t.defId, baseIndex: ctx.baseIndex, label: name + ' (力量 ' + power + ')' };
     });
     const minionOptions = buildMinionTargetOptions(options, { state: ctx.state, sourcePlayerId: ctx.playerId, effectType: 'destroy' });
     minionOptions.push(createSkipOption());
 
     return resolveOrPrompt(ctx, minionOptions, {
         id: 'trickster_gnome_pod',
-        title: '侏儒：你可以消灭这里一个力量低于你在此基地随从数量的随从（或跳过）',
+        title: '渚忓剴锛氫綘鍙互娑堢伃杩欓噷涓€涓姏閲忎綆浜庝綘鍦ㄦ鍩哄湴闅忎粠鏁伴噺鐨勯殢浠庯紙鎴栬烦杩囷級',
         sourceId: 'trickster_gnome_pod',
         targetType: 'minion',
         autoResolveIfSingle: false,
@@ -225,9 +420,10 @@ function registerTricksterPodAbilities(): void {
     registerAbility('trickster_pixie_pod', 'onPlay', tricksterPixiePodOnPlay);
     registerAbility('trickster_enshrouding_mist_pod', 'talent', tricksterEnshroudingMistPodTalent);
     registerAbility('trickster_hideout_pod', 'talent', tricksterHideoutPodTalent);
-    registerAbility('trickster_gnome_pod', 'special', tricksterGnomePodSpecial);
+    registerAbility('trickster_gnome_pod', 'onPlay', tricksterGnomePodOnPlay);
     registerAbility('trickster_gremlin_pod', 'onDestroy', () => ({ events: [] }));
     registerTricksterPodOngoingEffects();
+    registerTrigger('trickster_gnome_pod', 'beforeScoring', tricksterGnomePodBeforeScoring);
 }
 
 function tricksterHideoutPodTalent(ctx: AbilityContext): AbilityResult {
@@ -278,7 +474,7 @@ function tricksterHideoutPodTalent(ctx: AbilityContext): AbilityResult {
     const interaction = createSimpleChoice(
         `trickster_hideout_pod_swap_${ctx.now}`,
         ctx.playerId,
-        '藏身处：选择要交换进来的“打出到基地上”的持续战术（或跳过）',
+        '藏身处：选择要交换进来的基地持续战术（或跳过）',
         options as any[],
         { sourceId: 'trickster_hideout_pod_swap', targetType: 'generic' },
     );
@@ -291,11 +487,11 @@ function tricksterHideoutPodTalent(ctx: AbilityContext): AbilityResult {
     };
 }
 
-/** 注册诡术师派系的交互解决处理函数 */
+/** 娉ㄥ唽璇℃湳甯堟淳绯荤殑浜や簰瑙ｅ喅澶勭悊鍑芥暟 */
 export function registerTricksterInteractionHandlers(): void {
-    // 侏儒：选择目标后消灭（支持跳过）
+    // 渚忓剴锛氶€夋嫨鐩爣鍚庢秷鐏紙鏀寔璺宠繃锛?
     registerInteractionHandler('trickster_gnome', (state, playerId, value, _iData, _random, timestamp) => {
-        // 统一检查 skip 标记
+        // 缁熶竴妫€鏌?skip 鏍囪
         if ((value as any).skip) return { state, events: [] };
         
         const { minionUid, baseIndex } = value as { minionUid?: string; baseIndex?: number };
@@ -308,19 +504,41 @@ export function registerTricksterInteractionHandlers(): void {
         return { state, events: [destroyMinion(target.uid, target.defId, baseIndex, target.owner, playerId, 'trickster_gnome', timestamp)] };
     });
 
-    // 幻想破碎：选择行动卡后消灭
+    registerInteractionHandler('trickster_gnome_pod', (state, playerId, value, iData, _random, timestamp) => {
+        const continuation = iData?.continuationContext as {
+            baseIndex?: number;
+            remaining?: TricksterGnomePodPending[];
+        } | undefined;
+        const baseIndex = (value as { baseIndex?: number } | undefined)?.baseIndex ?? continuation?.baseIndex;
+        const selectedUid = (value as { minionUid?: string } | undefined)?.minionUid;
+        const events: SmashUpEvent[] = [];
+
+        if (!(value as any)?.skip && selectedUid && baseIndex !== undefined) {
+            const base = state.core.bases[baseIndex];
+            const target = base?.minions.find(m => m.uid === selectedUid);
+            if (target) {
+                events.push(destroyMinion(target.uid, target.defId, baseIndex, target.owner, playerId, 'trickster_gnome_pod', timestamp));
+            }
+        }
+
+        const remaining = (continuation?.remaining ?? []).filter(entry => entry.gnomeUid !== selectedUid);
+        const nextState = queueNextTricksterGnomePodInteraction(state, remaining, timestamp);
+        return { state: nextState ?? state, events };
+    });
+
+    // 骞绘兂鐮寸锛氶€夋嫨琛屽姩鍗″悗娑堢伃
     registerInteractionHandler('trickster_disenchant', (state, _playerId, value, _iData, _random, timestamp) => {
         const { cardUid: ongoingUid, defId, ownerId } = value as { cardUid: string; defId: string; ownerId: string };
         return { state, events: [{ type: SU_EVENTS.ONGOING_DETACHED, payload: { cardUid: ongoingUid, defId, ownerId, reason: 'trickster_disenchant' }, timestamp }] };
     });
 
-    // 沉睡印记：选择对手后标记（下回合生效）
+    // 娌夌潯鍗拌锛氶€夋嫨瀵规墜鍚庢爣璁帮紙涓嬪洖鍚堢敓鏁堬級
     registerInteractionHandler('trickster_mark_of_sleep', (state, _playerId, value, _iData, _random, _timestamp) => {
-        // 检查取消标记
+        // 妫€鏌ュ彇娑堟爣璁?
         if ((value as any).__cancel__) return { state, events: [] };
         
         const { pid } = value as { pid: string };
-        // 添加沉睡标记，在对手的下一个回合开始时生效
+        // 娣诲姞娌夌潯鏍囪锛屽湪瀵规墜鐨勪笅涓€涓洖鍚堝紑濮嬫椂鐢熸晥
         const currentMarked = state.core.sleepMarkedPlayers ?? [];
         if (currentMarked.includes(pid)) return { state, events: [] };
         return {
@@ -329,15 +547,59 @@ export function registerTricksterInteractionHandlers(): void {
         };
     });
 
-    // 封路：选择派系后，将派系信息存入 ongoing 的 metadata
+    registerInteractionHandler('trickster_mark_of_sleep_pod', (state, _playerId, value, iData, _random, timestamp) => {
+        const continuation = (iData as any)?.continuationContext as TricksterMarkOfSleepPodContext | undefined;
+        const restrictionType = (value as TricksterMarkOfSleepPodChoiceValue | undefined)?.restrictionType;
+        if (!continuation?.targetPlayerId || !continuation.sourcePlayerId || !restrictionType) {
+            return { state, events: [] };
+        }
+
+        const nextRestrictions = [
+            ...(state.core.playerRestrictionsUntilTurnStart ?? []).filter(entry => !(
+                entry.sourcePlayerId === continuation.sourcePlayerId
+                && entry.targetPlayerId === continuation.targetPlayerId
+                && entry.restrictionType === restrictionType
+            )),
+            {
+                sourcePlayerId: continuation.sourcePlayerId,
+                targetPlayerId: continuation.targetPlayerId,
+                restrictionType,
+            },
+        ];
+
+        let nextState: MatchState<SmashUpCore> = {
+            ...state,
+            core: {
+                ...state.core,
+                playerRestrictionsUntilTurnStart: nextRestrictions,
+            },
+        };
+
+        const [nextTargetPlayerId, ...remainingTargetPlayerIds] = continuation.remainingTargetPlayerIds;
+        if (nextTargetPlayerId) {
+            nextState = queueInteraction(
+                nextState,
+                createTricksterMarkOfSleepPodInteraction(
+                    continuation.sourcePlayerId,
+                    nextTargetPlayerId,
+                    remainingTargetPlayerIds,
+                    timestamp,
+                ),
+            );
+        }
+
+        return { state: nextState, events: [] };
+    });
+
+    // 灏佽矾锛氶€夋嫨娲剧郴鍚庯紝灏嗘淳绯讳俊鎭瓨鍏?ongoing 鐨?metadata
     registerInteractionHandler('trickster_block_the_path', (state, _playerId, value, iData, _random, _timestamp) => {
-        // 检查取消标记
+        // 妫€鏌ュ彇娑堟爣璁?
         if ((value as any).__cancel__) return { state, events: [] };
         
         const { factionId } = value as { factionId: string };
         const ctx = (iData as any)?.continuationContext as { cardUid: string; baseIndex: number };
         if (!ctx) return undefined;
-        // 找到刚附着的 ongoing 并更新 metadata
+        // 鎵惧埌鍒氶檮鐫€鐨?ongoing 骞舵洿鏂?metadata
         const newBases = state.core.bases.map((base, i) => {
             if (i !== ctx.baseIndex) return base;
             return {
@@ -349,26 +611,6 @@ export function registerTricksterInteractionHandlers(): void {
             };
         });
         return { state: { ...state, core: { ...state.core, bases: newBases } }, events: [] };
-    });
-
-    // POD 沉睡印记：一次性写入 noActions / noMove 标记，持续到施放者下回合开始
-    registerInteractionHandler('trickster_mark_of_sleep_pod', (state, playerId, value, _iData, _random, _timestamp) => {
-        if ((value as any).__cancel__) return { state, events: [] };
-        const { noActions, noMove } = value as { noActions: string[]; noMove: string[] };
-        const expiresOnTurnNumber = state.core.turnNumber + state.core.turnOrder.length;
-
-        return {
-            state: {
-                ...state,
-                core: {
-                    ...state.core,
-                    sleepMarkedPlayers: noActions.length ? noActions : undefined,
-                    sleepMoveMarkedPlayers: noMove.length ? noMove : undefined,
-                    sleepMarkExpiresOnTurnNumber: expiresOnTurnNumber,
-                } as any,
-            },
-            events: [],
-        };
     });
 
     // Pixie（战术）：先消灭一张已打出的战术，再选择 1-2 个己方随从分配两枚 +1 指示物
@@ -384,7 +626,7 @@ export function registerTricksterInteractionHandlers(): void {
                 const def = getCardDef(m.defId) as MinionCardDef | undefined;
                 const name = def?.name ?? m.defId;
                 const power = getMinionPower(state.core, m, bi);
-                myMinions.push({ uid: m.uid, defId: m.defId, baseIndex: bi, label: `${name} (力量 ${power})` });
+                myMinions.push({ uid: m.uid, defId: m.defId, baseIndex: bi, label: name + ' (力量 ' + power + ')' });
             }
         }
         if (myMinions.length === 0) {
@@ -467,7 +709,7 @@ export function registerTricksterInteractionHandlers(): void {
     registerInteractionHandler('trickster_flame_trap_pod_bp', (state, _playerId, value, _iData, _random, timestamp) => {
         const yes = (value as any)?.yes === true;
         if (!yes) return { state, events: [] };
-        // 选择窗口只会在拥有者回合开始时出现，因此直接定位该拥有者的第一张 trap
+        // 閫夋嫨绐楀彛鍙細鍦ㄦ嫢鏈夎€呭洖鍚堝紑濮嬫椂鍑虹幇锛屽洜姝ょ洿鎺ュ畾浣嶈鎷ユ湁鑰呯殑绗竴寮?trap
         const baseIndex = state.core.bases.findIndex(b => b.ongoingActions.some(o => o.defId === 'trickster_flame_trap_pod'));
         if (baseIndex < 0) return { state, events: [] };
         return {
@@ -513,14 +755,14 @@ export function registerTricksterInteractionHandlers(): void {
         const player = state.core.players[playerId];
         if (!player) return undefined;
 
-        // 1) 从手牌/牌库移除目标战术
+        // 1) 浠庢墜鐗?鐗屽簱绉婚櫎鐩爣鎴樻湳
         const fromHand = zone === 'hand' ? player.hand.filter(c => c.uid !== cardUid) : player.hand;
         const fromDeck = zone === 'deck' ? player.deck.filter(c => c.uid !== cardUid) : player.deck;
 
-        // 2) 藏身处从基地离场进手牌（swap 的另一半）
+        // 2) 钘忚韩澶勪粠鍩哄湴绂诲満杩涙墜鐗岋紙swap 鐨勫彟涓€鍗婏級
         const hideoutCard: CardInstance = { uid: hideout.uid, defId: hideout.defId, type: 'action', owner: hideout.ownerId };
 
-        // 3) 目标战术进入基地 ongoingActions（保持 cardUid）
+        // 3) 鐩爣鎴樻湳杩涘叆鍩哄湴 ongoingActions锛堜繚鎸?cardUid锛?
         const newOngoing = { uid: cardUid, defId, ownerId: playerId, talentUsed: false };
 
         const newBases = state.core.bases.map((b, i) => {
@@ -550,7 +792,7 @@ export function registerTricksterInteractionHandlers(): void {
             },
         };
 
-        // 4) 交换后：你可以消灭这里一个战斗力≤2的随从（可选）
+        // 4) 浜ゆ崲鍚庯細浣犲彲浠ユ秷鐏繖閲屼竴涓垬鏂楀姏鈮?鐨勯殢浠庯紙鍙€夛級
         const updatedBase = nextState.core.bases[ctx.baseIndex];
         const candidates = updatedBase.minions.filter(m => getMinionPower(nextState.core, m, ctx.baseIndex) <= 2);
         if (candidates.length === 0) return { state: nextState, events: [] };
@@ -558,14 +800,14 @@ export function registerTricksterInteractionHandlers(): void {
             const mDef = getCardDef(m.defId) as MinionCardDef | undefined;
             const name = mDef?.name ?? m.defId;
             const power = getMinionPower(nextState.core, m, ctx.baseIndex);
-            return { id: `m-${i}`, label: `${name} (战斗力 ${power})`, value: { minionUid: m.uid, minionDefId: m.defId, baseIndex: ctx.baseIndex }, _source: 'field' as const, displayMode: 'card' as const };
+            return { id: 'm-' + i, label: name + ' (战斗力 ' + power + ')', value: { minionUid: m.uid, minionDefId: m.defId, baseIndex: ctx.baseIndex }, _source: 'field' as const, displayMode: 'card' as const };
         });
         options.push(createSkipOption() as any);
 
         const prompt = createSimpleChoice(
             `trickster_hideout_pod_destroy_${timestamp}`,
             playerId,
-            '藏身处：你可以消灭这里一个战斗力≤2的随从（或跳过）',
+            '钘忚韩澶勶細浣犲彲浠ユ秷鐏繖閲屼竴涓垬鏂楀姏鈮?鐨勯殢浠庯紙鎴栬烦杩囷級',
             options as any[],
             { sourceId: 'trickster_hideout_pod_destroy', targetType: 'minion' },
         );
@@ -585,16 +827,31 @@ export function registerTricksterInteractionHandlers(): void {
             events: [destroyMinion(target.uid, target.defId, baseIndex, target.owner, playerId, 'trickster_hideout_pod', timestamp)],
         };
     });
+
+    registerInteractionHandler('trickster_pay_the_piper', (state, playerId, value, _iData, _random, timestamp) => {
+        const { cardUid } = value as Partial<PayThePiperChoiceValue>;
+        if (!cardUid) return { state, events: [] };
+        const player = state.core.players[playerId];
+        if (!player?.hand.some(card => card.uid === cardUid)) return { state, events: [] };
+        return {
+            state,
+            events: [{
+                type: SU_EVENTS.CARDS_DISCARDED,
+                payload: { playerId, cardUids: [cardUid] },
+                timestamp,
+            }],
+        };
+    });
 }
 
-/** 小妖精?onDestroy：被消灭后抽1张牌 + 每个对手随机?张牌 */
+/** 灏忓绮?onDestroy锛氳娑堢伃鍚庢娊1寮犵墝 + 姣忎釜瀵规墜闅忔満?寮犵墝 */
 function tricksterGremlinOnDestroy(ctx: AbilityContext): AbilityResult {
     const events: SmashUpEvent[] = [];
 
-    // ?张牌
+    // ?寮犵墝
     events.push(...buildStandardDrawEvents(ctx.state, ctx.playerId, 1, ctx.random, ctx.now));
 
-    // 每个对手随机?张牌
+    // 姣忎釜瀵规墜闅忔満?寮犵墝
     for (const pid of ctx.state.turnOrder) {
         if (pid === ctx.playerId) continue;
         const opponent = ctx.state.players[pid];
@@ -611,9 +868,9 @@ function tricksterGremlinOnDestroy(ctx: AbilityContext): AbilityResult {
     return { events };
 }
 
-/** 封路 onPlay（ongoing）：选择一个派系，该派系随从不能被打出到此基地 */
+/** 灏佽矾 onPlay锛坥ngoing锛夛細閫夋嫨涓€涓淳绯伙紝璇ユ淳绯婚殢浠庝笉鑳借鎵撳嚭鍒版鍩哄湴 */
 function tricksterBlockThePath(ctx: AbilityContext): AbilityResult {
-    // 收集场上所有派系
+    // 鏀堕泦鍦轰笂鎵€鏈夋淳绯?
     const factionSet = new Set<string>();
     for (const base of ctx.state.bases) {
         for (const m of base.minions) {
@@ -621,7 +878,7 @@ function tricksterBlockThePath(ctx: AbilityContext): AbilityResult {
             if (def?.faction) factionSet.add(def.faction);
         }
     }
-    // 也从所有玩家手牌中收集派系
+    // 涔熶粠鎵€鏈夌帺瀹舵墜鐗屼腑鏀堕泦娲剧郴
     for (const pid of ctx.state.turnOrder) {
         const player = ctx.state.players[pid];
         for (const c of player.hand) {
@@ -641,9 +898,9 @@ function tricksterBlockThePath(ctx: AbilityContext): AbilityResult {
     return { events: [], matchState: queueInteraction(ctx.matchState, { ...interaction, data: { ...interaction.data, continuationContext: { cardUid: ctx.cardUid, baseIndex: ctx.baseIndex } } }) };
 }
 
-/** 沉睡印记 onPlay：选择一个对手，其下回合不能打行动卡 */
+/** 娌夌潯鍗拌 onPlay锛氶€夋嫨涓€涓鎵嬶紝鍏朵笅鍥炲悎涓嶈兘鎵撹鍔ㄥ崱 */
 function tricksterMarkOfSleep(ctx: AbilityContext): AbilityResult {
-    // 可以选择任何玩家（包括自己）
+    // 鍙互閫夋嫨浠讳綍鐜╁锛堝寘鎷嚜宸憋級
     const allPlayers = ctx.state.turnOrder;
     const options = allPlayers.map((pid, i) => ({
         id: `player-${i}`, 
@@ -658,55 +915,34 @@ function tricksterMarkOfSleep(ctx: AbilityContext): AbilityResult {
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
 }
 
-/** POD 沉睡印记：对每个其他玩家分别选择“不能打出战术”或“不能移动随从”，持续到你下回合开始 */
+/** 睡眠印记 POD onPlay：为每个其他玩家分别选择“不能打出战术”或“不能移动随从” */
 function tricksterMarkOfSleepPod(ctx: AbilityContext): AbilityResult {
     const otherPlayers = ctx.state.turnOrder.filter(pid => pid !== ctx.playerId);
-    if (otherPlayers.length === 0) return { events: [] };
-
-    // 组合选项：每位对手二选一（最多 3 位对手 → 8 种组合）
-    const combos: { noActions: string[]; noMove: string[]; label: string }[] = [];
-    const total = 1 << otherPlayers.length;
-    for (let mask = 0; mask < total; mask++) {
-        const noActions: string[] = [];
-        const noMove: string[] = [];
-        const parts: string[] = [];
-        for (let i = 0; i < otherPlayers.length; i++) {
-            const pid = otherPlayers[i];
-            const pickNoActions = ((mask >> i) & 1) === 1;
-            if (pickNoActions) {
-                noActions.push(pid);
-                parts.push(`${getOpponentLabel(pid)}：不能打战术`);
-            } else {
-                noMove.push(pid);
-                parts.push(`${getOpponentLabel(pid)}：不能移动随从`);
-            }
-        }
-        combos.push({ noActions, noMove, label: parts.join('；') });
+    if (otherPlayers.length === 0) {
+        return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.no_valid_targets', ctx.now)] };
     }
 
-    const options = combos.map((c, i) => ({
-        id: `combo-${i}`,
-        label: c.label,
-        value: { noActions: c.noActions, noMove: c.noMove },
-    }));
-    const interaction = createSimpleChoice(
-        `trickster_mark_of_sleep_pod_${ctx.now}`,
-        ctx.playerId,
-        '睡眠印记：为每个对手选择限制（持续到你下回合开始）',
-        options as any[],
-        { sourceId: 'trickster_mark_of_sleep_pod', targetType: 'player', autoCancelOption: true },
-    );
-    return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
+    const [firstTargetPlayerId, ...remainingTargetPlayerIds] = otherPlayers;
+    return {
+        events: [],
+        matchState: queueInteraction(
+            ctx.matchState,
+            createTricksterMarkOfSleepPodInteraction(
+                ctx.playerId,
+                firstTargetPlayerId,
+                remainingTargetPlayerIds,
+                ctx.now,
+            ),
+        ),
+    };
 }
 
 function tricksterPixiePodOnPlay(ctx: AbilityContext): AbilityResult {
     const base = ctx.state.bases[ctx.baseIndex];
     if (!base) return { events: [] };
 
-    // 判定当前 pixie 是否作为随从在该基地上（融合卡：通过 uid 在 minions 中存在来区分）
     const isPixieMinion = base.minions.some(m => m.uid === ctx.cardUid);
     if (isPixieMinion) {
-        // 条件：手牌张数 > 至少一名其他玩家
         const me = ctx.state.players[ctx.playerId];
         if (!me) return { events: [] };
         const myHand = me.hand.length;
@@ -731,7 +967,6 @@ function tricksterPixiePodOnPlay(ctx: AbilityContext): AbilityResult {
                 displayMode: 'card' as const,
             };
         });
-        // any number（可 0 张）
         const interaction = createSimpleChoice(
             `trickster_pixie_pod_minion_${ctx.now}`,
             ctx.playerId,
@@ -744,7 +979,6 @@ function tricksterPixiePodOnPlay(ctx: AbilityContext): AbilityResult {
         return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
     }
 
-    // Pixie as action: choose an action in play to destroy, then distribute two +1 counters among your minions
     const targets: { uid: string; defId: string; ownerId: string; label: string }[] = [];
     for (let bi = 0; bi < ctx.state.bases.length; bi++) {
         const b = ctx.state.bases[bi];
@@ -784,28 +1018,27 @@ function tricksterPixiePodOnPlay(ctx: AbilityContext): AbilityResult {
         }),
     };
 }
-
-// executeMarkOfSleep 已移除，沉睡印记改为标记模式（在对手回合开始时生效）
+// executeMarkOfSleep 宸茬Щ闄わ紝娌夌潯鍗拌鏀逛负鏍囪妯″紡锛堝湪瀵规墜鍥炲悎寮€濮嬫椂鐢熸晥锛?
 
 // ============================================================================
-// Ongoing 拦截器注册?
+// Ongoing 鎷︽埅鍣ㄦ敞鍐?
 // ============================================================================
 
-/** 注册诡术师派系的 ongoing 拦截?*/
+/** 娉ㄥ唽璇℃湳甯堟淳绯荤殑 ongoing 鎷︽埅?*/
 function registerTricksterOngoingEffects(): void {
-    // 小矮妖：其他玩家打出力量更低的随从到同基地时消灭该随从
+    // 灏忕煯濡栵細鍏朵粬鐜╁鎵撳嚭鍔涢噺鏇翠綆鐨勯殢浠庡埌鍚屽熀鍦版椂娑堢伃璇ラ殢浠?
     registerTrigger('trickster_leprechaun', 'onMinionPlayed', (trigCtx) => {
         if (!trigCtx.triggerMinionUid || !trigCtx.triggerMinionDefId || trigCtx.baseIndex === undefined) return [];
-        // 找到 leprechaun 所在基地
+        // 鎵惧埌 leprechaun 鎵€鍦ㄥ熀鍦?
         for (let i = 0; i < trigCtx.state.bases.length; i++) {
             const base = trigCtx.state.bases[i];
             const leprechaun = base.minions.find(m => matchesDefId(m.defId, 'trickster_leprechaun'));
             if (!leprechaun) continue;
-            // 只在同基地触?
+            // 鍙湪鍚屽熀鍦拌Е?
             if (i !== trigCtx.baseIndex) continue;
-            // 只对其他玩家触发
+            // 鍙鍏朵粬鐜╁瑙﹀彂
             if (leprechaun.controller === trigCtx.playerId) continue;
-            // 检查打出的随从力量是否低于 leprechaun
+            // 妫€鏌ユ墦鍑虹殑闅忎粠鍔涢噺鏄惁浣庝簬 leprechaun
             const lepPower = getMinionPower(trigCtx.state, leprechaun, i);
             const triggerMinion = base.minions.find(m => m.uid === trigCtx.triggerMinionUid);
             if (!triggerMinion) continue;
@@ -827,13 +1060,13 @@ function registerTricksterOngoingEffects(): void {
         return [];
     });
 
-    // 布朗尼：被对手卡牌效果影响时，对手弃两张牌
-    // "影响"包含：消灭、移动、负力量修改、附着对手行动卡（规则术语映射）
+    // 甯冩湕灏硷細琚鎵嬪崱鐗屾晥鏋滃奖鍝嶆椂锛屽鎵嬪純涓ゅ紶鐗?
+    // "褰卞搷"鍖呭惈锛氭秷鐏€佺Щ鍔ㄣ€佽礋鍔涢噺淇敼銆侀檮鐫€瀵规墜琛屽姩鍗★紙瑙勫垯鏈鏄犲皠锛?
     registerTrigger('trickster_brownie', 'onMinionAffected', (trigCtx) => {
         if (trigCtx.triggerMinionDefId !== 'trickster_brownie') return [];
         const brownieOwner = trigCtx.triggerMinion?.controller;
         if (!brownieOwner || brownieOwner === trigCtx.playerId) return [];
-        // 对手（触发影响的玩家）弃两张牌
+        // 瀵规墜锛堣Е鍙戝奖鍝嶇殑鐜╁锛夊純涓ゅ紶鐗?
         const opponent = trigCtx.state.players[trigCtx.playerId];
         if (!opponent || opponent.hand.length === 0) return [];
         const discardCount = Math.min(2, opponent.hand.length);
@@ -851,13 +1084,13 @@ function registerTricksterOngoingEffects(): void {
         }];
     });
 
-    // 迷雾笼罩：此基地上可额外打出一个随从到此基地（回合开始时给基地限定额度）
+    // 杩烽浘绗肩僵锛氭鍩哄湴涓婂彲棰濆鎵撳嚭涓€涓殢浠庡埌姝ゅ熀鍦帮紙鍥炲悎寮€濮嬫椂缁欏熀鍦伴檺瀹氶搴︼級
     registerTrigger('trickster_enshrouding_mist', 'onTurnStart', (trigCtx) => {
         for (let bi = 0; bi < trigCtx.state.bases.length; bi++) {
             const base = trigCtx.state.bases[bi];
             const mist = base.ongoingActions.find(o => matchesDefId(o.defId, 'trickster_enshrouding_mist'));
             if (!mist) continue;
-            // 只在拥有者的回合触发
+            // 鍙湪鎷ユ湁鑰呯殑鍥炲悎瑙﹀彂
             if (mist.ownerId !== trigCtx.playerId) continue;
             return [{
                 type: SU_EVENTS.LIMIT_MODIFIED,
@@ -874,35 +1107,35 @@ function registerTricksterOngoingEffects(): void {
         return [];
     });
 
-    // 藏身处：保护同基地己方随从不受对手行动卡影响（消耗型：触发后自毁）
+    // 钘忚韩澶勶細淇濇姢鍚屽熀鍦板繁鏂归殢浠庝笉鍙楀鎵嬭鍔ㄥ崱褰卞搷锛堟秷鑰楀瀷锛氳Е鍙戝悗鑷瘉锛?
     registerProtection('trickster_hideout', 'action', (ctx) => {
-        // 检查目标随从是否附着了 hideout（附着在随从上的情况）
+        // 妫€鏌ョ洰鏍囬殢浠庢槸鍚﹂檮鐫€浜?hideout锛堥檮鐫€鍦ㄩ殢浠庝笂鐨勬儏鍐碉級
         const attachedHideout = ctx.targetMinion.attachedActions.find(a => matchesDefId(a.defId, 'trickster_hideout'));
         if (attachedHideout) {
-            // 只保护 Hideout 拥有者的随从，且行动卡来自对手
+            // 鍙繚鎶?Hideout 鎷ユ湁鑰呯殑闅忎粠锛屼笖琛屽姩鍗℃潵鑷鎵?
             return ctx.targetMinion.controller === attachedHideout.ownerId && ctx.sourcePlayerId !== attachedHideout.ownerId;
         }
-        // 也检查基地上的 ongoing（打在基地上的情况）
+        // 涔熸鏌ュ熀鍦颁笂鐨?ongoing锛堟墦鍦ㄥ熀鍦颁笂鐨勬儏鍐碉級
         const base = ctx.state.bases[ctx.targetBaseIndex];
         const baseHideout = base?.ongoingActions.find(o => matchesDefId(o.defId, 'trickster_hideout'));
         if (baseHideout) {
-            // 只保护 Hideout 拥有者的随从，且行动卡来自对手
+            // 鍙繚鎶?Hideout 鎷ユ湁鑰呯殑闅忎粠锛屼笖琛屽姩鍗℃潵鑷鎵?
             return ctx.targetMinion.controller === baseHideout.ownerId && ctx.sourcePlayerId !== baseHideout.ownerId;
         }
         return false;
     }, { consumable: true });
 
-    // 火焰陷阱：其他玩家打出随从到此基地时消灭该随从
+    // 鐏劙闄烽槺锛氬叾浠栫帺瀹舵墦鍑洪殢浠庡埌姝ゅ熀鍦版椂娑堢伃璇ラ殢浠?
     registerTrigger('trickster_flame_trap', 'onMinionPlayed', (trigCtx) => {
         if (!trigCtx.triggerMinionUid || !trigCtx.triggerMinionDefId || trigCtx.baseIndex === undefined) return [];
         for (let i = 0; i < trigCtx.state.bases.length; i++) {
             const base = trigCtx.state.bases[i];
             const trap = base.ongoingActions.find(o => matchesDefId(o.defId, 'trickster_flame_trap'));
             if (!trap || i !== trigCtx.baseIndex) continue;
-            // 只对其他玩家触发
+            // 鍙鍏朵粬鐜╁瑙﹀彂
             if (trap.ownerId === trigCtx.playerId) continue;
             return [
-                // 消灭打出的随从
+                // 娑堢伃鎵撳嚭鐨勯殢浠?
                 {
                     type: SU_EVENTS.MINION_DESTROYED,
                     payload: {
@@ -914,7 +1147,7 @@ function registerTricksterOngoingEffects(): void {
                     },
                     timestamp: trigCtx.now,
                 },
-                // 消灭火焰陷阱本身
+                // 娑堢伃鐏劙闄烽槺鏈韩
                 {
                     type: SU_EVENTS.ONGOING_DETACHED,
                     payload: {
@@ -930,40 +1163,45 @@ function registerTricksterOngoingEffects(): void {
         return [];
     });
 
-    // 封路：指定派系不能打出随从到此基地（描述无"对手"限定，对所有玩家生效）
+    // 灏佽矾锛氭寚瀹氭淳绯讳笉鑳芥墦鍑洪殢浠庡埌姝ゅ熀鍦帮紙鎻忚堪鏃?瀵规墜"闄愬畾锛屽鎵€鏈夌帺瀹剁敓鏁堬級
     registerRestriction('trickster_block_the_path', 'play_minion', (ctx) => {
         const base = ctx.state.bases[ctx.baseIndex];
         if (!base) return false;
         const blockAction = base.ongoingActions.find(o => matchesDefId(o.defId, 'trickster_block_the_path'));
         if (!blockAction) return false;
-        // 检查被限制的派系
+        // 妫€鏌ヨ闄愬埗鐨勬淳绯?
         const blockedFaction = blockAction.metadata?.blockedFaction as string | undefined;
         if (!blockedFaction) return false;
-        // 检查打出的随从是否属于被限制的派系
+        // 妫€鏌ユ墦鍑虹殑闅忎粠鏄惁灞炰簬琚檺鍒剁殑娲剧郴
         const minionDefId = ctx.extra?.minionDefId as string | undefined;
         if (!minionDefId) return false;
         const def = getCardDef(minionDefId);
         return def?.faction === blockedFaction;
     });
 
-    // 付笛手的钱：对手打出随从后弃一张牌
+    // 浠樼瑳鎵嬬殑閽憋細瀵规墜鎵撳嚭闅忎粠鍚庡純涓€寮犵墝
     registerTrigger('trickster_pay_the_piper', 'onMinionPlayed', (trigCtx) => {
         if (!trigCtx.triggerMinionUid || trigCtx.baseIndex === undefined) return [];
         for (let i = 0; i < trigCtx.state.bases.length; i++) {
             const base = trigCtx.state.bases[i];
             const piper = base.ongoingActions.find(o => matchesDefId(o.defId, 'trickster_pay_the_piper'));
             if (!piper || i !== trigCtx.baseIndex) continue;
-            // 只对其他玩家触发
+            // 鍙鍏朵粬鐜╁瑙﹀彂
             if (piper.ownerId === trigCtx.playerId) continue;
-            // 对手随机弃一张牌
+            // 瀵规墜鑷繁閫夋嫨寮冩帀 1 寮犳墜鐗?
             const opponent = trigCtx.state.players[trigCtx.playerId];
             if (!opponent || opponent.hand.length === 0) continue;
-            const idx = Math.floor(trigCtx.random.random() * opponent.hand.length);
-            return [{
-                type: SU_EVENTS.CARDS_DISCARDED,
-                payload: { playerId: trigCtx.playerId, cardUids: [opponent.hand[idx].uid] },
-                timestamp: trigCtx.now,
-            }];
+            if (!trigCtx.matchState) {
+                return [{
+                    type: SU_EVENTS.CARDS_DISCARDED,
+                    payload: { playerId: trigCtx.playerId, cardUids: [opponent.hand[0].uid] },
+                    timestamp: trigCtx.now,
+                }];
+            }
+            return {
+                events: [],
+                matchState: queuePayThePiperDiscardChoice(trigCtx.matchState, trigCtx.playerId, trigCtx.now),
+            };
         }
         return [];
     });
@@ -973,7 +1211,7 @@ function registerTricksterPodOngoingEffects(): void {
     registerTrigger('trickster_brownie_pod', 'onMinionAffected', () => []);
     registerTrigger('trickster_enshrouding_mist_pod', 'onTurnStart', () => []);
     registerProtection('trickster_hideout_pod', 'action', () => false);
-    // Hideout POD：其他玩家不能将随从移动到此基地（用事件拦截器阻止移动）
+    // Hideout POD锛氬叾浠栫帺瀹朵笉鑳藉皢闅忎粠绉诲姩鍒版鍩哄湴锛堢敤浜嬩欢鎷︽埅鍣ㄩ樆姝㈢Щ鍔級
     registerInterceptor('trickster_hideout_pod', (state, event) => {
         if (event.type !== SU_EVENTS.MINION_MOVED) return undefined;
         const { toBaseIndex, fromBaseIndex, minionUid } = (event as any).payload as { toBaseIndex: number; fromBaseIndex: number; minionUid: string };
@@ -984,29 +1222,29 @@ function registerTricksterPodOngoingEffects(): void {
         const fromBase = state.bases[fromBaseIndex];
         const moving = fromBase?.minions.find(m => m.uid === minionUid);
         if (!moving) return undefined;
-        // 近似规则：移动者通常是该随从的控制者
+        // 杩戜技瑙勫垯锛氱Щ鍔ㄨ€呴€氬父鏄闅忎粠鐨勬帶鍒惰€?
         if (moving.controller !== hideout.ownerId) return null;
         return undefined;
     });
 
-    // Leprechaun POD：每回合第一次“对手打出力量更低的随从到此基地（结算后仍在场）”时消灭之
+    // Leprechaun POD锛氭瘡鍥炲悎绗竴娆♀€滃鎵嬫墦鍑哄姏閲忔洿浣庣殑闅忎粠鍒版鍩哄湴锛堢粨绠楀悗浠嶅湪鍦猴級鈥濇椂娑堢伃涔?
     registerTrigger('trickster_leprechaun_pod', 'onMinionPlayed', (trigCtx) => {
         if (!trigCtx.triggerMinionUid || !trigCtx.triggerMinionDefId || trigCtx.baseIndex === undefined) return [];
         const baseIndex = trigCtx.baseIndex;
         const base = trigCtx.state.bases[baseIndex];
         if (!base) return [];
 
-        // 找到该基地上的 leprechaun（可能多个）
+        // 鎵惧埌璇ュ熀鍦颁笂鐨?leprechaun锛堝彲鑳藉涓級
         const leps = base.minions.filter(m => m.defId === 'trickster_leprechaun_pod');
         if (leps.length === 0) return [];
 
-        // 触发的随从必须仍在该基地（避免 Twister 等在结算中移动）
+        // 瑙﹀彂鐨勯殢浠庡繀椤讳粛鍦ㄨ鍩哄湴锛堥伩鍏?Twister 绛夊湪缁撶畻涓Щ鍔級
         const playedMinion = base.minions.find(m => m.uid === trigCtx.triggerMinionUid);
         if (!playedMinion) return [];
 
         const events: SmashUpEvent[] = [];
         for (const lep of leps) {
-            // 只对其他玩家触发
+            // 鍙鍏朵粬鐜╁瑙﹀彂
             if (lep.controller === trigCtx.playerId) continue;
 
             const used = (lep as any).metadata?.leprechaunPodLastTurnTriggered as number | undefined;
@@ -1043,21 +1281,21 @@ function registerTricksterPodOngoingEffects(): void {
         return events;
     });
 
-    // Brownie POD：每回合一次，当对手在另一基地打出随从后，你抽 1 张牌
+    // Brownie POD锛氭瘡鍥炲悎涓€娆★紝褰撳鎵嬪湪鍙︿竴鍩哄湴鎵撳嚭闅忎粠鍚庯紝浣犳娊 1 寮犵墝
     registerTrigger('trickster_brownie_pod', 'onMinionPlayed', (trigCtx) => {
         if (!trigCtx.triggerMinionUid || trigCtx.baseIndex === undefined) return [];
-        // 对手打出的随从：playerId=打出者；需要找到所有 brownie_pod（可能多个）
+        // 瀵规墜鎵撳嚭鐨勯殢浠庯細playerId=鎵撳嚭鑰咃紱闇€瑕佹壘鍒版墍鏈?brownie_pod锛堝彲鑳藉涓級
         const events: SmashUpEvent[] = [];
         for (let bi = 0; bi < trigCtx.state.bases.length; bi++) {
             const base = trigCtx.state.bases[bi];
             for (const brownie of base.minions.filter(m => m.defId === 'trickster_brownie_pod')) {
                 if (brownie.controller === trigCtx.playerId) continue;
-                if (bi === trigCtx.baseIndex) continue; // 另一基地
+                if (bi === trigCtx.baseIndex) continue; // 鍙︿竴鍩哄湴
                 const ownerId = brownie.controller;
                 const used = (brownie as any).metadata?.browniePodLastTurnTriggered as number | undefined;
                 if (used === trigCtx.state.turnNumber) continue;
 
-                // 抽 1
+                // 鎶?1
                 const owner = trigCtx.state.players[ownerId];
                 if (!owner) continue;
                 const drawEvents = buildStandardDrawEvents(trigCtx.state, ownerId, 1, trigCtx.random, trigCtx.now);
@@ -1078,7 +1316,7 @@ function registerTricksterPodOngoingEffects(): void {
         return events;
     });
 
-    // Gremlin POD：被消灭进入弃牌堆后抽 1；若被消灭则每位对手随机弃 1
+    // Gremlin POD锛氳娑堢伃杩涘叆寮冪墝鍫嗗悗鎶?1锛涜嫢琚秷鐏垯姣忎綅瀵规墜闅忔満寮?1
     registerTrigger('trickster_gremlin_pod', 'onMinionDestroyed', (trigCtx) => {
         if (trigCtx.triggerMinionDefId !== 'trickster_gremlin_pod') return [];
         const ownerId = trigCtx.triggerMinion?.owner ?? trigCtx.playerId;
@@ -1100,7 +1338,7 @@ function registerTricksterPodOngoingEffects(): void {
         return events;
     });
 
-    // Gremlin POD：基地计分清场时进入弃牌堆（非消灭）也抽 1
+    // Gremlin POD锛氬熀鍦拌鍒嗘竻鍦烘椂杩涘叆寮冪墝鍫嗭紙闈炴秷鐏級涔熸娊 1
     registerTrigger('trickster_gremlin_pod', 'onMinionDiscardedFromBase', (trigCtx) => {
         if (trigCtx.triggerMinionDefId !== 'trickster_gremlin_pod') return [];
         const ownerId = trigCtx.triggerMinion?.owner ?? trigCtx.playerId;
@@ -1109,7 +1347,7 @@ function registerTricksterPodOngoingEffects(): void {
         return buildStandardDrawEvents(trigCtx.state, ownerId, 1, trigCtx.random, trigCtx.now);
     });
 
-    // Flame Trap POD：对手打出随从到此基地后，先自毁再尝试消灭该随从
+    // Flame Trap POD锛氬鎵嬫墦鍑洪殢浠庡埌姝ゅ熀鍦板悗锛屽厛鑷瘉鍐嶅皾璇曟秷鐏闅忎粠
     registerTrigger('trickster_flame_trap_pod', 'onMinionPlayed', (trigCtx) => {
         if (!trigCtx.triggerMinionUid || !trigCtx.triggerMinionDefId || trigCtx.baseIndex === undefined) return [];
         const bi = trigCtx.baseIndex;
@@ -1139,7 +1377,7 @@ function registerTricksterPodOngoingEffects(): void {
         ];
     });
 
-    // Flame Trap POD：你回合开始时，可以让此基地本回合 breakpoint -4
+    // Flame Trap POD锛氫綘鍥炲悎寮€濮嬫椂锛屽彲浠ヨ姝ゅ熀鍦版湰鍥炲悎 breakpoint -4
     registerTrigger('trickster_flame_trap_pod', 'onTurnStart', (trigCtx) => {
         for (let bi = 0; bi < trigCtx.state.bases.length; bi++) {
             const base = trigCtx.state.bases[bi];
@@ -1153,7 +1391,7 @@ function registerTricksterPodOngoingEffects(): void {
             const interaction = createSimpleChoice(
                 `trickster_flame_trap_pod_bp_${trigCtx.now}`,
                 trigCtx.playerId,
-                '火焰陷阱：是否降低此基地爆分线？',
+                '鐏劙闄烽槺锛氭槸鍚﹂檷浣庢鍩哄湴鐖嗗垎绾匡紵',
                 options as any[],
                 { sourceId: 'trickster_flame_trap_pod_bp', targetType: 'option', autoCancelOption: false },
             );
@@ -1162,7 +1400,7 @@ function registerTricksterPodOngoingEffects(): void {
         return [];
     });
 
-    // Pay the Piper POD：对手在此基地打出随从后，该玩家弃 1 张牌（先按随机实现，后续可升级为选择弃牌）
+    // Pay the Piper POD锛氬鎵嬪湪姝ゅ熀鍦版墦鍑洪殢浠庡悗锛岃鐜╁寮?1 寮犵墝锛堝厛鎸夐殢鏈哄疄鐜帮紝鍚庣画鍙崌绾т负閫夋嫨寮冪墝锛?
     registerTrigger('trickster_pay_the_piper_pod', 'onMinionPlayed', (trigCtx) => {
         if (!trigCtx.triggerMinionUid || trigCtx.baseIndex === undefined) return [];
         const bi = trigCtx.baseIndex;
@@ -1181,7 +1419,7 @@ function registerTricksterPodOngoingEffects(): void {
         } as CardsDiscardedEvent];
     });
 
-    // Block the Path POD：对每个对手指定其拥有的一个派系，阻止该对手派系随从打到此基地
+    // Block the Path POD锛氬姣忎釜瀵规墜鎸囧畾鍏舵嫢鏈夌殑涓€涓淳绯伙紝闃绘璇ュ鎵嬫淳绯婚殢浠庢墦鍒版鍩哄湴
     registerAbility('trickster_block_the_path_pod', 'onPlay', (ctx) => {
         const otherPlayers = ctx.state.turnOrder.filter(pid => pid !== ctx.playerId);
         if (otherPlayers.length === 0) return { events: [] };
@@ -1193,7 +1431,7 @@ function registerTricksterPodOngoingEffects(): void {
             return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.condition_not_met', ctx.now)] };
         }
 
-        // 组合：每位对手在其两个派系中选一个（最多 3 位对手 → 2^3 = 8）
+        // 缁勫悎锛氭瘡浣嶅鎵嬪湪鍏朵袱涓淳绯讳腑閫変竴涓紙鏈€澶?3 浣嶅鎵?鈫?2^3 = 8锛?
         const combos: { blocked: Record<string, string>; label: string }[] = [];
         const total = 1 << otherPlayers.length;
         for (let mask = 0; mask < total; mask++) {
@@ -1220,7 +1458,7 @@ function registerTricksterPodOngoingEffects(): void {
             options as any[],
             { sourceId: 'trickster_block_the_path_pod', targetType: 'option', autoCancelOption: true },
         );
-        // continuationContext 由 Board.tsx/InteractionHandlers 需要存 cardUid/baseIndex
+        // continuationContext 鐢?Board.tsx/InteractionHandlers 闇€瑕佸瓨 cardUid/baseIndex
         return { events: [], matchState: queueInteraction(ctx.matchState, { ...interaction, data: { ...interaction.data, continuationContext: { cardUid: ctx.cardUid, baseIndex: ctx.baseIndex } } as any }) };
     });
 
@@ -1238,18 +1476,4 @@ function registerTricksterPodOngoingEffects(): void {
         return def?.faction === blockedFaction;
     });
 
-    // Mark of Sleep POD：限制“被标记者”的移动（用事件拦截器实现）
-    registerInterceptor('trickster_mark_of_sleep_pod', (state, event) => {
-        if (event.type !== SU_EVENTS.MINION_MOVED) return undefined;
-        const marked = (state.sleepMoveMarkedPlayers ?? []) as string[];
-        if (marked.length === 0) return undefined;
-        const { fromBaseIndex, minionUid } = (event as any).payload as { fromBaseIndex: number; minionUid: string };
-        const fromBase = state.bases[fromBaseIndex];
-        const minion = fromBase?.minions.find(m => m.uid === minionUid);
-        if (!minion) return undefined;
-        const expires = (state.sleepMarkExpiresOnTurnNumber as number | undefined);
-        if (expires !== undefined && state.turnNumber >= expires) return undefined;
-        if (marked.includes(minion.controller)) return null;
-        return undefined;
-    });
 }

--- a/src/games/smashup/abilities/vampires.ts
+++ b/src/games/smashup/abilities/vampires.ts
@@ -1154,11 +1154,7 @@ function vampireCullTheWeakPod(ctx: AbilityContext): AbilityResult {
         buildMinionTargetOptions(myMinions, { state: ctx.state, sourcePlayerId: ctx.playerId, effectType: 'affect' }) as any,
         { sourceId: 'vampire_cull_the_weak_pod', targetType: 'minion' },
     );
-    (interaction.data as any).continuationContext = {
-        discardedCount: picked.picked.length,
-        deckEvents: picked.events.filter(event => event.type !== SU_EVENTS.CARDS_DRAWN),
-        discardUids: picked.picked.map(c => c.uid),
-    };
+    (interaction.data as any).continuationContext = { discardedCount: picked.picked.length, deckEvents: picked.events, discardUids: picked.picked.map(c => c.uid) };
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
 }
 

--- a/src/games/smashup/data/cards.ts
+++ b/src/games/smashup/data/cards.ts
@@ -72,6 +72,46 @@ function registerBases(bases: BaseCardDef[]): void {
 }
 
 // 初始化注册
+const POD_SUFFIX = '_pod';
+const BASES_PER_FACTION = 2;
+
+function isPodVariantId(id: string): boolean {
+    return id.endsWith(POD_SUFFIX);
+}
+
+function toPodId(id: string): string {
+    return isPodVariantId(id) ? id : `${id}${POD_SUFFIX}`;
+}
+
+function cloneBaseRestrictions(restrictions: BaseCardDef['restrictions']): BaseCardDef['restrictions'] {
+    if (!restrictions) return undefined;
+    return restrictions.map(restriction => ({
+        ...restriction,
+        condition: restriction.condition ? { ...restriction.condition } : undefined,
+    }));
+}
+
+function cloneBaseAsPodSkeleton(base: BaseCardDef): BaseCardDef | undefined {
+    if (!base.faction || isPodVariantId(base.id)) return undefined;
+    return {
+        ...base,
+        id: toPodId(base.id),
+        faction: toPodId(base.faction) as BaseCardDef['faction'],
+        restrictions: cloneBaseRestrictions(base.restrictions),
+    };
+}
+
+function registerPodBaseSkeletons(): void {
+    const podBaseSkeletons: BaseCardDef[] = [];
+    for (const base of _baseRegistry.values()) {
+        const podBase = cloneBaseAsPodSkeleton(base);
+        if (!podBase) continue;
+        if (_baseRegistry.has(podBase.id)) continue;
+        podBaseSkeletons.push(podBase);
+    }
+    registerBases(podBaseSkeletons);
+}
+
 registerCards(PIRATE_CARDS);
 registerCards(PIRATE_POD_CARDS);
 registerCards(NINJA_CARDS);
@@ -151,7 +191,7 @@ export const BASE_CARDS: BaseCardDef[] = [
     {
         id: 'base_the_jungle',
         name: '绿洲丛林',
-        nameEn: 'The Jungle',
+        nameEn: 'Jungle Oasis',
         breakpoint: 12,
         vpAwards: [2, 0, 0],
         faction: 'dinosaurs',
@@ -623,13 +663,373 @@ export const BASE_CARDS_MONSTER_SMASH: BaseCardDef[] = [
     },
 ];
 registerBases(BASE_CARDS_MONSTER_SMASH);
+registerPodBaseSkeletons();
+
+/**
+ * POD 基地正式覆盖（仅覆盖当前已确认条目）。
+ * 说明：先由基础基地克隆骨架，再用同 id 的 *_pod 定义覆盖具体数值/名称。
+ */
+const POD_BASE_OVERRIDES: BaseCardDef[] = [
+    {
+        id: 'base_ninja_dojo_pod',
+        name: '忍者道场',
+        nameEn: 'Ninja Dojo',
+        breakpoint: 18,
+        vpAwards: [2, 3, 2],
+        faction: 'ninjas_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 0 },
+    },
+    {
+        id: 'base_temple_of_goju_pod',
+        name: '刚柔流寺庙',
+        nameEn: 'Temple of Goju',
+        breakpoint: 16,
+        vpAwards: [4, 3, 2],
+        faction: 'ninjas_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 4 },
+    },
+    {
+        id: 'base_the_factory_pod',
+        name: '436-1337工厂',
+        nameEn: 'Factory 436-1337',
+        breakpoint: 25,
+        vpAwards: [2, 2, 1],
+        faction: 'robots_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 7 },
+    },
+    {
+        id: 'base_central_brain_pod',
+        name: '中央大脑',
+        nameEn: 'The Central Brain',
+        breakpoint: 19,
+        vpAwards: [4, 2, 1],
+        faction: 'robots_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 8 },
+        minionPowerBonus: 1,
+    },
+    {
+        id: 'base_cave_of_shinies_pod',
+        name: '闪光洞穴',
+        nameEn: 'Cave of Shinies',
+        breakpoint: 23,
+        vpAwards: [4, 2, 1],
+        faction: 'tricksters_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 11 },
+    },
+    {
+        id: 'base_mushroom_kingdom_pod',
+        name: '蘑菇王国',
+        nameEn: 'Mushroom Kingdom',
+        breakpoint: 19,
+        vpAwards: [4, 3, 2],
+        faction: 'tricksters_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 6 },
+    },
+    {
+        id: 'base_wizard_academy_pod',
+        name: '巫术学院',
+        nameEn: 'School of Wizardry',
+        breakpoint: 20,
+        vpAwards: [3, 2, 1],
+        faction: 'wizards_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 12 },
+    },
+    {
+        id: 'base_great_library_pod',
+        name: '大图书馆',
+        nameEn: 'The Great Library',
+        breakpoint: 22,
+        vpAwards: [4, 2, 1],
+        faction: 'wizards_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 10 },
+    },
+    {
+        id: 'base_haunted_house_pod',
+        name: '伊万斯城公墓',
+        nameEn: 'Evans City Cemetery',
+        breakpoint: 20,
+        vpAwards: [5, 3, 2],
+        faction: 'zombies_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 14 },
+    },
+    {
+        id: 'base_rhodes_plaza_pod',
+        name: '罗德百货商场',
+        nameEn: 'Rhodes Plaza Mall',
+        breakpoint: 24,
+        vpAwards: [0, 0, 0],
+        faction: 'zombies_pod',
+        previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.BASE1, index: 2 },
+    },
+];
+registerBases(POD_BASE_OVERRIDES);
+
+function buildPodBaseOverrideFromRegistry(id: string, overrides: Partial<BaseCardDef>): BaseCardDef {
+    const podBase = _baseRegistry.get(id);
+    if (!podBase) {
+        throw new Error(`[smashup] missing pod base for override: ${id}`);
+    }
+    return {
+        ...podBase,
+        ...overrides,
+        id,
+    };
+}
+
+const POD_BASE_OVERRIDES_EXTENDED: BaseCardDef[] = [
+    // Keep previously confirmed base-set POD corrections
+    buildPodBaseOverrideFromRegistry('base_ninja_dojo_pod', {
+        nameEn: 'Ninja Dojo',
+        breakpoint: 18,
+        vpAwards: [2, 3, 2],
+        faction: SMASHUP_FACTION_IDS.NINJAS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_temple_of_goju_pod', {
+        nameEn: 'Temple of Goju',
+        breakpoint: 16,
+        vpAwards: [4, 3, 2],
+        faction: SMASHUP_FACTION_IDS.NINJAS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_the_factory_pod', {
+        nameEn: 'Factory 436-1337',
+        breakpoint: 25,
+        vpAwards: [2, 2, 1],
+        faction: SMASHUP_FACTION_IDS.ROBOTS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_central_brain_pod', {
+        nameEn: 'The Central Brain',
+        breakpoint: 19,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.ROBOTS_POD,
+        minionPowerBonus: 1,
+    }),
+    buildPodBaseOverrideFromRegistry('base_cave_of_shinies_pod', {
+        nameEn: 'Cave of Shinies',
+        breakpoint: 23,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.TRICKSTERS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_mushroom_kingdom_pod', {
+        nameEn: 'Mushroom Kingdom',
+        breakpoint: 19,
+        vpAwards: [4, 3, 2],
+        faction: SMASHUP_FACTION_IDS.TRICKSTERS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_wizard_academy_pod', {
+        nameEn: 'School of Wizardry',
+        breakpoint: 20,
+        vpAwards: [3, 2, 1],
+        faction: SMASHUP_FACTION_IDS.WIZARDS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_great_library_pod', {
+        nameEn: 'The Great Library',
+        breakpoint: 22,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.WIZARDS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_haunted_house_pod', {
+        nameEn: 'Evans City Cemetery',
+        breakpoint: 20,
+        vpAwards: [5, 3, 2],
+        faction: SMASHUP_FACTION_IDS.ZOMBIES_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_rhodes_plaza_pod', {
+        nameEn: 'Rhodes Plaza Mall',
+        breakpoint: 24,
+        vpAwards: [0, 0, 0],
+        faction: SMASHUP_FACTION_IDS.ZOMBIES_POD,
+    }),
+
+    // Bear Cavalry POD
+    buildPodBaseOverrideFromRegistry('base_the_field_of_honor_pod', {
+        nameEn: 'Field of Honor',
+        breakpoint: 16,
+        vpAwards: [3, 1, 1],
+        faction: SMASHUP_FACTION_IDS.BEAR_CAVALRY_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_tsars_palace_pod', {
+        nameEn: "Tsar's Palace",
+        breakpoint: 22,
+        vpAwards: [5, 3, 2],
+        faction: SMASHUP_FACTION_IDS.BEAR_CAVALRY_POD,
+    }),
+
+    // Elder Things POD
+    buildPodBaseOverrideFromRegistry('base_antarctic_base_pod', {
+        nameEn: 'Antarctic Base',
+        breakpoint: 24,
+        vpAwards: [5, 3, 2],
+        faction: SMASHUP_FACTION_IDS.ELDER_THINGS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_plateau_of_leng_pod', {
+        nameEn: 'Plateau of Leng',
+        breakpoint: 18,
+        vpAwards: [3, 2, 1],
+        faction: SMASHUP_FACTION_IDS.ELDER_THINGS_POD,
+    }),
+
+    // Ghosts POD
+    buildPodBaseOverrideFromRegistry('base_haunted_house_al9000_pod', {
+        nameEn: 'Haunted House',
+        breakpoint: 18,
+        vpAwards: [4, 3, 2],
+        faction: SMASHUP_FACTION_IDS.GHOSTS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_dread_lookout_pod', {
+        nameEn: 'The Dread Gazebo',
+        breakpoint: 20,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.GHOSTS_POD,
+    }),
+
+    // Giant Ants POD
+    buildPodBaseOverrideFromRegistry('base_the_hill_pod', {
+        nameEn: 'The Hill',
+        breakpoint: 23,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.GIANT_ANTS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_egg_chamber_pod', {
+        nameEn: 'Egg Chamber',
+        breakpoint: 17,
+        vpAwards: [3, 1, 1],
+        faction: SMASHUP_FACTION_IDS.GIANT_ANTS_POD,
+    }),
+
+    // Innsmouth POD
+    buildPodBaseOverrideFromRegistry('base_innsmouth_base_pod', {
+        nameEn: 'Innsmouth',
+        breakpoint: 23,
+        vpAwards: [5, 3, 2],
+        faction: SMASHUP_FACTION_IDS.INNSMOUTH_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_ritual_site_pod', {
+        nameEn: 'Ritual Site',
+        breakpoint: 20,
+        vpAwards: [4, 2, 2],
+        faction: SMASHUP_FACTION_IDS.INNSMOUTH_POD,
+    }),
+
+    // Killer Plants POD
+    buildPodBaseOverrideFromRegistry('base_secret_garden_pod', {
+        nameEn: 'Secret Grove',
+        breakpoint: 21,
+        vpAwards: [3, 2, 1],
+        faction: SMASHUP_FACTION_IDS.KILLER_PLANTS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_greenhouse_pod', {
+        nameEn: 'The Greenhouse',
+        breakpoint: 24,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.KILLER_PLANTS_POD,
+    }),
+
+    // Mad Scientists POD
+    buildPodBaseOverrideFromRegistry('base_golem_schloss_pod', {
+        nameEn: 'Golem Schloß',
+        breakpoint: 22,
+        vpAwards: [4, 3, 2],
+        faction: SMASHUP_FACTION_IDS.FRANKENSTEIN_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_laboratorium_pod', {
+        nameEn: 'Laboratorium',
+        breakpoint: 25,
+        vpAwards: [5, 3, 3],
+        faction: SMASHUP_FACTION_IDS.FRANKENSTEIN_POD,
+    }),
+
+    // Minions of Cthulhu POD
+    buildPodBaseOverrideFromRegistry('base_mountains_of_madness_pod', {
+        nameEn: 'Mountains of Madness',
+        breakpoint: 20,
+        vpAwards: [6, 4, 3],
+        faction: SMASHUP_FACTION_IDS.MINIONS_OF_CTHULHU_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_rlyeh_pod', {
+        nameEn: "R'lyeh",
+        breakpoint: 18,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.MINIONS_OF_CTHULHU_POD,
+    }),
+
+    // Miskatonic University POD
+    buildPodBaseOverrideFromRegistry('base_miskatonic_university_base_pod', {
+        nameEn: 'Arkham University',
+        breakpoint: 24,
+        vpAwards: [4, 3, 2],
+        faction: SMASHUP_FACTION_IDS.MISKATONIC_UNIVERSITY_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_the_asylum_pod', {
+        nameEn: 'Asylum',
+        breakpoint: 16,
+        vpAwards: [3, 1, 1],
+        faction: SMASHUP_FACTION_IDS.MISKATONIC_UNIVERSITY_POD,
+    }),
+
+    // Pirates POD
+    buildPodBaseOverrideFromRegistry('base_pirate_cove_pod', {
+        nameEn: 'The Grey Opal',
+        breakpoint: 17,
+        vpAwards: [3, 1, 1],
+        faction: SMASHUP_FACTION_IDS.PIRATES_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_tortuga_pod', {
+        nameEn: 'Tortuga',
+        breakpoint: 21,
+        vpAwards: [4, 3, 2],
+        faction: SMASHUP_FACTION_IDS.PIRATES_POD,
+    }),
+
+    // Steampunks POD
+    buildPodBaseOverrideFromRegistry('base_inventors_salon_pod', {
+        nameEn: "Inventor's Salon",
+        breakpoint: 22,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.STEAMPUNKS_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_the_workshop_pod', {
+        nameEn: 'Workshop',
+        breakpoint: 20,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.STEAMPUNKS_POD,
+    }),
+
+    // Werewolves POD
+    buildPodBaseOverrideFromRegistry('base_moot_site_pod', {
+        nameEn: 'Moot Site',
+        breakpoint: 15,
+        vpAwards: [2, 1, 0],
+        faction: SMASHUP_FACTION_IDS.WEREWOLVES_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_standing_stones_pod', {
+        nameEn: 'Standing Stones',
+        breakpoint: 20,
+        vpAwards: [4, 2, 1],
+        faction: SMASHUP_FACTION_IDS.WEREWOLVES_POD,
+    }),
+
+    // Vampires POD
+    buildPodBaseOverrideFromRegistry('base_castle_blood_pod', {
+        nameEn: 'Castle Blood',
+        breakpoint: 17,
+        vpAwards: [3, 1, 1],
+        faction: SMASHUP_FACTION_IDS.VAMPIRES_POD,
+    }),
+    buildPodBaseOverrideFromRegistry('base_crypt_pod', {
+        nameEn: 'Crypt',
+        breakpoint: 20,
+        vpAwards: [4, 2, 2],
+        faction: SMASHUP_FACTION_IDS.VAMPIRES_POD,
+    }),
+];
+registerBases(POD_BASE_OVERRIDES_EXTENDED);
 
 // ============================================================================
 // 基地选择：按所选派系过滤
 // ============================================================================
 
 /** 根据所选派系获取基地定义 ID（只使用所选派系的基地） */
-export function getBaseDefIdsForFactions(factionIds: string[]): string[] {
+function getBaseDefIdsForFactionsLegacy(factionIds: string[]): string[] {
     const selected = new Set(factionIds);
     const matched = Array.from(_baseRegistry.values())
         .filter(base => base.faction && selected.has(base.faction))
@@ -664,6 +1064,58 @@ export function getBaseDefIdsForFactions(factionIds: string[]): string[] {
 
 
 /** 查找卡牌定义 */
+/** 鏍规嵁鎵€閫夋淳绯昏幏鍙栧熀鍦板畾涔?ID锛堝悓鍙樹綋琛ュ厖锛欿OD 鍙ˉ POD锛屽熀纭€鍙ˉ鍩虹锛?*/
+export function getBaseDefIdsForFactions(factionIds: string[]): string[] {
+    const selectedFactions = Array.from(new Set(factionIds));
+    if (selectedFactions.length === 0) {
+        return getBaseDefIdsForFactionsLegacy(factionIds);
+    }
+    const allBases = Array.from(_baseRegistry.values()).filter(base => !!base.faction);
+
+    const basesByFaction = new Map<string, string[]>();
+    for (const base of allBases) {
+        const faction = base.faction as string;
+        const existing = basesByFaction.get(faction);
+        if (existing) {
+            existing.push(base.id);
+        } else {
+            basesByFaction.set(faction, [base.id]);
+        }
+    }
+
+    const result: string[] = [];
+    const usedBaseIds = new Set<string>();
+    const appendBaseIds = (baseIds: string[]) => {
+        for (const baseId of baseIds) {
+            if (usedBaseIds.has(baseId)) continue;
+            usedBaseIds.add(baseId);
+            result.push(baseId);
+        }
+    };
+
+    // 1) 绮剧‘鍖归厤鎵€閫夋淳绯伙紙鍚?POD 锛?
+    for (const factionId of selectedFactions) {
+        appendBaseIds(basesByFaction.get(factionId) ?? []);
+    }
+
+    // 2) 杞繃娓★細姣忎釜娲剧郴涓嶈冻 2 寮犲熀鍦版椂锛屾寜鍚屽彉浣撹ˉ榻?
+    for (const factionId of selectedFactions) {
+        const exactCount = (basesByFaction.get(factionId) ?? []).length;
+        const needCount = Math.max(0, BASES_PER_FACTION - exactCount);
+        if (needCount === 0) continue;
+
+        const wantsPodVariant = isPodVariantId(factionId);
+        const supplementCandidates = allBases
+            .filter(base => isPodVariantId(base.id) === wantsPodVariant)
+            .map(base => base.id)
+            .filter(baseId => !usedBaseIds.has(baseId));
+
+        appendBaseIds(supplementCandidates.slice(0, needCount));
+    }
+
+    return result;
+}
+
 export function getCardDef(defId: string): CardDef | undefined {
     return _cardRegistry.get(defId);
 }

--- a/src/games/smashup/data/factions/vampires_pod.ts
+++ b/src/games/smashup/data/factions/vampires_pod.ts
@@ -83,13 +83,13 @@ export const VAMPIRE_POD_ACTIONS: ActionCardDef[] = [
     {
         id: 'vampire_buffet_pod',
         type: 'action',
-        subtype: 'special',
+        subtype: 'standard',
         name: '自助餐',
         nameEn: 'Buffet',
         faction: 'vampires_pod',
         // 注意：POD 自助餐是 onMinionDestroyed 触发后，从手牌创建交互并打出
         // 不是通用计分响应窗口中的可手动 special，因此不能有 abilityTags: ['special']
-        specialTiming: 'triggered',
+        abilityTags: ['onPlay'],
         count: 1,
         previewRef: { type: 'atlas', atlasId: SMASHUP_ATLAS_IDS.CARDS5, index: 30 },
     },

--- a/src/games/smashup/domain/baseAbilities.ts
+++ b/src/games/smashup/domain/baseAbilities.ts
@@ -32,6 +32,7 @@ import {
     buildValidatedMoveEvents,
     buildValidatedDestroyEvents,
     buildValidatedReturnEvents,
+    buildStandardDrawEvents,
 } from './abilityHelpers';
 import { getCardDef, getBaseDef } from '../data/cards';
 import { createSimpleChoice, queueInteraction, type PromptOption } from '../../../engine/systems/InteractionSystem';
@@ -79,6 +80,8 @@ export interface BaseAbilityContext {
     destroyerId?: PlayerId;
     /** onMinionDestroyed 时：被消灭随从的控制者 */
     controllerId?: PlayerId;
+    /** onMinionDestroyed 时：本次消灭的来源 reason */
+    reason?: string;
     /** afterScoring 时：排名信息 */
     rankings?: { playerId: PlayerId; power: number; vp: number }[];
     /** onActionPlayed 时：行动卡目标基地 */
@@ -134,6 +137,15 @@ function getTurnMinionsPlayedAtBase(state: SmashUpCore, baseIndex: number): numb
 // ============================================================================
 
 type BaseAbilityEntry = { executor: BaseAbilityExecutor; options: Required<BaseAbilityRegistrationOptions> };
+const POD_SUFFIX = '_pod';
+
+function isPodDefId(defId: string): boolean {
+    return defId.endsWith(POD_SUFFIX);
+}
+
+function toPodDefId(defId: string): string {
+    return isPodDefId(defId) ? defId : `${defId}${POD_SUFFIX}`;
+}
 
 /** 内部存储：baseDefId 到 Map<BaseTriggerTiming, BaseAbilityEntry> */
 const baseAbilityRegistry = new Map<string, Map<BaseTriggerTiming, BaseAbilityEntry>>();
@@ -277,6 +289,49 @@ export function getExtendedBaseAbilityOptions(baseDefId: string, timing: string)
     return extendedRegistry.get(baseDefId)?.get(timing)?.options;
 }
 
+/**
+ * 为基地能力注册表补充 POD 别名。
+ *
+ * 说明：
+ * 1) 不覆盖已显式注册的 POD 能力（支持未来逐张覆写）。
+ * 2) 普通基地能力需要同步注册 reaction queue executor，确保触发队列可执行。
+ * 3) 扩展时机（extendedRegistry）只做映射，不在此处注册 queue executor（按现有收集路径动态注册）。
+ */
+export function registerPodBaseAbilityAliases(): void {
+    const baseEntries = Array.from(baseAbilityRegistry.entries());
+    for (const [baseDefId, timingMap] of baseEntries) {
+        if (isPodDefId(baseDefId)) continue;
+        const podDefId = toPodDefId(baseDefId);
+        const podTimingMap = baseAbilityRegistry.get(podDefId) ?? new Map<BaseTriggerTiming, BaseAbilityEntry>();
+
+        for (const [timing, entry] of timingMap.entries()) {
+            if (podTimingMap.has(timing)) continue;
+            podTimingMap.set(timing, entry);
+            registerBaseAbilityAsQueuedTrigger(podDefId, timing);
+        }
+
+        if (!baseAbilityRegistry.has(podDefId)) {
+            baseAbilityRegistry.set(podDefId, podTimingMap);
+        }
+    }
+
+    const extendedEntries = Array.from(extendedRegistry.entries());
+    for (const [baseDefId, timingMap] of extendedEntries) {
+        if (isPodDefId(baseDefId)) continue;
+        const podDefId = toPodDefId(baseDefId);
+        const podTimingMap = extendedRegistry.get(podDefId) ?? new Map<string, ExtendedBaseAbilityEntry>();
+
+        for (const [timing, entry] of timingMap.entries()) {
+            if (podTimingMap.has(timing)) continue;
+            podTimingMap.set(timing, entry);
+        }
+
+        if (!extendedRegistry.has(podDefId)) {
+            extendedRegistry.set(podDefId, podTimingMap);
+        }
+    }
+}
+
 // ============================================================================
 // 基地能力注册（所有可 Prompt 实现的基地）
 // ============================================================================
@@ -385,6 +440,25 @@ export function registerBaseAbilities(): void {
         };
     });
 
+    // base_cave_of_shinies_pod: 闪光洞穴（POD）
+    // "Once per turn, after a minion here you own is destroyed, gain 1 VP."
+    registerExtended('base_cave_of_shinies_pod', 'onMinionDestroyed', (ctx) => {
+        const alreadyTriggeredThisTurn = (ctx.state.turnDestroyedMinions ?? [])
+            .some(record => record.baseIndex === ctx.baseIndex);
+        if (alreadyTriggeredThisTurn) return { events: [] };
+        return {
+            events: [{
+                type: SU_EVENTS.VP_AWARDED,
+                payload: {
+                    playerId: ctx.playerId,
+                    amount: 1,
+                    reason: '闪光洞穴（POD）：每回合一次，己方随从被消灭获得1VP',
+                },
+                timestamp: ctx.now,
+            } as VpAwardedEvent],
+        };
+    });
+
     // base_the_factory: 436-1337工厂
     // "当这个基地计分时，冠军在这里每有5力量就获得1VP"
     registerBaseAbility('base_the_factory', 'beforeScoring', (ctx) => {
@@ -442,19 +516,21 @@ export function registerBaseAbilities(): void {
                 timestamp: ctx.now,
             } as CardsDiscardedEvent);
         }
-        // 抽5张牌（从牌库顶取）
-        const drawCount = Math.min(5, winner.deck.length);
-        if (drawCount > 0) {
-            events.push({
-                type: SU_EVENTS.CARDS_DRAWN,
-                payload: {
-                    playerId: winnerId,
-                    count: drawCount,
-                    cardUids: winner.deck.slice(0, drawCount).map(c => c.uid),
+        // 抽5张牌：需基于“弃手牌后”的临时状态计算，确保牌库为空时可洗入刚弃的手牌
+        const drawState = winner.hand.length > 0
+            ? {
+                ...ctx.state,
+                players: {
+                    ...ctx.state.players,
+                    [winnerId]: {
+                        ...winner,
+                        hand: [],
+                        discard: [...winner.discard, ...winner.hand],
+                    },
                 },
-                timestamp: ctx.now,
-            } as CardsDrawnEvent);
-        }
+            }
+            : ctx.state;
+        events.push(...buildStandardDrawEvents(drawState, winnerId, 5, ctx.random, ctx.now));
         return { events };
     });
 
@@ -558,6 +634,10 @@ export function registerBaseAbilities(): void {
         return { events };
     }, { mandatory: true });
 
+    // base_temple_of_goju_pod: POD 版本为“随从被消灭后置牌库底”，
+    // 由 reducer 在 MINION_DESTROYED 阶段处理；因此 afterScoring 无效果。
+    registerBaseAbility('base_temple_of_goju_pod', 'afterScoring', () => ({ events: [] }));
+
     // base_great_library: 大图书馆
     // "在这个基地计分后，所有在这里有随从的玩家可以抽一张卡牌"
     registerBaseAbility('base_great_library', 'afterScoring', (ctx) => {
@@ -570,17 +650,7 @@ export function registerBaseAbilities(): void {
             playersWithMinions.add(m.controller);
         }
         for (const pid of playersWithMinions) {
-            const player = ctx.state.players[pid];
-            if (!player || player.deck.length === 0) continue;
-            events.push({
-                type: SU_EVENTS.CARDS_DRAWN,
-                payload: {
-                    playerId: pid,
-                    count: 1,
-                    cardUids: [player.deck[0].uid],
-                },
-                timestamp: ctx.now,
-            } as CardsDrawnEvent);
+            events.push(...buildStandardDrawEvents(ctx.state, pid, 1, ctx.random, ctx.now));
         }
         return { events };
     });
@@ -636,10 +706,19 @@ export function registerBaseAbilities(): void {
     });
 
     // base_the_field_of_honor: 荣誉之地
-    // "当一个或多个随从在这里被消灭，那个将它们消灭的玩家获得1VP"
+    // "每回合中，在你第一次消灭这里另一位玩家的随从后，获得 1 VP"
     registerExtended('base_the_field_of_honor', 'onMinionDestroyed', (ctx) => {
-        // ctx.destroyerId 是消灭者；reason 标识本次消灭的直接来源（卡牌/能力）
         if (!ctx.destroyerId) return { events: [] };
+        const destroyedControllerId = ctx.controllerId ?? ctx.playerId;
+        // 仅当“消灭了另一位玩家的随从”时触发
+        if (destroyedControllerId === ctx.destroyerId) return { events: [] };
+        // 每回合同一位玩家在同一荣誉之地仅首次触发
+        const alreadyTriggeredThisTurn = (ctx.state.turnDestroyedMinions ?? []).some(record =>
+            record.baseIndex === ctx.baseIndex
+            && record.owner !== ctx.destroyerId
+            && record.destroyer === ctx.destroyerId,
+        );
+        if (alreadyTriggeredThisTurn) return { events: [] };
         return {
             events: [{
                 type: SU_EVENTS.VP_AWARDED,
@@ -920,12 +999,28 @@ export function registerBaseAbilities(): void {
         return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
     });
 
+    // base_rlyeh: 仅当“本基地能力导致的消灭真正发生”时给予 1VP
+    registerExtended('base_rlyeh', 'onMinionDestroyed', (ctx) => {
+        if (ctx.reason !== 'base_rlyeh') return { events: [] };
+        if (!ctx.destroyerId) return { events: [] };
+        return {
+            events: [{
+                type: SU_EVENTS.VP_AWARDED,
+                payload: { playerId: ctx.destroyerId, amount: 1, reason: '拉莱耶：消灭随从获得1VP' },
+                timestamp: ctx.now,
+            } as VpAwardedEvent],
+        };
+    });
+
     // === 基础版需要 Prompt 的基地 ===
 
     // base_the_homeworld: 母星
     // "每当有一个随从打出到这里后，它的拥有者可以额外打出一个力量为2或以下的随从"
     // 力量≤2 限制通过 LIMIT_MODIFIED 事件的 powerMax 字段全局生效
     registerBaseAbility('base_the_homeworld', 'onMinionPlayed', (ctx) => {
+        // POD 勘误：改为“每回合一次”。若统计缺失（如部分单测直接调用），按可触发处理。
+        const playedAtBaseThisTurn = getTurnMinionsPlayedAtBase(ctx.state, ctx.baseIndex);
+        if (playedAtBaseThisTurn >= 2) return { events: [] };
         return {
             events: [{
                 type: SU_EVENTS.LIMIT_MODIFIED,
@@ -1036,6 +1131,9 @@ export function registerBaseAbilities(): void {
         );
         return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
     }, { mandatory: false });
+
+    // base_ninja_dojo_pod: POD 勘误为无基地能力。
+    registerBaseAbility('base_ninja_dojo_pod', 'afterScoring', () => ({ events: [] }));
 
     // === 基础版需要 Prompt 的基地（续） ===
 
@@ -1325,12 +1423,68 @@ export function registerBaseAbilities(): void {
         };
     });
 
+    // base_mushroom_kingdom_pod: 蘑菇王国（POD）
+    // "At the start of your turn, if you have more cards in your hand than any other player,
+    //  you may move a minion to or from this base."
+    registerBaseAbility('base_mushroom_kingdom_pod', 'onTurnStart', (ctx) => {
+        const mushroomBaseIndex = ctx.baseIndex;
+        const me = ctx.state.players[ctx.playerId];
+        if (!me) return { events: [] };
+        const myHandCount = me.hand.length;
+        const hasStrictlyMoreThanAnyOther = Object.entries(ctx.state.players)
+            .filter(([pid]) => pid !== ctx.playerId)
+            .every(([, player]) => myHandCount > player.hand.length);
+        if (!hasStrictlyMoreThanAnyOther) return { events: [] };
+
+        const allMinions: { uid: string; defId: string; fromBaseIndex: number; label: string }[] = [];
+        for (let i = 0; i < ctx.state.bases.length; i++) {
+            const base = ctx.state.bases[i];
+            const bDef = getBaseDef(base.defId);
+            for (const m of base.minions) {
+                const def = getCardDef(m.defId);
+                allMinions.push({
+                    uid: m.uid,
+                    defId: m.defId,
+                    fromBaseIndex: i,
+                    label: `${def?.name ?? m.defId} (${bDef?.name ?? '基地'}, 力量${getEffectivePower(ctx.state, m, i)})`,
+                });
+            }
+        }
+        if (allMinions.length === 0) return { events: [] };
+
+        const minionOptions = allMinions.map((m, i) => ({
+            id: `minion-${i}`,
+            label: m.label,
+            value: { minionUid: m.uid, minionDefId: m.defId, fromBaseIndex: m.fromBaseIndex },
+            _source: 'field' as const,
+            displayMode: 'card' as const,
+        }));
+        const options: PromptOption<{ skip: true } | { minionUid: string; minionDefId: string; fromBaseIndex: number }>[] = [
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
+            ...minionOptions,
+        ];
+        if (!ctx.matchState) return { events: [] };
+        const interaction = createSimpleChoice(
+            `base_mushroom_kingdom_pod_${ctx.now}`, ctx.playerId,
+            '蘑菇王国（POD）：选择一个随从，移动到或移出该基地', options,
+            { sourceId: 'base_mushroom_kingdom_pod', targetType: 'minion' },
+        );
+        return {
+            events: [],
+            matchState: queueInteraction(ctx.matchState, {
+                ...interaction,
+                data: { ...interaction.data, continuationContext: { mushroomBaseIndex } },
+            }),
+        };
+    });
+
     // === 限制类基地已通过 BaseCardDef.restrictions 数据驱动，isOperationRestricted 自动解析 ===
 
     // === 被动保护类已在 baseAbilities_expansion.ts 中通过 registerProtection 注册 ===
 
     // === 扩展包基地能力（克苏鲁/AL9000/Pretty Pretty） ===
     registerExpansionBaseAbilities();
+    registerPodBaseAbilityAliases();
 }
 
 // ============================================================================
@@ -1357,14 +1511,12 @@ export function registerBaseInteractionHandlers(): void {
         if (!base) return { state, events: [] };
         const target = base.minions.find(m => m.uid === selected.minionUid);
         if (!target) return { state, events: [] };
-        return { state, events: [
-            destroyMinion(target.uid, target.defId, selected.baseIndex!, target.owner, undefined, 'base_rlyeh', timestamp),
-            {
-                type: SU_EVENTS.VP_AWARDED,
-                payload: { playerId, amount: 1, reason: '拉莱耶：消灭随从获得1VP' },
-                timestamp,
-            } as VpAwardedEvent,
-        ] };
+        return {
+            state,
+            events: [
+                destroyMinion(target.uid, target.defId, selected.baseIndex!, target.owner, playerId, 'base_rlyeh', timestamp),
+            ],
+        };
     });
 
     // 血堡：可选在刚打出的随从上放 +1 指示物
@@ -1657,6 +1809,89 @@ export function registerBaseInteractionHandlers(): void {
     });
 
     // 刚柔流寺庙：平局时拥有者选择放入牌库底的随从（链式处理多个玩家）
+    registerInteractionHandler('base_mushroom_kingdom_pod', (state, playerId, value, iData, _random, timestamp) => {
+        const selected = value as { skip?: boolean; minionUid?: string; minionDefId?: string; fromBaseIndex?: number };
+        if (selected.skip) return { state, events: [] };
+        if (!selected.minionUid || !selected.minionDefId || selected.fromBaseIndex === undefined) {
+            return { state, events: [] };
+        }
+        const ctx = getContinuationContext<{ mushroomBaseIndex: number }>(iData);
+        if (!ctx) return { state, events: [] };
+
+        if (selected.fromBaseIndex !== ctx.mushroomBaseIndex) {
+            return {
+                state,
+                events: buildValidatedMoveEvents(state, {
+                    minionUid: selected.minionUid,
+                    minionDefId: selected.minionDefId,
+                    fromBaseIndex: selected.fromBaseIndex,
+                    toBaseIndex: ctx.mushroomBaseIndex,
+                    reason: 'base_mushroom_kingdom_pod',
+                    now: timestamp,
+                }),
+            };
+        }
+
+        const baseCandidates: { baseIndex: number; label: string }[] = [];
+        for (let i = 0; i < state.core.bases.length; i++) {
+            if (i === ctx.mushroomBaseIndex) continue;
+            const bDef = getBaseDef(state.core.bases[i].defId);
+            baseCandidates.push({ baseIndex: i, label: bDef?.name ?? `基地 ${i + 1}` });
+        }
+        if (baseCandidates.length === 0) return { state, events: [] };
+        if (baseCandidates.length === 1) {
+            return {
+                state,
+                events: buildValidatedMoveEvents(state, {
+                    minionUid: selected.minionUid,
+                    minionDefId: selected.minionDefId,
+                    fromBaseIndex: selected.fromBaseIndex,
+                    toBaseIndex: baseCandidates[0].baseIndex,
+                    reason: 'base_mushroom_kingdom_pod',
+                    now: timestamp,
+                }),
+            };
+        }
+
+        const interaction = createSimpleChoice(
+            `base_mushroom_kingdom_pod_choose_base_${timestamp}`, playerId,
+            '蘑菇王国（POD）：选择要移动到的基地',
+            buildBaseTargetOptions(baseCandidates, state.core),
+            { sourceId: 'base_mushroom_kingdom_pod_choose_base', targetType: 'base' },
+        );
+        return {
+            state: queueInteraction(state, {
+                ...interaction,
+                data: {
+                    ...interaction.data,
+                    continuationContext: {
+                        minionUid: selected.minionUid,
+                        minionDefId: selected.minionDefId,
+                        fromBaseIndex: selected.fromBaseIndex,
+                    },
+                },
+            }),
+            events: [],
+        };
+    });
+
+    registerInteractionHandler('base_mushroom_kingdom_pod_choose_base', (state, _playerId, value, iData, _random, timestamp) => {
+        const { baseIndex: toBaseIndex } = value as { baseIndex: number };
+        const ctx = getContinuationContext<{ minionUid: string; minionDefId: string; fromBaseIndex: number }>(iData);
+        if (!ctx) return { state, events: [] };
+        return {
+            state,
+            events: buildValidatedMoveEvents(state, {
+                minionUid: ctx.minionUid,
+                minionDefId: ctx.minionDefId,
+                fromBaseIndex: ctx.fromBaseIndex,
+                toBaseIndex,
+                reason: 'base_mushroom_kingdom_pod',
+                now: timestamp,
+            }),
+        };
+    });
+
     registerInteractionHandler('base_temple_of_goju_tiebreak', (state, playerId, value, iData, _random, timestamp) => {
         const { minionUid, baseIndex } = value as { minionUid: string; baseIndex: number; defId: string };
         const base = state.core.bases[baseIndex];

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -6,7 +6,7 @@ import type { MatchState, ValidationResult } from '../../../engine/types';
 import type { SmashUpCommand, SmashUpCore, ActionCardDef, FusionCardDef, PlayConstraint } from './types';
 import { SU_COMMANDS, getCurrentPlayerId, HAND_LIMIT } from './types';
 import { getCardDef, getFusionDef, getMinionDef, getMinionLikePower } from '../data/cards';
-import { isOperationRestricted } from './ongoingEffects';
+import { hasPlayerTurnRestriction, isOperationRestricted } from './ongoingEffects';
 import {
     getScoringEligibleBaseIndices,
     getPlayerEffectivePowerOnBase,
@@ -37,6 +37,10 @@ function hasActiveBearNecessitiesPodRestriction(core: SmashUpCore, playerId: str
         if (hasOpponentActivePod) return true;
     }
     return false;
+}
+
+function isCurrentTurnPlayer(core: SmashUpCore, playerId: string): boolean {
+    return core.turnOrder[core.currentPlayerIndex] === playerId;
 }
 
 function isExtraMinionPlayAttempt(
@@ -254,6 +258,13 @@ export function validate(
                 hasResponseWindow: !!state.sys.responseWindow?.current,
                 windowType: state.sys.responseWindow?.current?.windowType,
             });
+
+            if (
+                hasPlayerTurnRestriction(core, command.playerId, 'play_action')
+                || (isCurrentTurnPlayer(core, command.playerId) && core.sleepMarkedPlayers?.includes(command.playerId))
+            ) {
+                return { valid: false, error: '当前效果禁止你打出战术' };
+            }
             
             // 响应窗口期间：允许当前响应者打出特殊行动卡
             const responseWindow = state.sys.responseWindow?.current;

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -1,12 +1,12 @@
-/**
- * 大杀四方 (Smash Up) - 命令验证
+﻿/**
+ * 澶ф潃鍥涙柟 (Smash Up) - 鍛戒护楠岃瘉
  */
 
 import type { MatchState, ValidationResult } from '../../../engine/types';
 import type { SmashUpCommand, SmashUpCore, ActionCardDef, FusionCardDef, PlayConstraint } from './types';
 import { SU_COMMANDS, getCurrentPlayerId, HAND_LIMIT } from './types';
 import { getCardDef, getFusionDef, getMinionDef, getMinionLikePower } from '../data/cards';
-import { isOperationRestricted } from './ongoingEffects';
+import { isCardSuppressed, isOperationRestricted } from './ongoingEffects';
 import {
     getScoringEligibleBaseIndices,
     getPlayerEffectivePowerOnBase,
@@ -76,28 +76,28 @@ export function validate(
     const currentPlayerId = getCurrentPlayerId(core);
     const phase = state.sys.phase;
 
-    // 防御性检查：确保 command 和 type 存在
+    // 闃插尽鎬ф鏌ワ細纭繚 command 鍜?type 瀛樺湪
     if (!command || typeof command.type !== 'string') {
         return { valid: false, error: 'Invalid command: missing type' };
     }
 
-    // 系统命令（SYS_ 前缀）由引擎层处理，领域层直接放行
+    // 绯荤粺鍛戒护锛圫YS_ 鍓嶇紑锛夌敱寮曟搸灞傚鐞嗭紝棰嗗煙灞傜洿鎺ユ斁琛?
     if (command.type.startsWith('SYS_')) {
         return { valid: true };
     }
 
     switch (command.type) {
         case SU_COMMANDS.PLAY_MINION: {
-            // meFirst 响应窗口期间：允许从手牌打出 beforeScoringPlayable 随从到即将计分的基地
+            // meFirst 鍝嶅簲绐楀彛鏈熼棿锛氬厑璁镐粠鎵嬬墝鎵撳嚭 beforeScoringPlayable 闅忎粠鍒板嵆灏嗚鍒嗙殑鍩哄湴
             const minionResponseWindow = state.sys.responseWindow?.current;
             if (minionResponseWindow && minionResponseWindow.windowType === 'meFirst') {
                 const responderQueue = minionResponseWindow.responderQueue;
                 const currentResponderId = responderQueue[minionResponseWindow.currentResponderIndex];
                 if (command.playerId !== currentResponderId) {
-                    return { valid: false, error: '等待对方响应' };
+                    return { valid: false, error: '绛夊緟瀵规柟鍝嶅簲' };
                 }
                 const mfPlayer = core.players[command.playerId];
-                if (!mfPlayer) return { valid: false, error: '玩家不存在' };
+                if (!mfPlayer) return { valid: false, error: '鐜╁涓嶅瓨鍦? };
                 const mfCard = mfPlayer.hand.find(c => c.uid === command.payload.cardUid);
                 if (!mfCard) return { valid: false, error: '手牌中没有该卡牌' };
                 if (!isCardMinionLike(mfCard)) return { valid: false, error: '该卡牌不是随从' };
@@ -109,43 +109,43 @@ export function validate(
                 }
                 const mfBaseIndex = command.payload.baseIndex;
                 if (mfBaseIndex < 0 || mfBaseIndex >= core.bases.length) {
-                    return { valid: false, error: '无效的基地索引' };
+                    return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
                 }
                 const mfEligible = getScoringEligibleBaseIndices(core);
                 if (!mfEligible.includes(mfBaseIndex)) {
-                    return { valid: false, error: '只能打出到即将计分的基地' };
+                    return { valid: false, error: '鍙兘鎵撳嚭鍒板嵆灏嗚鍒嗙殑鍩哄湴' };
                 }
                 if (isSpecialLimitBlocked(core, mfCard.defId, mfBaseIndex)) {
-                    return { valid: false, error: '该基地本回合已使用过同组特殊能力' };
+                    return { valid: false, error: '璇ュ熀鍦版湰鍥炲悎宸蹭娇鐢ㄨ繃鍚岀粍鐗规畩鑳藉姏' };
                 }
                 return { valid: true };
             }
 
             if (phase !== 'playCards') {
-                return { valid: false, error: '只能在出牌阶段打出随从' };
+                return { valid: false, error: '鍙兘鍦ㄥ嚭鐗岄樁娈垫墦鍑洪殢浠? };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const player = core.players[command.playerId];
-            if (!player) return { valid: false, error: '玩家不存在' };
+            if (!player) return { valid: false, error: '鐜╁涓嶅瓨鍦? };
 
             const { baseIndex, fromDiscard } = command.payload;
             if (baseIndex < 0 || baseIndex >= core.bases.length) {
-                return { valid: false, error: '无效的基地索引' };
+                return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
             }
 
-            // 从弃牌堆打出：通过 discardPlayability 模块验证
+            // 浠庡純鐗屽爢鎵撳嚭锛氶€氳繃 discardPlayability 妯″潡楠岃瘉
             if (fromDiscard) {
                 const discardCheck = canPlayFromDiscard(core, command.playerId, command.payload.cardUid, baseIndex);
                 if (!discardCheck) {
-                    return { valid: false, error: '该卡牌不能从弃牌堆打出到此基地' };
+                    return { valid: false, error: '璇ュ崱鐗屼笉鑳戒粠寮冪墝鍫嗘墦鍑哄埌姝ゅ熀鍦? };
                 }
-                // 消耗正常额度的弃牌堆出牌需要检查额度
+                // 娑堣€楁甯搁搴︾殑寮冪墝鍫嗗嚭鐗岄渶瑕佹鏌ラ搴?
                 if (discardCheck.consumesNormalLimit && player.minionsPlayed >= player.minionLimit) {
-                    return { valid: false, error: '本回合随从额度已用完' };
+                    return { valid: false, error: '鏈洖鍚堥殢浠庨搴﹀凡鐢ㄥ畬' };
                 }
-                // 限制检查
+                // 闄愬埗妫€鏌?
                 const discardCard = player.discard.find(c => c.uid === command.payload.cardUid);
                 if (!discardCard || !isCardMinionLike(discardCard)) {
                     return { valid: false, error: '弃牌堆中没有该随从' };
@@ -171,17 +171,17 @@ export function validate(
                     basePower,
                     usesBaseLimitedMinionQuota,
                 })) {
-                    return { valid: false, error: '该基地禁止打出该随从' };
+                    return { valid: false, error: '璇ュ熀鍦扮姝㈡墦鍑鸿闅忎粠' };
                 }
                 return { valid: true };
             }
 
-            // 正常手牌打出：全局额度 + 同名额度 + 基地限定额度
+            // 姝ｅ父鎵嬬墝鎵撳嚭锛氬叏灞€棰濆害 + 鍚屽悕棰濆害 + 鍩哄湴闄愬畾棰濆害
             const baseQuota = player.baseLimitedMinionQuota?.[baseIndex] ?? 0;
             const sameNameRemaining = player.sameNameMinionRemaining ?? 0;
             const globalQuotaRemaining = player.minionLimit - player.minionsPlayed;
             if (globalQuotaRemaining <= 0 && sameNameRemaining <= 0 && baseQuota <= 0) {
-                return { valid: false, error: '本回合随从额度已用完' };
+                return { valid: false, error: '鏈洖鍚堥殢浠庨搴﹀凡鐢ㄥ畬' };
             }
             const card = player.hand.find(c => c.uid === command.payload.cardUid);
             if (!card) return { valid: false, error: '手牌中没有该卡牌' };
@@ -203,39 +203,39 @@ export function validate(
                 return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
             }
             const usesBaseLimitedMinionQuota = mustUseBaseLimitedMinionQuota(core, player, baseIndex, card.defId, basePower);
-            // 同名额度检查：全局额度用完后，如果只剩同名额度，必须匹配已锁定的 defId
+            // 鍚屽悕棰濆害妫€鏌ワ細鍏ㄥ眬棰濆害鐢ㄥ畬鍚庯紝濡傛灉鍙墿鍚屽悕棰濆害锛屽繀椤诲尮閰嶅凡閿佸畾鐨?defId
             if (globalQuotaRemaining <= 0 && sameNameRemaining > 0 && baseQuota <= 0) {
-                // 已锁定 defId 时，只能打出同名随从
+                // 宸查攣瀹?defId 鏃讹紝鍙兘鎵撳嚭鍚屽悕闅忎粠
                 if (player.sameNameMinionDefId !== null && player.sameNameMinionDefId !== undefined && card.defId !== player.sameNameMinionDefId) {
-                    return { valid: false, error: '额外出牌只能打出同名随从' };
+                    return { valid: false, error: '棰濆鍑虹墝鍙兘鎵撳嚭鍚屽悕闅忎粠' };
                 }
             }
-            // 基地限定同名额度检查：全局额度和全局同名额度都用完后，使用基地限定额度时检查同名约束
+            // 鍩哄湴闄愬畾鍚屽悕棰濆害妫€鏌ワ細鍏ㄥ眬棰濆害鍜屽叏灞€鍚屽悕棰濆害閮界敤瀹屽悗锛屼娇鐢ㄥ熀鍦伴檺瀹氶搴︽椂妫€鏌ュ悓鍚嶇害鏉?
             if (usesBaseLimitedMinionQuota) {
                 if (player.baseLimitedSameNameRequired?.[baseIndex]) {
-                    // 必须与触发能力时的随从同名
+                    // 蹇呴』涓庤Е鍙戣兘鍔涙椂鐨勯殢浠庡悓鍚?
                     const requiredDefId = player.baseLimitedSameNameDefId?.[baseIndex];
                     if (requiredDefId && card.defId !== requiredDefId) {
                         const requiredCard = getCardDef(requiredDefId);
                         const requiredName = requiredCard?.name ?? requiredDefId;
-                        return { valid: false, error: `只能打出与触发能力的随从同名的随从（${requiredName}）` };
+                        return { valid: false, error: `鍙兘鎵撳嚭涓庤Е鍙戣兘鍔涚殑闅忎粠鍚屽悕鐨勯殢浠庯紙${requiredName}锛塦 };
                     }
                 }
             }
-            // 全局力量限制检查：额外出牌机会可能有力量上限（如家园：力量≤2）
+            // 鍏ㄥ眬鍔涢噺闄愬埗妫€鏌ワ細棰濆鍑虹墝鏈轰細鍙兘鏈夊姏閲忎笂闄愶紙濡傚鍥細鍔涢噺鈮?锛?
             if (mustUseGlobalPowerLimitedMinionQuota(core, player, baseIndex, card.defId, basePower)) {
                 const maxAllowedPower = getMaxRemainingGlobalPowerLimitedQuota(player);
                 if (maxAllowedPower !== undefined && basePower > maxAllowedPower) {
-                    return { valid: false, error: `额外出牌只能打出力量≤${maxAllowedPower}的随从` };
+                    return { valid: false, error: `棰濆鍑虹墝鍙兘鎵撳嚭鍔涢噺鈮?{maxAllowedPower}鐨勯殢浠巂 };
                 }
             }
-            // 限制检查：是否禁止打出随从到此基地（包括基地效果和 ongoing 效果）
+            // 闄愬埗妫€鏌ワ細鏄惁绂佹鎵撳嚭闅忎粠鍒版鍩哄湴锛堝寘鎷熀鍦版晥鏋滃拰 ongoing 鏁堟灉锛?
             if (isOperationRestricted(core, baseIndex, command.playerId, 'play_minion', {
                 minionDefId: card.defId,
                 basePower,
                 usesBaseLimitedMinionQuota,
             })) {
-                return { valid: false, error: '该基地禁止打出该随从' };
+                return { valid: false, error: '璇ュ熀鍦扮姝㈡墦鍑鸿闅忎粠' };
             }
             // 随从打出约束（数据驱动）
             const constraint = minionDef?.playConstraint ?? fusionDef?.minionPlayConstraint;
@@ -254,8 +254,8 @@ export function validate(
                 hasResponseWindow: !!state.sys.responseWindow?.current,
                 windowType: state.sys.responseWindow?.current?.windowType,
             });
-            
-            // 响应窗口期间：允许当前响应者打出特殊行动卡
+
+            // 鍝嶅簲绐楀彛鏈熼棿锛氬厑璁稿綋鍓嶅搷搴旇€呮墦鍑虹壒娈婅鍔ㄥ崱
             const responseWindow = state.sys.responseWindow?.current;
             if (responseWindow && (responseWindow.windowType === 'meFirst' || responseWindow.windowType === 'afterScoring')) {
                 const responderQueue = responseWindow.responderQueue;
@@ -270,26 +270,26 @@ export function validate(
                 
                 if (command.playerId !== currentResponderId) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - not current responder');
-                    return { valid: false, error: '等待对方响应' };
+                    return { valid: false, error: '绛夊緟瀵规柟鍝嶅簲' };
                 }
                 const rPlayer = core.players[command.playerId];
                 if (!rPlayer) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - player not found');
-                    return { valid: false, error: '玩家不存在' };
+                    return { valid: false, error: '鐜╁涓嶅瓨鍦? };
                 }
                 const rCard = rPlayer.hand.find(c => c.uid === command.payload.cardUid);
                 if (!rCard) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - card not in hand');
-                    return { valid: false, error: '手牌中没有该卡牌' };
+                    return { valid: false, error: '鎵嬬墝涓病鏈夎鍗＄墝' };
                 }
                 if (!isCardActionLike(rCard)) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - not action card');
-                    return { valid: false, error: '该卡牌不是行动卡' };
+                    return { valid: false, error: '璇ュ崱鐗屼笉鏄鍔ㄥ崱' };
                 }
                 const rDef = getCardDef(rCard.defId) as ActionCardDef | FusionCardDef | undefined;
                 if (!rDef) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - card def not found');
-                    return { valid: false, error: '卡牌定义不存在' };
+                    return { valid: false, error: '鍗＄墝瀹氫箟涓嶅瓨鍦? };
                 }
                 const responseTiming = getActionLikeResponseWindowTiming(rDef);
                 if (!responseTiming) {
@@ -306,14 +306,14 @@ export function validate(
                         cardTiming,
                         windowType: responseWindow.windowType,
                     });
-                    return { valid: false, error: '该卡牌只能在计分后打出' };
+                    return { valid: false, error: '璇ュ崱鐗屽彧鑳藉湪璁″垎鍚庢墦鍑? };
                 }
                 if (responseWindow.windowType === 'afterScoring' && cardTiming !== 'afterScoring') {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - wrong timing for afterScoring window', {
                         cardTiming,
                         windowType: responseWindow.windowType,
                     });
-                    return { valid: false, error: '该卡牌只能在计分前打出' };
+                    return { valid: false, error: '璇ュ崱鐗屽彧鑳藉湪璁″垎鍓嶆墦鍑? };
                 }
 
                 const targetBase = command.payload.targetBaseIndex;
@@ -331,10 +331,10 @@ export function validate(
                     const targetBaseIndex = targetBase;
                     if (targetBaseIndex < 0 || targetBaseIndex >= core.bases.length) {
                         console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - invalid base index');
-                        return { valid: false, error: '无效的基地索引' };
+                        return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
                     }
 
-                    // 使用统一查询函数（优先锁定列表，回退实时计算）
+                    // 浣跨敤缁熶竴鏌ヨ鍑芥暟锛堜紭鍏堥攣瀹氬垪琛紝鍥為€€瀹炴椂璁＄畻锛?
                     const eligibleIndices = getScoringEligibleBaseIndices(core);
                     console.log('[DEBUG] PLAY_ACTION validation: eligible bases', {
                         eligibleIndices,
@@ -344,10 +344,10 @@ export function validate(
                     
                     if (!eligibleIndices.includes(targetBaseIndex)) {
                         console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - base not eligible');
-                        return { valid: false, error: '只能选择达到临界点的基地' };
+                        return { valid: false, error: '鍙兘閫夋嫨杈惧埌涓寸晫鐐圭殑鍩哄湴' };
                     }
 
-                    // specialLimitGroup 检查：该基地本回合是否已使用过同组 special 能力
+                    // specialLimitGroup 妫€鏌ワ細璇ュ熀鍦版湰鍥炲悎鏄惁宸蹭娇鐢ㄨ繃鍚岀粍 special 鑳藉姏
                     const isBlocked = isSpecialLimitBlocked(core, rCard.defId, targetBaseIndex);
                     console.log('[DEBUG] PLAY_ACTION validation: special limit check', {
                         cardDefId: rCard.defId,
@@ -357,7 +357,7 @@ export function validate(
                     
                     if (isBlocked) {
                         console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - special limit');
-                        return { valid: false, error: '该基地本回合已使用过同组特殊能力' };
+                        return { valid: false, error: '璇ュ熀鍦版湰鍥炲悎宸蹭娇鐢ㄨ繃鍚岀粍鐗规畩鑳藉姏' };
                     }
                 } else if (targetBase !== undefined) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - base provided but not needed');
@@ -369,7 +369,7 @@ export function validate(
             }
 
             if (phase !== 'playCards') {
-                return { valid: false, error: '只能在出牌阶段打出行动卡' };
+                return { valid: false, error: '鍙兘鍦ㄥ嚭鐗岄樁娈垫墦鍑鸿鍔ㄥ崱' };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
@@ -380,7 +380,7 @@ export function validate(
                 return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
             }
             if (player.actionsPlayed >= player.actionLimit) {
-                return { valid: false, error: '本回合行动额度已用完' };
+                return { valid: false, error: '鏈洖鍚堣鍔ㄩ搴﹀凡鐢ㄥ畬' };
             }
             const card = player.hand.find(c => c.uid === command.payload.cardUid);
             if (!card) return { valid: false, error: '手牌中没有该卡牌' };
@@ -396,20 +396,20 @@ export function validate(
                     ? ((def as FusionCardDef).actionSpecialTiming ?? 'beforeScoring')
                     : ((def as ActionCardDef).specialTiming ?? 'beforeScoring');
                 if (cardTiming === 'beforeScoring') {
-                    return { valid: false, error: '该特殊行动卡只能在基地计分前的响应窗口中打出' };
+                    return { valid: false, error: '璇ョ壒娈婅鍔ㄥ崱鍙兘鍦ㄥ熀鍦拌鍒嗗墠鐨勫搷搴旂獥鍙ｄ腑鎵撳嚭' };
                 } else {
-                    return { valid: false, error: '该特殊行动卡只能在基地计分后的响应窗口中打出' };
+                    return { valid: false, error: '璇ョ壒娈婅鍔ㄥ崱鍙兘鍦ㄥ熀鍦拌鍒嗗悗鐨勫搷搴旂獥鍙ｄ腑鎵撳嚭' };
                 }
             }
 
-            // 持续行动卡：必须显式选择附着目标
+            // 鎸佺画琛屽姩鍗★細蹇呴』鏄惧紡閫夋嫨闄勭潃鐩爣
             const targetBase = command.payload.targetBaseIndex;
             if (subtype === 'ongoing') {
                 if (typeof targetBase !== 'number' || !Number.isInteger(targetBase)) {
-                    return { valid: false, error: '持续行动卡需要选择目标基地' };
+                    return { valid: false, error: '鎸佺画琛屽姩鍗￠渶瑕侀€夋嫨鐩爣鍩哄湴' };
                 }
                 if (targetBase < 0 || targetBase >= core.bases.length) {
-                    return { valid: false, error: '无效的基地索引' };
+                    return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
                 }
 
                 const ongoingTarget = (def as any).type === 'fusion'
@@ -418,14 +418,14 @@ export function validate(
                 const targetMinionUid = command.payload.targetMinionUid;
                 if (ongoingTarget === 'minion') {
                     if (!targetMinionUid) {
-                        return { valid: false, error: '该持续行动卡需要选择目标随从' };
+                        return { valid: false, error: '璇ユ寔缁鍔ㄥ崱闇€瑕侀€夋嫨鐩爣闅忎粠' };
                     }
                     const targetMinion = core.bases[targetBase].minions.find(m => m.uid === targetMinionUid);
                     if (!targetMinion) {
-                        return { valid: false, error: '基地上没有该随从' };
+                        return { valid: false, error: '鍩哄湴涓婃病鏈夎闅忎粠' };
                     }
                 } else if (targetMinionUid !== undefined) {
-                    return { valid: false, error: '该持续行动卡不需要选择随从目标' };
+                    return { valid: false, error: '璇ユ寔缁鍔ㄥ崱涓嶉渶瑕侀€夋嫨闅忎粠鐩爣' };
                 }
 
                 // 打出约束检查（数据驱动）
@@ -438,14 +438,14 @@ export function validate(
                 }
             }
 
-            // ongoing 限制检查：是否禁止打出行动卡到目标基地
-            // 注意：ongoingTarget='minion' 的行动卡附着到随从上，不受基地 play_action 限制
+            // ongoing 闄愬埗妫€鏌ワ細鏄惁绂佹鎵撳嚭琛屽姩鍗″埌鐩爣鍩哄湴
+            // 娉ㄦ剰锛歰ngoingTarget='minion' 鐨勮鍔ㄥ崱闄勭潃鍒伴殢浠庝笂锛屼笉鍙楀熀鍦?play_action 闄愬埗
             if (typeof targetBase === 'number') {
                 const ongoingTarget = (def as any).type === 'fusion'
                     ? ((def as FusionCardDef).actionOngoingTarget ?? 'base')
                     : (((def as ActionCardDef).ongoingTarget ?? 'base'));
                 if (ongoingTarget === 'base' && isOperationRestricted(core, targetBase, command.playerId, 'play_action')) {
-                    return { valid: false, error: '该基地禁止打出行动卡' };
+                    return { valid: false, error: '璇ュ熀鍦扮姝㈡墦鍑鸿鍔ㄥ崱' };
                 }
             }
             return { valid: true };
@@ -453,22 +453,22 @@ export function validate(
 
         case SU_COMMANDS.DISCARD_TO_LIMIT: {
             if (phase !== 'draw') {
-                return { valid: false, error: '只能在抽牌阶段弃牌' };
+                return { valid: false, error: '鍙兘鍦ㄦ娊鐗岄樁娈靛純鐗? };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const player = core.players[command.playerId];
-            if (!player) return { valid: false, error: '玩家不存在' };
+            if (!player) return { valid: false, error: '鐜╁涓嶅瓨鍦? };
             const excess = player.hand.length - HAND_LIMIT;
-            if (excess <= 0) return { valid: false, error: '手牌未超过上限' };
+            if (excess <= 0) return { valid: false, error: '鎵嬬墝鏈秴杩囦笂闄? };
             if (command.payload.cardUids.length !== excess) {
-                return { valid: false, error: `需要弃掉 ${excess} 张牌` };
+                return { valid: false, error: `闇€瑕佸純鎺?${excess} 寮犵墝` };
             }
             const handUids = new Set(player.hand.map(c => c.uid));
             for (const uid of command.payload.cardUids) {
                 if (!handUids.has(uid)) {
-                    return { valid: false, error: `手牌中不存在 uid=${uid}` };
+                    return { valid: false, error: `鎵嬬墝涓笉瀛樺湪 uid=${uid}` };
                 }
             }
             return { valid: true };
@@ -476,22 +476,22 @@ export function validate(
 
         case SU_COMMANDS.SELECT_FACTION: {
             if (phase !== 'factionSelect') {
-                return { valid: false, error: '只能在派系选择阶段选择派系' };
+                return { valid: false, error: '鍙兘鍦ㄦ淳绯婚€夋嫨闃舵閫夋嫨娲剧郴' };
             }
             // Check turn order strictness
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const selection = core.factionSelection;
-            if (!selection) return { valid: false, error: '派系选择状态未初始化' };
+            if (!selection) return { valid: false, error: '娲剧郴閫夋嫨鐘舵€佹湭鍒濆鍖? };
 
             const factionId = command.payload.factionId;
             if (selection.takenFactions.includes(factionId)) {
-                return { valid: false, error: '该派系已被选择' };
+                return { valid: false, error: '璇ユ淳绯诲凡琚€夋嫨' };
             }
             const playerSelections = selection.playerSelections[command.playerId] || [];
             if (playerSelections.length >= 2) {
-                return { valid: false, error: '你已选择了两个派系' };
+                return { valid: false, error: '浣犲凡閫夋嫨浜嗕袱涓淳绯? };
             }
 
             return { valid: true };
@@ -499,114 +499,123 @@ export function validate(
 
         case SU_COMMANDS.USE_TALENT: {
             if (phase !== 'playCards') {
-                return { valid: false, error: '只能在出牌阶段使用天赋' };
+                return { valid: false, error: '鍙兘鍦ㄥ嚭鐗岄樁娈典娇鐢ㄥぉ璧? };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const { minionUid, ongoingCardUid, baseIndex } = command.payload;
             const targetBase = core.bases[baseIndex];
-            if (!targetBase) return { valid: false, error: '无效的基地索引' };
+            if (!targetBase) return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
 
-            // ongoing 行动卡天赋（基地上或随从附着）
+            // ongoing 琛屽姩鍗″ぉ璧嬶紙鍩哄湴涓婃垨闅忎粠闄勭潃锛?
             if (ongoingCardUid) {
-                // 先查基地 ongoingActions
+                // 鍏堟煡鍩哄湴 ongoingActions
                 let ongoing = targetBase.ongoingActions.find(o => o.uid === ongoingCardUid);
-                // 再查随从 attachedActions
+                // 鍐嶆煡闅忎粠 attachedActions
                 if (!ongoing) {
                     for (const m of targetBase.minions) {
                         const aa = m.attachedActions.find(a => a.uid === ongoingCardUid);
                         if (aa) { ongoing = aa; break; }
                     }
                 }
-                if (!ongoing) return { valid: false, error: '基地上没有该持续行动卡' };
+                if (!ongoing) return { valid: false, error: '鍩哄湴涓婃病鏈夎鎸佺画琛屽姩鍗? };
                 if (ongoing.ownerId !== command.playerId) {
-                    return { valid: false, error: '只能使用自己的持续行动卡天赋' };
+                    return { valid: false, error: '鍙兘浣跨敤鑷繁鐨勬寔缁鍔ㄥ崱澶╄祴' };
                 }
                 if (ongoing.talentUsed) {
-                    return { valid: false, error: '本回合天赋已使用' };
+                    return { valid: false, error: '鏈洖鍚堝ぉ璧嬪凡浣跨敤' };
+                }
+                if (isCardSuppressed(core, ongoingCardUid)) {
+                    return { valid: false, error: '璇ュ崱鐗岃兘鍔涘凡琚帇鍒? };
                 }
                 const oDef = getCardDef(ongoing.defId);
                 if (!oDef || !('abilityTags' in oDef) || !oDef.abilityTags?.includes('talent')) {
-                    return { valid: false, error: '该持续行动卡没有天赋能力' };
+                    return { valid: false, error: '璇ユ寔缁鍔ㄥ崱娌℃湁澶╄祴鑳藉姏' };
                 }
                 return { valid: true };
             }
 
-            // 随从天赋
-            if (!minionUid) return { valid: false, error: '必须指定随从或持续行动卡' };
+            // 闅忎粠澶╄祴
+            if (!minionUid) return { valid: false, error: '蹇呴』鎸囧畾闅忎粠鎴栨寔缁鍔ㄥ崱' };
             const targetMinion = targetBase.minions.find(m => m.uid === minionUid);
-            if (!targetMinion) return { valid: false, error: '基地上没有该随从' };
+            if (!targetMinion) return { valid: false, error: '鍩哄湴涓婃病鏈夎闅忎粠' };
             if (targetMinion.controller !== command.playerId) {
-                return { valid: false, error: '只能使用自己控制的随从的天赋' };
+                return { valid: false, error: '鍙兘浣跨敤鑷繁鎺у埗鐨勯殢浠庣殑澶╄祴' };
             }
             if (targetMinion.talentUsed) {
-                // 巨石阵例外：允许一个随从每回合使用才能两次
+                // 宸ㄧ煶闃典緥澶栵細鍏佽涓€涓殢浠庢瘡鍥炲悎浣跨敤鎵嶈兘涓ゆ
                 const isStandingStones = targetBase.defId === 'base_standing_stones';
                 const doubleTalentAvailable = !core.standingStonesDoubleTalentMinionUid;
                 if (!(isStandingStones && doubleTalentAvailable)) {
-                    return { valid: false, error: '本回合天赋已使用' };
+                    return { valid: false, error: '鏈洖鍚堝ぉ璧嬪凡浣跨敤' };
                 }
             }
-            // 检查是否有天赋能力
+            if (isCardSuppressed(core, minionUid)) {
+                return { valid: false, error: '璇ュ崱鐗岃兘鍔涘凡琚帇鍒? };
+            }
+            // 妫€鏌ユ槸鍚︽湁澶╄祴鑳藉姏
             const mDef = getCardDef(targetMinion.defId);
             if (!mDef || !('abilityTags' in mDef) || !mDef.abilityTags?.includes('talent')) {
-                return { valid: false, error: '该随从没有天赋能力' };
+                return { valid: false, error: '璇ラ殢浠庢病鏈夊ぉ璧嬭兘鍔? };
             }
             return { valid: true };
         }
 
         case SU_COMMANDS.ACTIVATE_SPECIAL: {
-            // 允许在 playCards 和 scoreBases 阶段激活特殊能力
-            // scoreBases 阶段：基地计分前的 beforeScoring 特殊能力（如忍者侍从）
+            // 鍏佽鍦?playCards 鍜?scoreBases 闃舵婵€娲荤壒娈婅兘鍔?
+            // scoreBases 闃舵锛氬熀鍦拌鍒嗗墠鐨?beforeScoring 鐗规畩鑳藉姏锛堝蹇嶈€呬緧浠庯級
             if (phase !== 'playCards' && phase !== 'scoreBases') {
-                return { valid: false, error: '只能在出牌阶段或计分阶段激活特殊能力' };
+                return { valid: false, error: '鍙兘鍦ㄥ嚭鐗岄樁娈垫垨璁″垎闃舵婵€娲荤壒娈婅兘鍔? };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const { minionUid: spMinionUid, baseIndex: spBaseIndex } = command.payload;
             const spBase = core.bases[spBaseIndex];
-            if (!spBase) return { valid: false, error: '无效的基地索引' };
+            if (!spBase) return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
             const spMinion = spBase.minions.find(m => m.uid === spMinionUid);
-            if (!spMinion) return { valid: false, error: '基地上没有该随从' };
+            if (!spMinion) return { valid: false, error: '鍩哄湴涓婃病鏈夎闅忎粠' };
             if (spMinion.controller !== command.playerId) {
-                return { valid: false, error: '只能激活自己控制的随从的特殊能力' };
+                return { valid: false, error: '鍙兘婵€娲昏嚜宸辨帶鍒剁殑闅忎粠鐨勭壒娈婅兘鍔? };
             }
             const spDef = getCardDef(spMinion.defId);
             if (!spDef || !('abilityTags' in spDef) || !spDef.abilityTags?.includes('special')) {
-                return { valid: false, error: '该随从没有特殊能力' };
+                return { valid: false, error: '璇ラ殢浠庢病鏈夌壒娈婅兘鍔? };
             }
-            // specialLimitGroup 检查
+            if (isCardSuppressed(core, spMinionUid)) {
+                return { valid: false, error: '璇ュ崱鐗岃兘鍔涘凡琚帇鍒? };
+            }
+            // specialLimitGroup 妫€鏌?
             if (isSpecialLimitBlocked(core, spMinion.defId, spBaseIndex)) {
-                return { valid: false, error: '该基地本回合已使用过同组特殊能力' };
+                return { valid: false, error: '璇ュ熀鍦版湰鍥炲悎宸蹭娇鐢ㄨ繃鍚岀粍鐗规畩鑳藉姏' };
             }
-            // scoreBases 阶段额外验证：只能在达标基地上激活
+            // scoreBases 闃舵棰濆楠岃瘉锛氬彧鑳藉湪杈炬爣鍩哄湴涓婃縺娲?
             if (phase === 'scoreBases') {
                 const eligibleIndices = getScoringEligibleBaseIndices(core);
                 if (!eligibleIndices.includes(spBaseIndex)) {
-                    return { valid: false, error: '只能在达到临界点的基地上激活计分前特殊能力' };
+                    return { valid: false, error: '鍙兘鍦ㄨ揪鍒颁复鐣岀偣鐨勫熀鍦颁笂婵€娲昏鍒嗗墠鐗规畩鑳藉姏' };
                 }
-                // 响应窗口仍打开时不允许激活（Me First! 优先）
+                // 鍝嶅簲绐楀彛浠嶆墦寮€鏃朵笉鍏佽婵€娲伙紙Me First! 浼樺厛锛?
                 if (state.sys.responseWindow?.current) {
-                    return { valid: false, error: 'Me First! 响应窗口仍在进行中' };
+                    return { valid: false, error: 'Me First! 鍝嶅簲绐楀彛浠嶅湪杩涜涓? };
                 }
             }
             return { valid: true };
         }
 
         default:
-            // RESPONSE_PASS 由引擎 ResponseWindowSystem 处理，领域层直接放行
+            // RESPONSE_PASS 鐢卞紩鎿?ResponseWindowSystem 澶勭悊锛岄鍩熷眰鐩存帴鏀捐
             if ((command as { type: string }).type === 'RESPONSE_PASS') {
                 return { valid: true };
             }
-            return { valid: false, error: '未知命令' };
+            return { valid: false, error: '鏈煡鍛戒护' };
     }
 }
 
 /**
- * 通用打出约束检查（数据驱动）。
- * 返回 null 表示通过，返回字符串表示拒绝原因。
+ * 閫氱敤鎵撳嚭绾︽潫妫€鏌ワ紙鏁版嵁椹卞姩锛夈€?
+ * 杩斿洖 null 琛ㄧず閫氳繃锛岃繑鍥炲瓧绗︿覆琛ㄧず鎷掔粷鍘熷洜銆?
  */
 function checkPlayConstraint(
     constraint: PlayConstraint,
@@ -616,21 +625,22 @@ function checkPlayConstraint(
 ): string | null {
     if (constraint === 'requireOwnMinion') {
         const hasOwnMinion = core.bases[baseIndex].minions.some(m => m.controller === playerId);
-        if (!hasOwnMinion) return '目标基地上必须有你的随从';
+        if (!hasOwnMinion) return '鐩爣鍩哄湴涓婂繀椤绘湁浣犵殑闅忎粠';
         return null;
     }
     if (constraint === 'onlyCardInHand') {
         const handSize = core.players[playerId]?.hand.length ?? 0;
-        if (handSize !== 1) return '只能在本卡是你的唯一手牌时打出';
+        if (handSize !== 1) return '鍙兘鍦ㄦ湰鍗℃槸浣犵殑鍞竴鎵嬬墝鏃舵墦鍑?;
         return null;
     }
     if (typeof constraint === 'object' && constraint.type === 'requireOwnPower') {
         const base = core.bases[baseIndex];
         const myPower = getPlayerEffectivePowerOnBase(core, base, baseIndex, playerId);
         if (myPower < constraint.minPower) {
-            return `只能打到你至少拥有${constraint.minPower}点力量的基地`;
+            return `鍙兘鎵撳埌浣犺嚦灏戞嫢鏈?{constraint.minPower}鐐瑰姏閲忕殑鍩哄湴`;
         }
         return null;
     }
     return null;
 }
+

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -1,5 +1,5 @@
-﻿/**
- * 澶ф潃鍥涙柟 (Smash Up) - 鍛戒护楠岃瘉
+/**
+ * 大杀四方 (Smash Up) - 命令验证
  */
 
 import type { MatchState, ValidationResult } from '../../../engine/types';
@@ -76,28 +76,28 @@ export function validate(
     const currentPlayerId = getCurrentPlayerId(core);
     const phase = state.sys.phase;
 
-    // 闃插尽鎬ф鏌ワ細纭繚 command 鍜?type 瀛樺湪
+    // 防御性检查：确保 command 和 type 存在
     if (!command || typeof command.type !== 'string') {
         return { valid: false, error: 'Invalid command: missing type' };
     }
 
-    // 绯荤粺鍛戒护锛圫YS_ 鍓嶇紑锛夌敱寮曟搸灞傚鐞嗭紝棰嗗煙灞傜洿鎺ユ斁琛?
+    // 系统命令（SYS_ 前缀）由引擎层处理，领域层直接放行
     if (command.type.startsWith('SYS_')) {
         return { valid: true };
     }
 
     switch (command.type) {
         case SU_COMMANDS.PLAY_MINION: {
-            // meFirst 鍝嶅簲绐楀彛鏈熼棿锛氬厑璁镐粠鎵嬬墝鎵撳嚭 beforeScoringPlayable 闅忎粠鍒板嵆灏嗚鍒嗙殑鍩哄湴
+            // meFirst 响应窗口期间：允许从手牌打出 beforeScoringPlayable 随从到即将计分的基地
             const minionResponseWindow = state.sys.responseWindow?.current;
             if (minionResponseWindow && minionResponseWindow.windowType === 'meFirst') {
                 const responderQueue = minionResponseWindow.responderQueue;
                 const currentResponderId = responderQueue[minionResponseWindow.currentResponderIndex];
                 if (command.playerId !== currentResponderId) {
-                    return { valid: false, error: '绛夊緟瀵规柟鍝嶅簲' };
+                    return { valid: false, error: '等待对方响应' };
                 }
                 const mfPlayer = core.players[command.playerId];
-                if (!mfPlayer) return { valid: false, error: '鐜╁涓嶅瓨鍦? };
+                if (!mfPlayer) return { valid: false, error: '玩家不存在' };
                 const mfCard = mfPlayer.hand.find(c => c.uid === command.payload.cardUid);
                 if (!mfCard) return { valid: false, error: '手牌中没有该卡牌' };
                 if (!isCardMinionLike(mfCard)) return { valid: false, error: '该卡牌不是随从' };
@@ -109,43 +109,43 @@ export function validate(
                 }
                 const mfBaseIndex = command.payload.baseIndex;
                 if (mfBaseIndex < 0 || mfBaseIndex >= core.bases.length) {
-                    return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
+                    return { valid: false, error: '无效的基地索引' };
                 }
                 const mfEligible = getScoringEligibleBaseIndices(core);
                 if (!mfEligible.includes(mfBaseIndex)) {
-                    return { valid: false, error: '鍙兘鎵撳嚭鍒板嵆灏嗚鍒嗙殑鍩哄湴' };
+                    return { valid: false, error: '只能打出到即将计分的基地' };
                 }
                 if (isSpecialLimitBlocked(core, mfCard.defId, mfBaseIndex)) {
-                    return { valid: false, error: '璇ュ熀鍦版湰鍥炲悎宸蹭娇鐢ㄨ繃鍚岀粍鐗规畩鑳藉姏' };
+                    return { valid: false, error: '该基地本回合已使用过同组特殊能力' };
                 }
                 return { valid: true };
             }
 
             if (phase !== 'playCards') {
-                return { valid: false, error: '鍙兘鍦ㄥ嚭鐗岄樁娈垫墦鍑洪殢浠? };
+                return { valid: false, error: '只能在出牌阶段打出随从' };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const player = core.players[command.playerId];
-            if (!player) return { valid: false, error: '鐜╁涓嶅瓨鍦? };
+            if (!player) return { valid: false, error: '玩家不存在' };
 
             const { baseIndex, fromDiscard } = command.payload;
             if (baseIndex < 0 || baseIndex >= core.bases.length) {
-                return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
+                return { valid: false, error: '无效的基地索引' };
             }
 
-            // 浠庡純鐗屽爢鎵撳嚭锛氶€氳繃 discardPlayability 妯″潡楠岃瘉
+            // 从弃牌堆打出：通过 discardPlayability 模块验证
             if (fromDiscard) {
                 const discardCheck = canPlayFromDiscard(core, command.playerId, command.payload.cardUid, baseIndex);
                 if (!discardCheck) {
-                    return { valid: false, error: '璇ュ崱鐗屼笉鑳戒粠寮冪墝鍫嗘墦鍑哄埌姝ゅ熀鍦? };
+                    return { valid: false, error: '该卡牌不能从弃牌堆打出到此基地' };
                 }
-                // 娑堣€楁甯搁搴︾殑寮冪墝鍫嗗嚭鐗岄渶瑕佹鏌ラ搴?
+                // 消耗正常额度的弃牌堆出牌需要检查额度
                 if (discardCheck.consumesNormalLimit && player.minionsPlayed >= player.minionLimit) {
-                    return { valid: false, error: '鏈洖鍚堥殢浠庨搴﹀凡鐢ㄥ畬' };
+                    return { valid: false, error: '本回合随从额度已用完' };
                 }
-                // 闄愬埗妫€鏌?
+                // 限制检查
                 const discardCard = player.discard.find(c => c.uid === command.payload.cardUid);
                 if (!discardCard || !isCardMinionLike(discardCard)) {
                     return { valid: false, error: '弃牌堆中没有该随从' };
@@ -171,17 +171,17 @@ export function validate(
                     basePower,
                     usesBaseLimitedMinionQuota,
                 })) {
-                    return { valid: false, error: '璇ュ熀鍦扮姝㈡墦鍑鸿闅忎粠' };
+                    return { valid: false, error: '该基地禁止打出该随从' };
                 }
                 return { valid: true };
             }
 
-            // 姝ｅ父鎵嬬墝鎵撳嚭锛氬叏灞€棰濆害 + 鍚屽悕棰濆害 + 鍩哄湴闄愬畾棰濆害
+            // 正常手牌打出：全局额度 + 同名额度 + 基地限定额度
             const baseQuota = player.baseLimitedMinionQuota?.[baseIndex] ?? 0;
             const sameNameRemaining = player.sameNameMinionRemaining ?? 0;
             const globalQuotaRemaining = player.minionLimit - player.minionsPlayed;
             if (globalQuotaRemaining <= 0 && sameNameRemaining <= 0 && baseQuota <= 0) {
-                return { valid: false, error: '鏈洖鍚堥殢浠庨搴﹀凡鐢ㄥ畬' };
+                return { valid: false, error: '本回合随从额度已用完' };
             }
             const card = player.hand.find(c => c.uid === command.payload.cardUid);
             if (!card) return { valid: false, error: '手牌中没有该卡牌' };
@@ -203,39 +203,39 @@ export function validate(
                 return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
             }
             const usesBaseLimitedMinionQuota = mustUseBaseLimitedMinionQuota(core, player, baseIndex, card.defId, basePower);
-            // 鍚屽悕棰濆害妫€鏌ワ細鍏ㄥ眬棰濆害鐢ㄥ畬鍚庯紝濡傛灉鍙墿鍚屽悕棰濆害锛屽繀椤诲尮閰嶅凡閿佸畾鐨?defId
+            // 同名额度检查：全局额度用完后，如果只剩同名额度，必须匹配已锁定的 defId
             if (globalQuotaRemaining <= 0 && sameNameRemaining > 0 && baseQuota <= 0) {
-                // 宸查攣瀹?defId 鏃讹紝鍙兘鎵撳嚭鍚屽悕闅忎粠
+                // 已锁定 defId 时，只能打出同名随从
                 if (player.sameNameMinionDefId !== null && player.sameNameMinionDefId !== undefined && card.defId !== player.sameNameMinionDefId) {
-                    return { valid: false, error: '棰濆鍑虹墝鍙兘鎵撳嚭鍚屽悕闅忎粠' };
+                    return { valid: false, error: '额外出牌只能打出同名随从' };
                 }
             }
-            // 鍩哄湴闄愬畾鍚屽悕棰濆害妫€鏌ワ細鍏ㄥ眬棰濆害鍜屽叏灞€鍚屽悕棰濆害閮界敤瀹屽悗锛屼娇鐢ㄥ熀鍦伴檺瀹氶搴︽椂妫€鏌ュ悓鍚嶇害鏉?
+            // 基地限定同名额度检查：全局额度和全局同名额度都用完后，使用基地限定额度时检查同名约束
             if (usesBaseLimitedMinionQuota) {
                 if (player.baseLimitedSameNameRequired?.[baseIndex]) {
-                    // 蹇呴』涓庤Е鍙戣兘鍔涙椂鐨勯殢浠庡悓鍚?
+                    // 必须与触发能力时的随从同名
                     const requiredDefId = player.baseLimitedSameNameDefId?.[baseIndex];
                     if (requiredDefId && card.defId !== requiredDefId) {
                         const requiredCard = getCardDef(requiredDefId);
                         const requiredName = requiredCard?.name ?? requiredDefId;
-                        return { valid: false, error: `鍙兘鎵撳嚭涓庤Е鍙戣兘鍔涚殑闅忎粠鍚屽悕鐨勯殢浠庯紙${requiredName}锛塦 };
+                        return { valid: false, error: `只能打出与触发能力的随从同名的随从（${requiredName}）` };
                     }
                 }
             }
-            // 鍏ㄥ眬鍔涢噺闄愬埗妫€鏌ワ細棰濆鍑虹墝鏈轰細鍙兘鏈夊姏閲忎笂闄愶紙濡傚鍥細鍔涢噺鈮?锛?
+            // 全局力量限制检查：额外出牌机会可能有力量上限（如家园：力量≤2）
             if (mustUseGlobalPowerLimitedMinionQuota(core, player, baseIndex, card.defId, basePower)) {
                 const maxAllowedPower = getMaxRemainingGlobalPowerLimitedQuota(player);
                 if (maxAllowedPower !== undefined && basePower > maxAllowedPower) {
-                    return { valid: false, error: `棰濆鍑虹墝鍙兘鎵撳嚭鍔涢噺鈮?{maxAllowedPower}鐨勯殢浠巂 };
+                    return { valid: false, error: `额外出牌只能打出力量≤${maxAllowedPower}的随从` };
                 }
             }
-            // 闄愬埗妫€鏌ワ細鏄惁绂佹鎵撳嚭闅忎粠鍒版鍩哄湴锛堝寘鎷熀鍦版晥鏋滃拰 ongoing 鏁堟灉锛?
+            // 限制检查：是否禁止打出随从到此基地（包括基地效果和 ongoing 效果）
             if (isOperationRestricted(core, baseIndex, command.playerId, 'play_minion', {
                 minionDefId: card.defId,
                 basePower,
                 usesBaseLimitedMinionQuota,
             })) {
-                return { valid: false, error: '璇ュ熀鍦扮姝㈡墦鍑鸿闅忎粠' };
+                return { valid: false, error: '该基地禁止打出该随从' };
             }
             // 随从打出约束（数据驱动）
             const constraint = minionDef?.playConstraint ?? fusionDef?.minionPlayConstraint;
@@ -255,7 +255,7 @@ export function validate(
                 windowType: state.sys.responseWindow?.current?.windowType,
             });
 
-            // 鍝嶅簲绐楀彛鏈熼棿锛氬厑璁稿綋鍓嶅搷搴旇€呮墦鍑虹壒娈婅鍔ㄥ崱
+            // 响应窗口期间：允许当前响应者打出特殊行动卡
             const responseWindow = state.sys.responseWindow?.current;
             if (responseWindow && (responseWindow.windowType === 'meFirst' || responseWindow.windowType === 'afterScoring')) {
                 const responderQueue = responseWindow.responderQueue;
@@ -270,26 +270,26 @@ export function validate(
                 
                 if (command.playerId !== currentResponderId) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - not current responder');
-                    return { valid: false, error: '绛夊緟瀵规柟鍝嶅簲' };
+                    return { valid: false, error: '等待对方响应' };
                 }
                 const rPlayer = core.players[command.playerId];
                 if (!rPlayer) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - player not found');
-                    return { valid: false, error: '鐜╁涓嶅瓨鍦? };
+                    return { valid: false, error: '玩家不存在' };
                 }
                 const rCard = rPlayer.hand.find(c => c.uid === command.payload.cardUid);
                 if (!rCard) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - card not in hand');
-                    return { valid: false, error: '鎵嬬墝涓病鏈夎鍗＄墝' };
+                    return { valid: false, error: '手牌中没有该卡牌' };
                 }
                 if (!isCardActionLike(rCard)) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - not action card');
-                    return { valid: false, error: '璇ュ崱鐗屼笉鏄鍔ㄥ崱' };
+                    return { valid: false, error: '该卡牌不是行动卡' };
                 }
                 const rDef = getCardDef(rCard.defId) as ActionCardDef | FusionCardDef | undefined;
                 if (!rDef) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - card def not found');
-                    return { valid: false, error: '鍗＄墝瀹氫箟涓嶅瓨鍦? };
+                    return { valid: false, error: '卡牌定义不存在' };
                 }
                 const responseTiming = getActionLikeResponseWindowTiming(rDef);
                 if (!responseTiming) {
@@ -306,14 +306,14 @@ export function validate(
                         cardTiming,
                         windowType: responseWindow.windowType,
                     });
-                    return { valid: false, error: '璇ュ崱鐗屽彧鑳藉湪璁″垎鍚庢墦鍑? };
+                    return { valid: false, error: '该卡牌只能在计分后打出' };
                 }
                 if (responseWindow.windowType === 'afterScoring' && cardTiming !== 'afterScoring') {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - wrong timing for afterScoring window', {
                         cardTiming,
                         windowType: responseWindow.windowType,
                     });
-                    return { valid: false, error: '璇ュ崱鐗屽彧鑳藉湪璁″垎鍓嶆墦鍑? };
+                    return { valid: false, error: '该卡牌只能在计分前打出' };
                 }
 
                 const targetBase = command.payload.targetBaseIndex;
@@ -331,10 +331,10 @@ export function validate(
                     const targetBaseIndex = targetBase;
                     if (targetBaseIndex < 0 || targetBaseIndex >= core.bases.length) {
                         console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - invalid base index');
-                        return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
+                        return { valid: false, error: '无效的基地索引' };
                     }
 
-                    // 浣跨敤缁熶竴鏌ヨ鍑芥暟锛堜紭鍏堥攣瀹氬垪琛紝鍥為€€瀹炴椂璁＄畻锛?
+                    // 使用统一查询函数（优先锁定列表，回退实时计算）
                     const eligibleIndices = getScoringEligibleBaseIndices(core);
                     console.log('[DEBUG] PLAY_ACTION validation: eligible bases', {
                         eligibleIndices,
@@ -344,10 +344,10 @@ export function validate(
                     
                     if (!eligibleIndices.includes(targetBaseIndex)) {
                         console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - base not eligible');
-                        return { valid: false, error: '鍙兘閫夋嫨杈惧埌涓寸晫鐐圭殑鍩哄湴' };
+                        return { valid: false, error: '只能选择达到临界点的基地' };
                     }
 
-                    // specialLimitGroup 妫€鏌ワ細璇ュ熀鍦版湰鍥炲悎鏄惁宸蹭娇鐢ㄨ繃鍚岀粍 special 鑳藉姏
+                    // specialLimitGroup 检查：该基地本回合是否已使用过同组 special 能力
                     const isBlocked = isSpecialLimitBlocked(core, rCard.defId, targetBaseIndex);
                     console.log('[DEBUG] PLAY_ACTION validation: special limit check', {
                         cardDefId: rCard.defId,
@@ -357,7 +357,7 @@ export function validate(
                     
                     if (isBlocked) {
                         console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - special limit');
-                        return { valid: false, error: '璇ュ熀鍦版湰鍥炲悎宸蹭娇鐢ㄨ繃鍚岀粍鐗规畩鑳藉姏' };
+                        return { valid: false, error: '该基地本回合已使用过同组特殊能力' };
                     }
                 } else if (targetBase !== undefined) {
                     console.log('[DEBUG] PLAY_ACTION validation: BLOCKED - base provided but not needed');
@@ -369,7 +369,7 @@ export function validate(
             }
 
             if (phase !== 'playCards') {
-                return { valid: false, error: '鍙兘鍦ㄥ嚭鐗岄樁娈垫墦鍑鸿鍔ㄥ崱' };
+                return { valid: false, error: '只能在出牌阶段打出行动卡' };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
@@ -380,7 +380,7 @@ export function validate(
                 return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
             }
             if (player.actionsPlayed >= player.actionLimit) {
-                return { valid: false, error: '鏈洖鍚堣鍔ㄩ搴﹀凡鐢ㄥ畬' };
+                return { valid: false, error: '本回合行动额度已用完' };
             }
             const card = player.hand.find(c => c.uid === command.payload.cardUid);
             if (!card) return { valid: false, error: '手牌中没有该卡牌' };
@@ -396,20 +396,20 @@ export function validate(
                     ? ((def as FusionCardDef).actionSpecialTiming ?? 'beforeScoring')
                     : ((def as ActionCardDef).specialTiming ?? 'beforeScoring');
                 if (cardTiming === 'beforeScoring') {
-                    return { valid: false, error: '璇ョ壒娈婅鍔ㄥ崱鍙兘鍦ㄥ熀鍦拌鍒嗗墠鐨勫搷搴旂獥鍙ｄ腑鎵撳嚭' };
+                    return { valid: false, error: '该特殊行动卡只能在基地计分前的响应窗口中打出' };
                 } else {
-                    return { valid: false, error: '璇ョ壒娈婅鍔ㄥ崱鍙兘鍦ㄥ熀鍦拌鍒嗗悗鐨勫搷搴旂獥鍙ｄ腑鎵撳嚭' };
+                    return { valid: false, error: '该特殊行动卡只能在基地计分后的响应窗口中打出' };
                 }
             }
 
-            // 鎸佺画琛屽姩鍗★細蹇呴』鏄惧紡閫夋嫨闄勭潃鐩爣
+            // 持续行动卡：必须显式选择附着目标
             const targetBase = command.payload.targetBaseIndex;
             if (subtype === 'ongoing') {
                 if (typeof targetBase !== 'number' || !Number.isInteger(targetBase)) {
-                    return { valid: false, error: '鎸佺画琛屽姩鍗￠渶瑕侀€夋嫨鐩爣鍩哄湴' };
+                    return { valid: false, error: '持续行动卡需要选择目标基地' };
                 }
                 if (targetBase < 0 || targetBase >= core.bases.length) {
-                    return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
+                    return { valid: false, error: '无效的基地索引' };
                 }
 
                 const ongoingTarget = (def as any).type === 'fusion'
@@ -418,14 +418,14 @@ export function validate(
                 const targetMinionUid = command.payload.targetMinionUid;
                 if (ongoingTarget === 'minion') {
                     if (!targetMinionUid) {
-                        return { valid: false, error: '璇ユ寔缁鍔ㄥ崱闇€瑕侀€夋嫨鐩爣闅忎粠' };
+                        return { valid: false, error: '该持续行动卡需要选择目标随从' };
                     }
                     const targetMinion = core.bases[targetBase].minions.find(m => m.uid === targetMinionUid);
                     if (!targetMinion) {
-                        return { valid: false, error: '鍩哄湴涓婃病鏈夎闅忎粠' };
+                        return { valid: false, error: '基地上没有该随从' };
                     }
                 } else if (targetMinionUid !== undefined) {
-                    return { valid: false, error: '璇ユ寔缁鍔ㄥ崱涓嶉渶瑕侀€夋嫨闅忎粠鐩爣' };
+                    return { valid: false, error: '该持续行动卡不需要选择随从目标' };
                 }
 
                 // 打出约束检查（数据驱动）
@@ -438,14 +438,14 @@ export function validate(
                 }
             }
 
-            // ongoing 闄愬埗妫€鏌ワ細鏄惁绂佹鎵撳嚭琛屽姩鍗″埌鐩爣鍩哄湴
-            // 娉ㄦ剰锛歰ngoingTarget='minion' 鐨勮鍔ㄥ崱闄勭潃鍒伴殢浠庝笂锛屼笉鍙楀熀鍦?play_action 闄愬埗
+            // ongoing 限制检查：是否禁止打出行动卡到目标基地
+            // 注意：ongoingTarget='minion' 的行动卡附着到随从上，不受基地 play_action 限制
             if (typeof targetBase === 'number') {
                 const ongoingTarget = (def as any).type === 'fusion'
                     ? ((def as FusionCardDef).actionOngoingTarget ?? 'base')
                     : (((def as ActionCardDef).ongoingTarget ?? 'base'));
                 if (ongoingTarget === 'base' && isOperationRestricted(core, targetBase, command.playerId, 'play_action')) {
-                    return { valid: false, error: '璇ュ熀鍦扮姝㈡墦鍑鸿鍔ㄥ崱' };
+                    return { valid: false, error: '该基地禁止打出行动卡' };
                 }
             }
             return { valid: true };
@@ -453,22 +453,22 @@ export function validate(
 
         case SU_COMMANDS.DISCARD_TO_LIMIT: {
             if (phase !== 'draw') {
-                return { valid: false, error: '鍙兘鍦ㄦ娊鐗岄樁娈靛純鐗? };
+                return { valid: false, error: '只能在抽牌阶段弃牌' };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const player = core.players[command.playerId];
-            if (!player) return { valid: false, error: '鐜╁涓嶅瓨鍦? };
+            if (!player) return { valid: false, error: '玩家不存在' };
             const excess = player.hand.length - HAND_LIMIT;
-            if (excess <= 0) return { valid: false, error: '鎵嬬墝鏈秴杩囦笂闄? };
+            if (excess <= 0) return { valid: false, error: '手牌未超过上限' };
             if (command.payload.cardUids.length !== excess) {
-                return { valid: false, error: `闇€瑕佸純鎺?${excess} 寮犵墝` };
+                return { valid: false, error: `需要弃掉 ${excess} 张牌` };
             }
             const handUids = new Set(player.hand.map(c => c.uid));
             for (const uid of command.payload.cardUids) {
                 if (!handUids.has(uid)) {
-                    return { valid: false, error: `鎵嬬墝涓笉瀛樺湪 uid=${uid}` };
+                    return { valid: false, error: `手牌中不存在 uid=${uid}` };
                 }
             }
             return { valid: true };
@@ -476,22 +476,22 @@ export function validate(
 
         case SU_COMMANDS.SELECT_FACTION: {
             if (phase !== 'factionSelect') {
-                return { valid: false, error: '鍙兘鍦ㄦ淳绯婚€夋嫨闃舵閫夋嫨娲剧郴' };
+                return { valid: false, error: '只能在派系选择阶段选择派系' };
             }
             // Check turn order strictness
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const selection = core.factionSelection;
-            if (!selection) return { valid: false, error: '娲剧郴閫夋嫨鐘舵€佹湭鍒濆鍖? };
+            if (!selection) return { valid: false, error: '派系选择状态未初始化' };
 
             const factionId = command.payload.factionId;
             if (selection.takenFactions.includes(factionId)) {
-                return { valid: false, error: '璇ユ淳绯诲凡琚€夋嫨' };
+                return { valid: false, error: '该派系已被选择' };
             }
             const playerSelections = selection.playerSelections[command.playerId] || [];
             if (playerSelections.length >= 2) {
-                return { valid: false, error: '浣犲凡閫夋嫨浜嗕袱涓淳绯? };
+                return { valid: false, error: '你已选择了两个派系' };
             }
 
             return { valid: true };
@@ -499,123 +499,123 @@ export function validate(
 
         case SU_COMMANDS.USE_TALENT: {
             if (phase !== 'playCards') {
-                return { valid: false, error: '鍙兘鍦ㄥ嚭鐗岄樁娈典娇鐢ㄥぉ璧? };
+                return { valid: false, error: '只能在出牌阶段使用天赋' };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const { minionUid, ongoingCardUid, baseIndex } = command.payload;
             const targetBase = core.bases[baseIndex];
-            if (!targetBase) return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
+            if (!targetBase) return { valid: false, error: '无效的基地索引' };
 
-            // ongoing 琛屽姩鍗″ぉ璧嬶紙鍩哄湴涓婃垨闅忎粠闄勭潃锛?
+            // ongoing 行动卡天赋（基地上或随从附着）
             if (ongoingCardUid) {
-                // 鍏堟煡鍩哄湴 ongoingActions
+                // 先查基地 ongoingActions
                 let ongoing = targetBase.ongoingActions.find(o => o.uid === ongoingCardUid);
-                // 鍐嶆煡闅忎粠 attachedActions
+                // 再查随从 attachedActions
                 if (!ongoing) {
                     for (const m of targetBase.minions) {
                         const aa = m.attachedActions.find(a => a.uid === ongoingCardUid);
                         if (aa) { ongoing = aa; break; }
                     }
                 }
-                if (!ongoing) return { valid: false, error: '鍩哄湴涓婃病鏈夎鎸佺画琛屽姩鍗? };
+                if (!ongoing) return { valid: false, error: '基地上没有该持续行动卡' };
                 if (ongoing.ownerId !== command.playerId) {
-                    return { valid: false, error: '鍙兘浣跨敤鑷繁鐨勬寔缁鍔ㄥ崱澶╄祴' };
+                    return { valid: false, error: '只能使用自己的持续行动卡天赋' };
                 }
                 if (ongoing.talentUsed) {
-                    return { valid: false, error: '鏈洖鍚堝ぉ璧嬪凡浣跨敤' };
+                    return { valid: false, error: '本回合天赋已使用' };
                 }
                 if (isCardSuppressed(core, ongoingCardUid)) {
-                    return { valid: false, error: '璇ュ崱鐗岃兘鍔涘凡琚帇鍒? };
+                    return { valid: false, error: '该卡牌能力已被压制' };
                 }
                 const oDef = getCardDef(ongoing.defId);
                 if (!oDef || !('abilityTags' in oDef) || !oDef.abilityTags?.includes('talent')) {
-                    return { valid: false, error: '璇ユ寔缁鍔ㄥ崱娌℃湁澶╄祴鑳藉姏' };
+                    return { valid: false, error: '该持续行动卡没有天赋能力' };
                 }
                 return { valid: true };
             }
 
-            // 闅忎粠澶╄祴
-            if (!minionUid) return { valid: false, error: '蹇呴』鎸囧畾闅忎粠鎴栨寔缁鍔ㄥ崱' };
+            // 随从天赋
+            if (!minionUid) return { valid: false, error: '必须指定随从或持续行动卡' };
             const targetMinion = targetBase.minions.find(m => m.uid === minionUid);
-            if (!targetMinion) return { valid: false, error: '鍩哄湴涓婃病鏈夎闅忎粠' };
+            if (!targetMinion) return { valid: false, error: '基地上没有该随从' };
             if (targetMinion.controller !== command.playerId) {
-                return { valid: false, error: '鍙兘浣跨敤鑷繁鎺у埗鐨勯殢浠庣殑澶╄祴' };
+                return { valid: false, error: '只能使用自己控制的随从的天赋' };
             }
             if (targetMinion.talentUsed) {
-                // 宸ㄧ煶闃典緥澶栵細鍏佽涓€涓殢浠庢瘡鍥炲悎浣跨敤鎵嶈兘涓ゆ
+                // 巨石阵例外：允许一个随从每回合使用才能两次
                 const isStandingStones = targetBase.defId === 'base_standing_stones';
                 const doubleTalentAvailable = !core.standingStonesDoubleTalentMinionUid;
                 if (!(isStandingStones && doubleTalentAvailable)) {
-                    return { valid: false, error: '鏈洖鍚堝ぉ璧嬪凡浣跨敤' };
+                    return { valid: false, error: '本回合天赋已使用' };
                 }
             }
             if (isCardSuppressed(core, minionUid)) {
-                return { valid: false, error: '璇ュ崱鐗岃兘鍔涘凡琚帇鍒? };
+                return { valid: false, error: '该卡牌能力已被压制' };
             }
-            // 妫€鏌ユ槸鍚︽湁澶╄祴鑳藉姏
+            // 检查是否有天赋能力
             const mDef = getCardDef(targetMinion.defId);
             if (!mDef || !('abilityTags' in mDef) || !mDef.abilityTags?.includes('talent')) {
-                return { valid: false, error: '璇ラ殢浠庢病鏈夊ぉ璧嬭兘鍔? };
+                return { valid: false, error: '该随从没有天赋能力' };
             }
             return { valid: true };
         }
 
         case SU_COMMANDS.ACTIVATE_SPECIAL: {
-            // 鍏佽鍦?playCards 鍜?scoreBases 闃舵婵€娲荤壒娈婅兘鍔?
-            // scoreBases 闃舵锛氬熀鍦拌鍒嗗墠鐨?beforeScoring 鐗规畩鑳藉姏锛堝蹇嶈€呬緧浠庯級
+            // 允许在 playCards 和 scoreBases 阶段激活特殊能力
+            // scoreBases 阶段：基地计分前的 beforeScoring 特殊能力（如忍者侍从）
             if (phase !== 'playCards' && phase !== 'scoreBases') {
-                return { valid: false, error: '鍙兘鍦ㄥ嚭鐗岄樁娈垫垨璁″垎闃舵婵€娲荤壒娈婅兘鍔? };
+                return { valid: false, error: '只能在出牌阶段或计分阶段激活特殊能力' };
             }
             if (command.playerId !== currentPlayerId) {
                 return { valid: false, error: 'player_mismatch' };
             }
             const { minionUid: spMinionUid, baseIndex: spBaseIndex } = command.payload;
             const spBase = core.bases[spBaseIndex];
-            if (!spBase) return { valid: false, error: '鏃犳晥鐨勫熀鍦扮储寮? };
+            if (!spBase) return { valid: false, error: '无效的基地索引' };
             const spMinion = spBase.minions.find(m => m.uid === spMinionUid);
-            if (!spMinion) return { valid: false, error: '鍩哄湴涓婃病鏈夎闅忎粠' };
+            if (!spMinion) return { valid: false, error: '基地上没有该随从' };
             if (spMinion.controller !== command.playerId) {
-                return { valid: false, error: '鍙兘婵€娲昏嚜宸辨帶鍒剁殑闅忎粠鐨勭壒娈婅兘鍔? };
+                return { valid: false, error: '只能激活自己控制的随从的特殊能力' };
             }
             const spDef = getCardDef(spMinion.defId);
             if (!spDef || !('abilityTags' in spDef) || !spDef.abilityTags?.includes('special')) {
-                return { valid: false, error: '璇ラ殢浠庢病鏈夌壒娈婅兘鍔? };
+                return { valid: false, error: '该随从没有特殊能力' };
             }
             if (isCardSuppressed(core, spMinionUid)) {
-                return { valid: false, error: '璇ュ崱鐗岃兘鍔涘凡琚帇鍒? };
+                return { valid: false, error: '该卡牌能力已被压制' };
             }
-            // specialLimitGroup 妫€鏌?
+            // specialLimitGroup 检查
             if (isSpecialLimitBlocked(core, spMinion.defId, spBaseIndex)) {
-                return { valid: false, error: '璇ュ熀鍦版湰鍥炲悎宸蹭娇鐢ㄨ繃鍚岀粍鐗规畩鑳藉姏' };
+                return { valid: false, error: '该基地本回合已使用过同组特殊能力' };
             }
-            // scoreBases 闃舵棰濆楠岃瘉锛氬彧鑳藉湪杈炬爣鍩哄湴涓婃縺娲?
+            // scoreBases 阶段额外验证：只能在达标基地上激活
             if (phase === 'scoreBases') {
                 const eligibleIndices = getScoringEligibleBaseIndices(core);
                 if (!eligibleIndices.includes(spBaseIndex)) {
-                    return { valid: false, error: '鍙兘鍦ㄨ揪鍒颁复鐣岀偣鐨勫熀鍦颁笂婵€娲昏鍒嗗墠鐗规畩鑳藉姏' };
+                    return { valid: false, error: '只能在达到临界点的基地上激活计分前特殊能力' };
                 }
-                // 鍝嶅簲绐楀彛浠嶆墦寮€鏃朵笉鍏佽婵€娲伙紙Me First! 浼樺厛锛?
+                // 响应窗口仍打开时不允许激活（Me First! 优先）
                 if (state.sys.responseWindow?.current) {
-                    return { valid: false, error: 'Me First! 鍝嶅簲绐楀彛浠嶅湪杩涜涓? };
+                    return { valid: false, error: 'Me First! 响应窗口仍在进行中' };
                 }
             }
             return { valid: true };
         }
 
         default:
-            // RESPONSE_PASS 鐢卞紩鎿?ResponseWindowSystem 澶勭悊锛岄鍩熷眰鐩存帴鏀捐
+            // RESPONSE_PASS 由引擎 ResponseWindowSystem 处理，领域层直接放行
             if ((command as { type: string }).type === 'RESPONSE_PASS') {
                 return { valid: true };
             }
-            return { valid: false, error: '鏈煡鍛戒护' };
+            return { valid: false, error: '未知命令' };
     }
 }
 
 /**
- * 閫氱敤鎵撳嚭绾︽潫妫€鏌ワ紙鏁版嵁椹卞姩锛夈€?
- * 杩斿洖 null 琛ㄧず閫氳繃锛岃繑鍥炲瓧绗︿覆琛ㄧず鎷掔粷鍘熷洜銆?
+ * 通用打出约束检查（数据驱动）。
+ * 返回 null 表示通过，返回字符串表示拒绝原因。
  */
 function checkPlayConstraint(
     constraint: PlayConstraint,
@@ -625,22 +625,21 @@ function checkPlayConstraint(
 ): string | null {
     if (constraint === 'requireOwnMinion') {
         const hasOwnMinion = core.bases[baseIndex].minions.some(m => m.controller === playerId);
-        if (!hasOwnMinion) return '鐩爣鍩哄湴涓婂繀椤绘湁浣犵殑闅忎粠';
+        if (!hasOwnMinion) return '目标基地上必须有你的随从';
         return null;
     }
     if (constraint === 'onlyCardInHand') {
         const handSize = core.players[playerId]?.hand.length ?? 0;
-        if (handSize !== 1) return '鍙兘鍦ㄦ湰鍗℃槸浣犵殑鍞竴鎵嬬墝鏃舵墦鍑?;
+        if (handSize !== 1) return '只能在本卡是你的唯一手牌时打出';
         return null;
     }
     if (typeof constraint === 'object' && constraint.type === 'requireOwnPower') {
         const base = core.bases[baseIndex];
         const myPower = getPlayerEffectivePowerOnBase(core, base, baseIndex, playerId);
         if (myPower < constraint.minPower) {
-            return `鍙兘鎵撳埌浣犺嚦灏戞嫢鏈?{constraint.minPower}鐐瑰姏閲忕殑鍩哄湴`;
+            return `只能打到你至少拥有${constraint.minPower}点力量的基地`;
         }
         return null;
     }
     return null;
 }
-

--- a/src/games/smashup/domain/events.ts
+++ b/src/games/smashup/domain/events.ts
@@ -72,6 +72,7 @@ export const SU_EVENTS = defineEvents({
   'su:minion_moved': { audio: 'immediate', sound: MOVE_KEY },
   'su:minion_metadata_updated': 'silent',
   'su:base_ability_suppressed': 'silent',
+  'su:card_suppressed': 'silent',
   
   'su:power_counter_added': { audio: 'immediate', sound: POWER_GAIN_KEY },
   'su:power_counter_removed': { audio: 'immediate', sound: POWER_LOSE_KEY },
@@ -148,6 +149,7 @@ export const SU_EVENT_TYPES = {
   MINION_MOVED: SU_EVENTS['su:minion_moved'].type,
   MINION_METADATA_UPDATED: SU_EVENTS['su:minion_metadata_updated'].type,
   BASE_ABILITY_SUPPRESSED: SU_EVENTS['su:base_ability_suppressed'].type,
+  CARD_SUPPRESSED: SU_EVENTS['su:card_suppressed'].type,
   POWER_COUNTER_ADDED: SU_EVENTS['su:power_counter_added'].type,
   POWER_COUNTER_REMOVED: SU_EVENTS['su:power_counter_removed'].type,
   PERMANENT_POWER_ADDED: SU_EVENTS['su:permanent_power_added'].type,

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -28,6 +28,7 @@ import {
     PHASE_ORDER,
     SU_EVENTS,
     SU_EVENT_TYPES,
+    SU_COMMANDS,
     DRAW_PER_TURN,
     HAND_LIMIT,
     VP_TO_WIN,
@@ -74,6 +75,27 @@ function collectQualifiedPlayerPowers(
     }
 
     return playerPowers;
+}
+
+function hasPendingScoreBasesSpecialActivation(state: MatchState<SmashUpCore>): boolean {
+    const playerId = getCurrentPlayerId(state.core);
+    if (!playerId) return false;
+
+    for (const baseIndex of getScoringEligibleBaseIndices(state.core)) {
+        const base = state.core.bases[baseIndex];
+        if (!base) continue;
+
+        for (const minion of base.minions) {
+            const result = validate(state, {
+                type: SU_COMMANDS.ACTIVATE_SPECIAL,
+                playerId,
+                payload: { minionUid: minion.uid, baseIndex },
+            });
+            if (result.valid) return true;
+        }
+    }
+
+    return false;
 }
 
 function buildBaseRankings(
@@ -1569,6 +1591,11 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
             if (eligibleIndices.length === 0) {
                 console.log('[onAutoContinueCheck] scoreBases: 无 eligible 基地，自动推进');
                 return { autoContinue: true, playerId: pid };
+            }
+
+            if (hasPendingScoreBasesSpecialActivation(state)) {
+                console.log('[onAutoContinueCheck] scoreBases: 当前玩家还有可激活的 special，暂停自动推进');
+                return undefined;
             }
 
             console.log('[onAutoContinueCheck] scoreBases: 响应窗口已关闭，自动推进触发计分');

--- a/src/games/smashup/domain/ongoingEffects.ts
+++ b/src/games/smashup/domain/ongoingEffects.ts
@@ -11,7 +11,14 @@
  */
 
 import type { PlayerId, RandomFn, MatchState } from '../../../engine/types';
-import type { SmashUpCore, SmashUpEvent, MinionOnBase, TriggerInstance, TriggerQueuedEvent } from './types';
+import type {
+    SmashUpCore,
+    SmashUpEvent,
+    MinionOnBase,
+    TriggerInstance,
+    TriggerQueuedEvent,
+    PlayerTurnRestrictionType,
+} from './types';
 import { SU_EVENTS } from './types';
 import { registerTriggerExecutor } from './triggerExecutors';
 import { getBaseDef } from '../data/cards';
@@ -717,6 +724,17 @@ export function isOperationRestricted(
     }
 
     return false;
+}
+
+/** 检查玩家是否处于持续中的全局限制（如睡眠印记 POD） */
+export function hasPlayerTurnRestriction(
+    state: SmashUpCore,
+    playerId: PlayerId,
+    restrictionType: PlayerTurnRestrictionType,
+): boolean {
+    return state.playerRestrictionsUntilTurnStart?.some(
+        entry => entry.targetPlayerId === playerId && entry.restrictionType === restrictionType,
+    ) ?? false;
 }
 
 /**

--- a/src/games/smashup/domain/ongoingEffects.ts
+++ b/src/games/smashup/domain/ongoingEffects.ts
@@ -510,10 +510,80 @@ export function isBaseAbilitySuppressed(
     // 2. 检查基于场上卡牌的持续压制
     if (baseAbilitySuppressionRegistry.length === 0) return false;
     for (const entry of baseAbilitySuppressionRegistry) {
-        if (!isSourceActiveOnBase(state, entry.sourceDefId, baseIndex)) continue;
-        if (entry.checker(state, baseIndex)) return true;
+        const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
+        if (!isSourceActiveOnBase(filteredState, entry.sourceDefId, baseIndex)) continue;
+        if (entry.checker(filteredState, baseIndex)) return true;
     }
     return false;
+}
+
+/** 检查卡牌能力是否处于压制中 */
+export function isCardSuppressed(
+    state: SmashUpCore,
+    cardUid: string,
+): boolean {
+    return state.suppressedCardsUntilTurnStart?.some(entry => entry.cardUid === cardUid) ?? false;
+}
+
+export function getSuppressionFilteredStateForSource(
+    state: SmashUpCore,
+    sourceDefId: string,
+): SmashUpCore {
+    if (!state.suppressedCardsUntilTurnStart?.length) {
+        return state;
+    }
+
+    const suppressedUids = new Set(state.suppressedCardsUntilTurnStart.map(entry => entry.cardUid));
+    let changed = false;
+
+    const bases = state.bases.map(base => {
+        let baseChanged = false;
+
+        const ongoingActions = base.ongoingActions.filter(action => {
+            const keep = !(action.defId === sourceDefId && suppressedUids.has(action.uid));
+            if (!keep) baseChanged = true;
+            return keep;
+        });
+
+        const minions = base.minions.flatMap(minion => {
+            if (minion.defId === sourceDefId && suppressedUids.has(minion.uid)) {
+                baseChanged = true;
+                return [];
+            }
+
+            const attachedActions = (minion.attachedActions ?? []).filter(action => {
+                const keep = !(action.defId === sourceDefId && suppressedUids.has(action.uid));
+                if (!keep) baseChanged = true;
+                return keep;
+            });
+
+            if (attachedActions.length !== (minion.attachedActions ?? []).length) {
+                return [{ ...minion, attachedActions }];
+            }
+
+            return [minion];
+        });
+
+        if (!baseChanged) {
+            return base;
+        }
+
+        changed = true;
+        return {
+            ...base,
+            minions,
+            ongoingActions,
+        };
+    });
+
+    if (!changed) {
+        return state;
+    }
+
+    return {
+        ...state,
+        bases,
+    };
 }
 
 /**
@@ -542,8 +612,9 @@ export function isMinionProtected(
     for (const entry of protectionRegistry) {
         if (entry.protectionType !== protectionType) continue;
         // 检查场上是否有提供保护的来源（ongoing 卡或随从）
-        if (!isSourceActive(state, entry.sourceDefId)) continue;
-        if (entry.checker(ctx)) return true;
+        const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
+        if (!isSourceActive(filteredState, entry.sourceDefId)) continue;
+        if (entry.checker({ ...ctx, state: filteredState })) return true;
     }
     return false;
 }
@@ -574,8 +645,9 @@ export function isMinionProtectedNonConsumable(
     for (const entry of protectionRegistry) {
         if (entry.protectionType !== protectionType) continue;
         if (entry.consumable) continue; // 跳过消耗型保护
-        if (!isSourceActive(state, entry.sourceDefId)) continue;
-        if (entry.checker(ctx)) return true;
+        const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
+        if (!isSourceActive(filteredState, entry.sourceDefId)) continue;
+        if (entry.checker({ ...ctx, state: filteredState })) return true;
     }
     return false;
 }
@@ -607,13 +679,15 @@ export function getConsumableProtectionSource(
     for (const entry of protectionRegistry) {
         if (entry.protectionType !== protectionType) continue;
         if (!entry.consumable) continue;
-        if (!isSourceActive(state, entry.sourceDefId)) continue;
-        if (!entry.checker(ctx)) continue;
+        const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
+        if (!isSourceActive(filteredState, entry.sourceDefId)) continue;
+        if (!entry.checker({ ...ctx, state: filteredState })) continue;
         // 找到消耗型保护来源，查找具体的 ongoing 卡牌实例
-        const base = state.bases[targetBaseIndex];
+        const base = filteredState.bases[targetBaseIndex];
         if (!base) continue;
         // 先检查随从附着
-        const attached = targetMinion.attachedActions.find(a => a.defId === entry.sourceDefId);
+        const filteredTargetMinion = base.minions.find(minion => minion.uid === targetMinion.uid) ?? targetMinion;
+        const attached = filteredTargetMinion.attachedActions.find(a => a.defId === entry.sourceDefId);
         if (attached) return { uid: attached.uid, defId: attached.defId, ownerId: attached.ownerId };
         // 再检查基地 ongoing
         const ongoing = base.ongoingActions.find(o => o.defId === entry.sourceDefId);
@@ -711,8 +785,9 @@ export function isOperationRestricted(
         };
         for (const entry of restrictionRegistry) {
             if (entry.restrictionType !== restrictionType) continue;
-            if (!isSourceActiveOnBase(state, entry.sourceDefId, baseIndex)) continue;
-            if (entry.checker(ctx)) return true;
+            const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
+            if (!isSourceActiveOnBase(filteredState, entry.sourceDefId, baseIndex)) continue;
+            if (entry.checker({ ...ctx, state: filteredState })) return true;
         }
     }
 
@@ -734,8 +809,9 @@ export function interceptEvent(
     if (interceptorRegistry.length === 0) return undefined;
 
     for (const entry of interceptorRegistry) {
-        if (!isSourceActive(state, entry.sourceDefId)) continue;
-        const result = entry.interceptor(state, event);
+        const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
+        if (!isSourceActive(filteredState, entry.sourceDefId)) continue;
+        const result = entry.interceptor(filteredState, event);
         if (result !== undefined) return result;
     }
     return undefined;
@@ -764,10 +840,16 @@ export function fireTriggers(
         if (entry.timing !== timing) continue;
         if (options?.phase && (entry.phase ?? 'reaction') !== options.phase) continue;
         
-        const isActive = entry.global ? isSourceInHandOrDiscard(state, entry.sourceDefId) : isSourceActive(state, entry.sourceDefId);
+        const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
+        const isActive = entry.global
+            ? isSourceInHandOrDiscard(state, entry.sourceDefId)
+            : isSourceActive(filteredState, entry.sourceDefId);
         if (!isActive) continue;
-        
-        const result = entry.callback({ ...fullCtx, matchState });
+
+        const filteredMatchState = matchState && matchState.core === state
+            ? { ...matchState, core: filteredState }
+            : matchState;
+        const result = entry.callback({ ...fullCtx, state: filteredState, matchState: filteredMatchState });
         const triggerEvents = Array.isArray(result) ? result : result.events;
         if (triggerEvents.length > 0) {
             events.push(...triggerEvents);
@@ -842,6 +924,11 @@ export function isSourceActiveOnBase(state: SmashUpCore, sourceDefId: string, ba
     if (base.ongoingActions.some(o => o.defId === sourceDefId)) return true;
     // 检查基地上的随从
     if (base.minions.some(m => m.defId === sourceDefId)) return true;
+    for (const minion of base.minions) {
+        if (minion.attachedActions?.some(action => action.defId === sourceDefId)) {
+            return true;
+        }
+    }
     return false;
 }
 

--- a/src/games/smashup/domain/ongoingModifiers.ts
+++ b/src/games/smashup/domain/ongoingModifiers.ts
@@ -13,6 +13,7 @@
 import type { PlayerId } from '../../../engine/types';
 import type { SmashUpCore, MinionOnBase, BaseInPlay } from './types';
 import { getBaseDef, getCardDef } from '../data/cards';
+import { getSuppressionFilteredStateForSource, isCardSuppressed } from './ongoingEffects';
 
 // ============================================================================
 // 类型定义
@@ -94,6 +95,42 @@ const breakpointModifierRegistry: BreakpointModifierEntry[] = [];
 /** 基地级别力量修正注册表 */
 const basePowerModifiers: Map<string, BasePowerModifierFn> = new Map();
 
+function getFilteredPowerModifierContext(
+    state: SmashUpCore,
+    minion: MinionOnBase,
+    baseIndex: number,
+    sourceDefId: string,
+    includePodAlias = false,
+): PowerModifierContext {
+    let filteredState = getSuppressionFilteredStateForSource(state, sourceDefId);
+    if (includePodAlias && !sourceDefId.endsWith('_pod')) {
+        filteredState = getSuppressionFilteredStateForSource(filteredState, `${sourceDefId}_pod`);
+    }
+    const filteredBase = filteredState.bases[baseIndex] ?? state.bases[baseIndex];
+    const filteredMinion = filteredBase?.minions.find(candidate => candidate.uid === minion.uid) ?? minion;
+    return {
+        state: filteredState,
+        minion: filteredMinion,
+        baseIndex,
+        base: filteredBase,
+    };
+}
+
+function getFilteredBreakpointModifierContext(
+    state: SmashUpCore,
+    baseIndex: number,
+    sourceDefId: string,
+    originalBreakpoint: number,
+): BreakpointModifierContext {
+    const filteredState = getSuppressionFilteredStateForSource(state, sourceDefId);
+    return {
+        state: filteredState,
+        baseIndex,
+        base: filteredState.bases[baseIndex] ?? state.bases[baseIndex],
+        originalBreakpoint,
+    };
+}
+
 /**
  * 注册一个持续力量修正
  * 
@@ -140,9 +177,17 @@ export function getBasePowerModifiers(
 
     // 遍历基地上的所有 ongoing 行动卡
     for (const ongoing of base.ongoingActions) {
+        if (isCardSuppressed(state, ongoing.uid)) continue;
         const modifier = basePowerModifiers.get(ongoing.defId);
         if (modifier) {
-            total += modifier({ state, baseIndex, base, playerId, ongoing });
+            const filteredState = getSuppressionFilteredStateForSource(state, ongoing.defId);
+            total += modifier({
+                state: filteredState,
+                baseIndex,
+                base: filteredState.bases[baseIndex] ?? base,
+                playerId,
+                ongoing,
+            });
         }
     }
 
@@ -381,7 +426,13 @@ export function getOngoingPowerModifierDetails(
 
     const details: PowerModifierDetail[] = [];
     for (const entry of modifierRegistry) {
-        const ctx: PowerModifierContext = { state, minion, baseIndex, base };
+        const ctx = getFilteredPowerModifierContext(
+            state,
+            minion,
+            baseIndex,
+            entry.sourceDefId,
+            entry.handlesPodInternally,
+        );
         const value = entry.modifier(ctx);
         if (value !== 0) {
             // 通过 getCardDef 获取 i18n 名称，fallback 到 defId
@@ -445,7 +496,13 @@ export function getOngoingPowerModifier(
 
     let total = 0;
     for (const entry of modifierRegistry) {
-        const ctx: PowerModifierContext = { state, minion, baseIndex, base };
+        const ctx = getFilteredPowerModifierContext(
+            state,
+            minion,
+            baseIndex,
+            entry.sourceDefId,
+            entry.handlesPodInternally,
+        );
         total += entry.modifier(ctx);
     }
     return total;
@@ -541,12 +598,12 @@ export function getEffectiveBreakpoint(
     let total = 0;
     if (breakpointModifierRegistry.length > 0) {
         for (const entry of breakpointModifierRegistry) {
-            const ctx: BreakpointModifierContext = {
+            const ctx = getFilteredBreakpointModifierContext(
                 state,
                 baseIndex,
-                base,
-                originalBreakpoint: baseDef.breakpoint,
-            };
+                entry.sourceDefId,
+                baseDef.breakpoint,
+            );
             total += entry.modifier(ctx);
         }
     }

--- a/src/games/smashup/domain/playLegality.ts
+++ b/src/games/smashup/domain/playLegality.ts
@@ -1,10 +1,14 @@
 import type { ValidationResult } from '../../../engine/types';
 import type { ActionCardDef, FusionCardDef, PlayConstraint, SmashUpCore } from './types';
 import { getCardDef, getFusionDef, getMinionDef, getMinionLikePower } from '../data/cards';
-import { isOperationRestricted } from './ongoingEffects';
+import { hasPlayerTurnRestriction, isOperationRestricted } from './ongoingEffects';
 import { getPlayerEffectivePowerOnBase } from './ongoingModifiers';
 import { mustUseBaseLimitedMinionQuota } from './utils';
 import { isCardMinionLike } from './utils';
+
+function isCurrentTurnPlayer(core: SmashUpCore, playerId: string): boolean {
+    return core.turnOrder[core.currentPlayerIndex] === playerId;
+}
 
 export function validateDiscardMinionPlaySemantics(
     core: SmashUpCore,
@@ -57,6 +61,13 @@ export function validateActionPlaySemantics(
         effectiveHandSize?: number;
     },
 ): ValidationResult {
+    if (
+        hasPlayerTurnRestriction(core, playerId, 'play_action')
+        || (isCurrentTurnPlayer(core, playerId) && core.sleepMarkedPlayers?.includes(playerId))
+    ) {
+        return { valid: false, error: '当前效果禁止你打出战术' };
+    }
+
     const def = getCardDef(params.defId) as ActionCardDef | FusionCardDef | undefined;
     if (!def) return { valid: false, error: '卡牌定义不存在' };
 

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -733,13 +733,15 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                     talentUsed: o.ownerId === playerId ? false : o.talentUsed,
                 })),
             }));
-            // POD 沉睡印记：直到施放者下回合开始前，目标玩家 actionLimit = 0
-            const expires = state.sleepMarkExpiresOnTurnNumber;
-            const isExpired = typeof expires === 'number' && turnNumber >= expires;
-            const activeSleepMarked = isExpired ? undefined : state.sleepMarkedPlayers;
-            const activeSleepMoveMarked = isExpired ? undefined : state.sleepMoveMarkedPlayers;
-            const activeExpires = isExpired ? undefined : expires;
-            const newActionLimit = activeSleepMarked?.includes(playerId) ? 0 : 1;
+            const remainingPlayerRestrictions = state.playerRestrictionsUntilTurnStart?.filter(
+                entry => entry.sourcePlayerId !== playerId,
+            );
+            // 检查沉睡印记 / 睡眠印记 POD：被限制打出战术的玩家本回合 actionLimit 设为 0
+            const isSleepMarked = state.sleepMarkedPlayers?.includes(playerId);
+            const isActionRestricted = remainingPlayerRestrictions?.some(
+                entry => entry.targetPlayerId === playerId && entry.restrictionType === 'play_action',
+            ) ?? false;
+            const newActionLimit = (isSleepMarked || isActionRestricted) ? 0 : 1;
 
             // Smash Up 的 each turn 以“当前玩家回合”为单位。
             // 因此每个玩家回合开始时，都要清空全体玩家在各基地的本回合出牌计数，
@@ -816,16 +818,22 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 scoringEligibleBaseIndices: undefined,
                 // 清空本回合已使用的持续行动 UID 追踪
                 turnUsedOngoingUids: undefined,
-                sleepMarkedPlayers: activeSleepMarked?.length ? activeSleepMarked : undefined,
-                sleepMoveMarkedPlayers: activeSleepMoveMarked?.length ? activeSleepMoveMarked : undefined,
-                sleepMarkExpiresOnTurnNumber: activeExpires,
+                sleepMarkedPlayers: state.sleepMarkedPlayers,
+                playerRestrictionsUntilTurnStart: remainingPlayerRestrictions?.length
+                    ? remainingPlayerRestrictions
+                    : undefined,
                 players: newPlayers,
             };
         }
 
         case SU_EVENTS.TURN_ENDED: {
-            const { nextPlayerIndex } = event.payload;
-            return { ...state, currentPlayerIndex: nextPlayerIndex };
+            const { playerId, nextPlayerIndex } = event.payload;
+            const remainingSleepMarked = state.sleepMarkedPlayers?.filter(pid => pid !== playerId);
+            return {
+                ...state,
+                currentPlayerIndex: nextPlayerIndex,
+                sleepMarkedPlayers: remainingSleepMarked?.length ? remainingSleepMarked : undefined,
+            };
         }
 
         case SU_EVENTS.BASE_REPLACED: {

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -1104,8 +1104,14 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 if (i !== fromBaseIndex) return b;
                 return { ...b, minions: b.minions.filter(m => m.uid !== minionUid) };
             });
-            // 焦油坑：被消灭后改去向（仍算消灭），放入拥有者牌库底而不是弃牌堆
-            const isTarPits = base?.defId === 'base_tar_pits';
+            const destroyedAtBaseThisTurnCount = (state.turnDestroyedMinions ?? [])
+                .filter(record => record.baseIndex === fromBaseIndex)
+                .length;
+            // POD 刚柔流寺庙：这里被消灭的随从始终改放拥有者牌库底。
+            // 焦油坑：只在同基地本回合第一次随从被消灭时改去向，后续照常进弃牌堆。
+            const shouldRedirectToDeckBottom =
+                base?.defId === 'base_temple_of_goju_pod'
+                || (base?.defId === 'base_tar_pits' && destroyedAtBaseThisTurnCount === 0);
             let newPlayers = { ...state.players };
             const owner = newPlayers[ownerId];
             const destroyedCard: CardInstance = {
@@ -1114,7 +1120,7 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 type: 'minion',
                 owner: ownerId,
             };
-            newPlayers = isTarPits
+            newPlayers = shouldRedirectToDeckBottom
                 ? {
                     ...newPlayers,
                     [ownerId]: { ...owner, deck: [...owner.deck, destroyedCard] },

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -25,6 +25,7 @@ import type {
     BaseReplacedEvent,
     TempPowerAddedEvent,
     PermanentPowerAddedEvent,
+    CardSuppressedEvent,
     BreakpointModifiedEvent,
     BaseDeckShuffledEvent,
     SpecialLimitUsedEvent,
@@ -799,6 +800,11 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 // 清理“直到本回合开始”的基地压制（仅清除由当前回合玩家施加的条目）
                 suppressedBasesUntilTurnStart: (() => {
                     const remaining = (state.suppressedBasesUntilTurnStart ?? [])
+                        .filter(s => s.suppressorPlayerId !== playerId);
+                    return remaining.length ? remaining : undefined;
+                })(),
+                suppressedCardsUntilTurnStart: (() => {
+                    const remaining = (state.suppressedCardsUntilTurnStart ?? [])
                         .filter(s => s.suppressorPlayerId !== playerId);
                     return remaining.length ? remaining : undefined;
                 })(),
@@ -1770,6 +1776,18 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
             return {
                 ...state,
                 suppressedBasesUntilTurnStart: [...prev, { baseIndex, suppressorPlayerId }],
+            };
+        }
+
+        case SU_EVENTS.CARD_SUPPRESSED: {
+            const { cardUid, baseIndex, suppressorPlayerId, cardType } = (event as CardSuppressedEvent).payload;
+            const prev = state.suppressedCardsUntilTurnStart ?? [];
+            if (prev.some(s => s.cardUid === cardUid && s.suppressorPlayerId === suppressorPlayerId)) {
+                return state;
+            }
+            return {
+                ...state,
+                suppressedCardsUntilTurnStart: [...prev, { cardUid, baseIndex, suppressorPlayerId, cardType }],
             };
         }
 

--- a/src/games/smashup/domain/reducer.ts
+++ b/src/games/smashup/domain/reducer.ts
@@ -47,6 +47,7 @@ import type {
     PowerCounterAddedEvent,
     PowerCounterRemovedEvent,
     TempPowerAddedEvent,
+    PermanentPowerAddedEvent,
     CardToDeckBottomEvent,
     SpecialAfterScoringArmedEvent,
 } from './types';
@@ -60,7 +61,7 @@ import { maybeQueueStartingHandMulliganPrompt } from './mulliganHandlers';
 import { resolveOnPlay, resolveSpecial, resolveTalent, resolveOnDestroy } from './abilityRegistry';
 import type { AbilityContext } from './abilityRegistry';
 import { triggerBaseAbility, triggerExtendedBaseAbility } from './baseAbilities';
-import { fireTriggers, collectTriggers, isMinionProtected, getConsumableProtectionSource } from './ongoingEffects';
+import { fireTriggers, collectTriggers, hasPlayerTurnRestriction, isMinionProtected, getConsumableProtectionSource } from './ongoingEffects';
 import { maybeResolveReactionQueue } from './reactionQueue';
 import { canPlayFromDiscard } from './discardPlayability';
 import { reduce } from './reduce';
@@ -315,7 +316,7 @@ function executeCommand(
                                 payload: {
                                     sourceDefId: card.defId,
                                     playerId: command.playerId,
-                                    baseIndex: command.payload.targetBaseIndex ?? 0,
+                                    baseIndex: command.payload.targetBaseIndex,
                                     cardUid: card.uid,
                                 },
                                 timestamp: now,
@@ -710,10 +711,6 @@ export function processDestroyTriggers(
         const currentMS_save = ms ?? state;
         const interactionCountBefore =
             (currentMS_save.sys.interaction.current ? 1 : 0) + currentMS_save.sys.interaction.queue.length;
-        const interactionIdsBefore = new Set<string>([
-            ...(currentMS_save.sys.interaction.current ? [currentMS_save.sys.interaction.current.id] : []),
-            ...currentMS_save.sys.interaction.queue.map(i => i.id),
-        ]);
 
         const saveEvents: SmashUpEvent[] = [];
 
@@ -806,26 +803,10 @@ export function processDestroyTriggers(
                     'giant_ant_drone_prevent_destroy',   // 雄蜂防止消灭
                     'pirate_buccaneer_move',             // 海盗：被消灭时移动到其他基地
                 ];
-
-                // 精确识别本次消灭新增的交互（可能插入到 queue 中、且不一定是 current/队尾）
-                const candidates = [
-                    ...(ms.sys.interaction.current ? [ms.sys.interaction.current] : []),
-                    ...ms.sys.interaction.queue,
-                ].filter(i => !interactionIdsBefore.has(i.id));
-
-                const isPreventDestroyInteraction = (interaction: any): boolean => {
-                    const sourceId = (interaction?.data as any)?.sourceId as string | undefined;
-                    if (!sourceId || !PREVENT_DESTROY_SOURCE_IDS.includes(sourceId)) return false;
-                    const cc = (interaction?.data as any)?.continuationContext;
-                    // 不同防止消灭交互的上下文形态不同，尽量覆盖常见字段
-                    const referencedUid =
-                        (cc?.targetMinionUid as string | undefined)
-                        ?? (cc?.minionUid as string | undefined)
-                        ?? (cc?.cardUid as string | undefined);
-                    return referencedUid ? referencedUid === minionUid : true;
-                };
-
-                if (candidates.some(isPreventDestroyInteraction)) {
+                const newInteraction = ms.sys.interaction.current ?? ms.sys.interaction.queue[ms.sys.interaction.queue.length - 1];
+                const sourceId = (newInteraction?.data as any)?.sourceId as string | undefined;
+                const isPreventDestroy = sourceId ? PREVENT_DESTROY_SOURCE_IDS.includes(sourceId) : false;
+                if (isPreventDestroy) {
                     isPendingSave = true;
                     pendingSaveMinionUids.add(minionUid);
                 }
@@ -959,6 +940,9 @@ export function filterProtectedMoveEvents(
         const minion = base?.minions.find(m => m.uid === minionUid);
         if (!minion) { result.push(e); continue; }
         const effectiveSource = me.payload.reason?.startsWith('base_') ? minion.controller : sourcePlayerId;
+        if (hasPlayerTurnRestriction(core, effectiveSource, 'move_minion')) {
+            continue;
+        }
         if (isMinionProtected(core, minion, fromBaseIndex, effectiveSource, 'move')) continue;
         // 检查 'action' 和 'affect' 两种广义保护类型（与 filterProtectedDestroyEvents 对齐）
         const actionProtected = isMinionProtected(core, minion, fromBaseIndex, effectiveSource, 'action');
@@ -1325,6 +1309,18 @@ export function processAffectTriggers(
                 if (te.payload.amount < 0) {
                     minionUid = te.payload.minionUid;
                     baseIndex = te.payload.baseIndex;
+                    affectType = 'power_change';
+                    const base = core.bases[baseIndex];
+                    const minion = base?.minions.find(m => m.uid === minionUid);
+                    minionDefId = minion?.defId;
+                }
+                break;
+            }
+            case SU_EVENTS.PERMANENT_POWER_ADDED: {
+                const pe = evt as PermanentPowerAddedEvent;
+                if (pe.payload.amount < 0) {
+                    minionUid = pe.payload.minionUid;
+                    baseIndex = pe.payload.baseIndex;
                     affectType = 'power_change';
                     const base = core.bases[baseIndex];
                     const minion = base?.minions.find(m => m.uid === minionUid);

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -528,10 +528,13 @@ export interface SmashUpCore {
     // （保留扩展字段位于此处）
     /** 被沉睡印记标记的玩家（下回合不能打行动卡） */
     sleepMarkedPlayers?: PlayerId[];
-    /** POD 沉睡印记：被标记的玩家本回合不能移动随从（通过事件拦截器阻止移动） */
-    sleepMoveMarkedPlayers?: PlayerId[];
-    /** POD 沉睡印记：标记过期的 turnNumber（到施放者下回合开始时清空） */
-    sleepMarkExpiresOnTurnNumber?: number;
+    /**
+     * 持续到施加者下个回合开始的玩家限制（如睡眠印记 POD）
+     *
+     * - play_action: 目标玩家在效果持续期间不能打出战术/行动卡
+     * - move_minion: 目标玩家在效果持续期间不能移动随从
+     */
+    playerRestrictionsUntilTurnStart?: PlayerTurnRestriction[];
     /** 本回合每位玩家移动随从到各基地的次数（用于牧场等"首次移动"触发） */
     minionsMovedToBaseThisTurn?: Record<string, Record<number, number>>;
     /**
@@ -603,6 +606,14 @@ export interface FactionSelectionState {
     playerSelections: Record<PlayerId, string[]>;
     /** 选择完成的玩家 */
     completedPlayers: PlayerId[];
+}
+
+export type PlayerTurnRestrictionType = 'play_action' | 'move_minion';
+
+export interface PlayerTurnRestriction {
+    targetPlayerId: PlayerId;
+    sourcePlayerId: PlayerId;
+    restrictionType: PlayerTurnRestrictionType;
 }
 
 

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -581,6 +581,13 @@ export interface SmashUpCore {
      * 用于实现类似“渗透 POD 天赋”这种“即使牌已离场，压制仍持续到下回合开始”的规则。
      */
     suppressedBasesUntilTurnStart?: Array<{ baseIndex: number; suppressorPlayerId: PlayerId }>;
+    /** 临时卡牌能力压制（直到压制者的下个回合开始） */
+    suppressedCardsUntilTurnStart?: Array<{
+        cardUid: string;
+        baseIndex: number;
+        suppressorPlayerId: PlayerId;
+        cardType: 'minion' | 'ongoing' | 'attached' | 'titan';
+    }>;
 
     /**
      * 本回合已触发过“每回合一次”的持续行动卡 UID 列表。
@@ -1001,6 +1008,7 @@ export type SmashUpEvent =
     | AbilityFeedbackEvent
     | AbilityTriggeredEvent
     | BaseAbilitySuppressedEvent
+    | CardSuppressedEvent
     | BaseClearedEvent;
 
 // ============================================================================
@@ -1312,6 +1320,17 @@ export interface BaseAbilitySuppressedEvent extends GameEvent<typeof SU_EVENTS.B
     payload: {
         baseIndex: number;
         suppressorPlayerId: PlayerId;
+        reason: string;
+    };
+}
+
+/** 卡牌能力压制事件（直到压制者的下个回合开始） */
+export interface CardSuppressedEvent extends GameEvent<typeof SU_EVENTS.CARD_SUPPRESSED> {
+    payload: {
+        cardUid: string;
+        baseIndex: number;
+        suppressorPlayerId: PlayerId;
+        cardType: 'minion' | 'ongoing' | 'attached' | 'titan';
         reason: string;
     };
 }

--- a/src/games/smashup/rule/POD-SYSTEM.md
+++ b/src/games/smashup/rule/POD-SYSTEM.md
@@ -106,3 +106,15 @@ node scripts/audit-pod-data-consistency.mjs
 - `docs/refactor/pod-system-architecture.md` - POD 系统架构详细说明
 - `docs/refactor/pod-auto-mapping.md` - 能力自动映射系统设计
 - `docs/refactor/pod-system-summary.md` - POD 系统完整修复总结
+## POD 基地策略（骨架阶段）
+
+- 当选择 `*_pod` 阵营时，选基只使用 `base_*_pod` 变体，不混入基础版 `base_*`。
+- 当前采用“骨架先行”：由基础基地自动克隆 POD 基地骨架，复制 `breakpoint`、`vpAwards`、限制与能力相关字段，只把 `id/faction` 加 `_pod` 后缀。
+- 软过渡规则：如果某个 POD 阵营基地不足 2 张，补足时也只从 POD 变体池补，不回退基础版基地。
+- 后续手工录入正式 POD 基地后，可用同名 `base_*_pod` 定义覆盖骨架数据。
+> 2026-03-19 补充：`base_*_pod` 会自动复用 `base_*` 的基地能力注册，并同步支持 reaction queue 执行路径。
+
+> 2026-03-19 行为修正补充（POD 同步生效）：
+> - `Field of Honor`（含 `_pod`）：改为“每回合你第一次在此消灭另一位玩家的随从时”才得 1VP。
+> - `Tsar's Palace`（含 `_pod`）：仅当你在该基地“严格领先每位其他玩家”时，才可打出力量 `<=2` 的随从。
+> - `R'lyeh`（含 `_pod`）：交互只发起消灭；1VP 在“消灭实际成立”后结算，若被保护/替代导致未消灭则不加分。

--- a/src/games/smashup/rule/wiki-rules-coverage.md
+++ b/src/games/smashup/rule/wiki-rules-coverage.md
@@ -117,7 +117,7 @@
 - **事件链**：
   - 打开：`abilityHelpers.openMeFirstWindow()` → `RESPONSE_WINDOW_EVENTS.OPENED(windowType='meFirst')`
   - 窗口允许命令：`game.ts` ResponseWindowSystem 配置（仅 `su:play_action/su:play_minion`）
-  - 领域校验二次约束：`commands.ts`（窗口中 `play_action` 只能 special 且 timing 匹配；`play_minion` 仅 beforeScoringPlayable）
+  - 领域校验二次约束：`commands.ts`（窗口中 `play_action` 只能 special 且 timing 匹配；`specialTiming='triggered'` 的牌不能进入通用计分响应窗口；`play_minion` 仅 beforeScoringPlayable）
 - **结论**：✅ 已实现
 
 ### 3.4 Step4：Award VPs（VP 结算按当前力量）


### PR DESCRIPTION
﻿## 变更说明
- 修复 `bear_cavalry_commission_pod` 在随从额度用尽时，打出额外随从后仍错误残留额外额度的问题
- 修复 `bear_cavalry_bear_rides_you_pod` 移动己方随从后，压制目标列表不完整的问题
- 为卡牌级压制补齐统一过滤视图，确保被压制实例的触发、持续修正、爆破点修正与主动能力都不会继续生效
- 补充熊骑兵 POD 压制、委任额度、基地压制、持续修正与天赋禁用回归测试

## 验证
- `npx vitest run src/games/smashup/__tests__/ongoingModifiers.test.ts src/games/smashup/__tests__/newOngoingAbilities.test.ts src/games/smashup/__tests__/bearCavalry-youre-screwed-pod-breakpoint.test.ts src/games/smashup/__tests__/interactionChainE2E.test.ts src/games/smashup/__tests__/baseAbilityIntegration.test.ts src/games/smashup/__tests__/ongoingTalent.test.ts src/games/smashup/__tests__/talentAbilities.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Card suppression and per-turn restriction system: temporary ability suppression and turn-scoped action/move restrictions.
  * New POD base variants and related base behaviors (POD-specific abilities and interactions).

* **UX**
  * Lobby: separate lobby-loading state and loading message; room list shows a dedicated loading placeholder.
  * Bonus-die overlay now closes on backdrop click before confirming.

* **Localization**
  * Added many POD base translations (en & zh‑CN) and lobby loading strings.

* **Tests**
  * Expanded E2E and unit tests covering suppression, POD behaviors, interactions, and rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->