### PR TITLE
fix(smashup): 修复POD怪物天赋点击无反馈问题

### DIFF
--- a/e2e/smashup-4p-layout-test.e2e.ts
+++ b/e2e/smashup-4p-layout-test.e2e.ts
@@ -218,6 +218,78 @@ function buildFourPlayerMobileScene() {
     };
 }
 
+function buildMonsterWithoutCountersMobileScene() {
+    return {
+        gameId: 'smashup',
+        currentPlayer: '0' as const,
+        phase: 'playCards',
+        bases: [
+            {
+                defId: 'base_the_jungle',
+                breakpoint: 12,
+                minions: [
+                    {
+                        uid: 'p0-monster-no-counter',
+                        defId: 'frankenstein_the_monster_pod',
+                        owner: '0',
+                        controller: '0',
+                        powerCounters: 0,
+                        talentUsed: false,
+                    },
+                ],
+            },
+        ],
+        extra: {
+            core: {
+                turnOrder: ['0', '1'],
+                turnNumber: 3,
+                nextUid: 3000,
+                baseDeck: [],
+                players: {
+                    '0': createPlayerState('0', 0, ['frankenstein', 'aliens']),
+                    '1': createPlayerState('1', 0, ['pirates', 'ninjas']),
+                },
+            },
+        },
+    };
+}
+
+function buildMonsterWithCounterMobileScene() {
+    return {
+        gameId: 'smashup',
+        currentPlayer: '0' as const,
+        phase: 'playCards',
+        bases: [
+            {
+                defId: 'base_the_jungle',
+                breakpoint: 12,
+                minions: [
+                    {
+                        uid: 'p0-monster-with-counter',
+                        defId: 'frankenstein_the_monster_pod',
+                        owner: '0',
+                        controller: '0',
+                        powerCounters: 1,
+                        talentUsed: false,
+                    },
+                ],
+            },
+        ],
+        extra: {
+            core: {
+                turnOrder: ['0', '1'],
+                turnNumber: 3,
+                nextUid: 3001,
+                baseDeck: [],
+                players: {
+                    '0': createPlayerState('0', 0, ['frankenstein', 'aliens']),
+                    '1': createPlayerState('1', 0, ['pirates', 'ninjas']),
+                },
+            },
+        },
+    };
+}
+
 async function expectLocatorInsideViewport(
     locator: any,
     name: string,
@@ -545,5 +617,134 @@ test.describe('大杀四方四人局三基地同时计分', () => {
         await expect(endTurnActionButton).toBeVisible({ timeout: 5000 });
         await expect(endTurnHints).toBeVisible({ timeout: 5000 });
         await game.screenshot('13-desktop-end-turn-restored', testInfo);
+    });
+
+    test('移动端不会把没有+1力量指示物的怪物当成可发动天赋', async ({ page, game }, testInfo) => {
+        test.setTimeout(90000);
+
+        await page.setViewportSize({ width: 812, height: 375 });
+        await page.addInitScript(() => {
+            const query = '(pointer: coarse)';
+            const originalMatchMedia = window.matchMedia.bind(window);
+            window.matchMedia = ((media: string) => {
+                if (media !== query) {
+                    return originalMatchMedia(media);
+                }
+
+                return {
+                    matches: true,
+                    media,
+                    onchange: null,
+                    addListener: () => {},
+                    removeListener: () => {},
+                    addEventListener: () => {},
+                    removeEventListener: () => {},
+                    dispatchEvent: () => true,
+                } as MediaQueryList;
+            }) as typeof window.matchMedia;
+        });
+
+        await game.openTestGame('smashup', {
+            numPlayers: 2,
+            skipInitialization: true,
+        });
+        await game.setupScene(buildMonsterWithoutCountersMobileScene());
+
+        await page.waitForFunction(() => {
+            const state = (window as any).__BG_TEST_HARNESS__?.state?.get?.();
+            return window.innerWidth === 812
+                && window.matchMedia('(pointer: coarse)').matches
+                && state?.sys?.phase === 'playCards'
+                && state?.core?.bases?.[0]?.minions?.[0]?.uid === 'p0-monster-no-counter';
+        }, { timeout: 10000, polling: 200 });
+
+        const monster = page.locator('[data-minion-uid="p0-monster-no-counter"]');
+
+        await expect(monster).toBeVisible({ timeout: 15000 });
+        await expect(monster).toHaveAttribute('data-expanded', 'false');
+        await expect(monster).toHaveAttribute('data-activation-armed', 'false');
+
+        await clickCenter(monster, page);
+
+        await expect(monster).toHaveAttribute('data-expanded', 'false');
+        await expect(monster).toHaveAttribute('data-activation-armed', 'false');
+        await expect.poll(async () => {
+            const state = await game.getState();
+            return state.core.bases[0].minions.find((minion: any) => minion.uid === 'p0-monster-no-counter')?.talentUsed ?? false;
+        }, { timeout: 5000 }).toBe(false);
+
+        await game.screenshot('12-monster-without-counter-does-not-arm-talent', testInfo);
+    });
+
+    test('移动端有+1力量指示物的怪物发动天赋后会移除指示物并提示额外随从机会', async ({ page, game }, testInfo) => {
+        test.setTimeout(90000);
+
+        await page.setViewportSize({ width: 812, height: 375 });
+        await page.addInitScript(() => {
+            const query = '(pointer: coarse)';
+            const originalMatchMedia = window.matchMedia.bind(window);
+            window.matchMedia = ((media: string) => {
+                if (media !== query) {
+                    return originalMatchMedia(media);
+                }
+
+                return {
+                    matches: true,
+                    media,
+                    onchange: null,
+                    addListener: () => {},
+                    removeListener: () => {},
+                    addEventListener: () => {},
+                    removeEventListener: () => {},
+                    dispatchEvent: () => true,
+                } as MediaQueryList;
+            }) as typeof window.matchMedia;
+        });
+
+        await game.openTestGame('smashup', {
+            numPlayers: 2,
+            skipInitialization: true,
+        });
+        await game.setupScene(buildMonsterWithCounterMobileScene());
+
+        await page.waitForFunction(() => {
+            const state = (window as any).__BG_TEST_HARNESS__?.state?.get?.();
+            return window.innerWidth === 812
+                && window.matchMedia('(pointer: coarse)').matches
+                && state?.sys?.phase === 'playCards'
+                && state?.core?.bases?.[0]?.minions?.[0]?.uid === 'p0-monster-with-counter';
+        }, { timeout: 10000, polling: 200 });
+
+        const monster = page.locator('[data-minion-uid="p0-monster-with-counter"]');
+
+        await expect(monster).toBeVisible({ timeout: 15000 });
+        await expect(monster).toContainText('+1');
+        await expect(monster).toHaveAttribute('data-activation-armed', 'false');
+
+        await clickCenter(monster, page);
+        await expect(monster).toHaveAttribute('data-expanded', 'true');
+        await expect(monster).toHaveAttribute('data-activation-armed', 'true');
+        await expect(page.getByText('再次点击发动')).toBeVisible({ timeout: 5000 });
+
+        await clickCenter(monster, page);
+
+        await expect.poll(async () => {
+            const state = await game.getState();
+            const player = state.core.players['0'];
+            return {
+                powerCounters: state.core.bases[0].minions.find((minion: any) => minion.uid === 'p0-monster-with-counter')?.powerCounters ?? -1,
+                talentUsed: state.core.bases[0].minions.find((minion: any) => minion.uid === 'p0-monster-with-counter')?.talentUsed ?? false,
+                minionLimit: player.minionLimit,
+            };
+        }, { timeout: 5000 }).toEqual({
+            powerCounters: 0,
+            talentUsed: true,
+            minionLimit: 2,
+        });
+
+        await expect(page.getByText('获得1次额外随从机会')).toBeVisible({ timeout: 5000 });
+
+        await expect(monster).toHaveAttribute('data-activation-armed', 'false');
+        await game.screenshot('13-monster-with-counter-grants-extra-minion', testInfo);
     });
 });

--- a/evidence/smashup-monster-pod-talent-e2e-test.md
+++ b/evidence/smashup-monster-pod-talent-e2e-test.md
@@ -1,0 +1,61 @@
+# 大杀四方 POD 科学怪人「怪物」天赋点击验证
+
+## 问题描述
+
+用户反馈：POD 版科学怪人派系的「怪物」在准备发动天赋时，点击后看起来没有反应。
+
+本次重点核对两条路径：
+
+1. 没有 `+1` 力量指示物时，不应被当成可发动天赋。
+2. 有 `1` 个 `+1` 力量指示物时，触屏路径应先进入武装态，再在第二次点击时成功发动，并给出明确反馈。
+
+## 修复点
+
+1. 统一了「怪物」天赋的前置条件判断：
+   - 领域校验层禁止无 `+1` 指示物时发动。
+   - execute 层增加兜底，避免误生成 `TALENT_USED`。
+   - UI 层不再把无 `+1` 指示物的怪物渲染为可发动状态。
+2. 成功发动后补充明确反馈：
+   - 获得额外随从额度时弹出 `获得1次额外随从机会` toast。
+3. 触屏交互补充提示：
+   - 第一次点击进入武装态时显示 `再次点击发动`，避免用户误以为点击无效。
+
+## 验证命令
+
+```bash
+npx tsc -p tsconfig.json --noEmit --pretty false
+npm run test:e2e:ci -- e2e/smashup-4p-layout-test.e2e.ts
+```
+
+## 关键截图
+
+1. 无指示物：
+   - `D:\GA\BoardGame-main-clean\test-results\evidence-screenshots\smashup-4p-layout-test.e2e\移动端不会把没有+1力量指示物的怪物当成可发动天赋\12-monster-without-counter-does-not-arm-talent.png`
+2. 有 1 个指示物并成功发动：
+   - `D:\GA\BoardGame-main-clean\test-results\evidence-screenshots\smashup-4p-layout-test.e2e\移动端有+1力量指示物的怪物发动天赋后会移除指示物并提示额外随从机会\13-monster-with-counter-grants-extra-minion.png`
+
+## 截图分析
+
+### 1. 无 `+1` 指示物
+
+- 怪物卡牌不会进入武装态。
+- 点击后不会消耗天赋，不会误触发 `TALENT_USED`。
+- E2E 断言了：
+  - `data-activation-armed = false`
+  - `talentUsed = false`
+
+### 2. 有 `1` 个 `+1` 指示物
+
+- 第一次点击进入武装态，并显示 `再次点击发动` 提示。
+- 第二次点击后：
+  - `powerCounters` 从 `1` 变为 `0`
+  - `talentUsed` 变为 `true`
+  - 玩家 `minionLimit` 从 `1` 增加到 `2`
+- 页面断言命中 `获得1次额外随从机会`，说明成功反馈已到达 UI。
+
+## 结论
+
+问题已被拆成两部分并分别修复：
+
+1. 无指示物时不再出现“明明不能用却还能点”的误导。
+2. 有指示物时，触屏路径现在有明确的“第一次武装、第二次发动”提示，发动成功后也会看到额外随从机会反馈。

--- a/src/games/smashup/Board.tsx
+++ b/src/games/smashup/Board.tsx
@@ -110,19 +110,26 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
     const { setSelectedFactions } = useSmashUpOverlay();
     
     const core = G?.core;
-    const phase = G?.sys.phase;
+    const system = G?.sys;
+    const phase = system?.phase;
+    // 进入房间和派系选择切到正式棋盘之间，G/core 可能会有短暂未就绪窗口。
+    const corePlayers = core?.players;
+    const coreBases = core?.bases;
+    const turnOrder = core?.turnOrder;
+    const eventEntries = system?.eventStream?.entries ?? [];
+    const tutorialState = system?.tutorial;
     const currentPid = core ? getCurrentPlayerId(core) : '0';
     const playerID = rawPlayerID;
     const isMyTurn = playerID === currentPid;
+    const myPlayer = playerID && corePlayers ? corePlayers[playerID] : corePlayers?.['0'];
     // 观战模式下默认显示玩家 0 的视角
-    const myPlayer = playerID && core ? core.players[playerID] : (core ? core.players['0'] : undefined);
-    const isGameOver = G?.sys.gameover;
+    const isGameOver = system?.gameover;
     const rootPid = playerID || '0';
     const isWinner = !!isGameOver && isGameOver.winner === rootPid;
     const isMobileViewport = useMobileViewport();
     
     // 响应式布局配置
-    const playerCount = core?.turnOrder.length || 2;
+    const playerCount = turnOrder?.length ?? 2;
     const layout = getLayoutConfig(playerCount, { isMobileViewport });
     const topHudScale = layout.topHudScale;
     const endTurnHudScale = layout.endTurnHudScale;
@@ -163,16 +170,15 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
     
     // 更新选择的派系到 Context（游戏开始后）
     useEffect(() => {
-        if (phase !== 'factionSelect') {
-            const allFactions: string[] = [];
-            for (const player of Object.values(core.players)) {
-                if (player.factions) {
-                    allFactions.push(...player.factions);
-                }
+        if (!corePlayers || phase === 'factionSelect') return;
+        const allFactions: string[] = [];
+        for (const player of Object.values(corePlayers)) {
+            if (player.factions) {
+                allFactions.push(...player.factions);
             }
-            setSelectedFactions(allFactions);
         }
-    }, [phase, core.players, setSelectedFactions]);
+        setSelectedFactions(allFactions);
+    }, [phase, corePlayers, setSelectedFactions]);
     
     // 对手视角切换状态（必须在使用前声明，避免 TDZ 错误）
     const [viewMode, setViewMode] = useState<'self' | 'opponent'>('self');
@@ -181,8 +187,8 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
     }, []);
     
     // 对手玩家数据
-    const opponentPid = core.turnOrder.find(pid => pid !== playerID) || '1';
-    const opponentPlayer = core.players[opponentPid];
+    const opponentPid = turnOrder?.find(pid => pid !== playerID) || '1';
+    const opponentPlayer = corePlayers?.[opponentPid];
     
     // 根据视角模式选择显示的玩家数据
     // 重赛系统（通用 hook）
@@ -264,7 +270,7 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
     }, [core, isMyTurn, phase, playerID, myPlayer]);
 
     // 手牌弃牌交互检测：当前 interaction 的所有选项都对应手牌时，用手牌区直接选择
-    const currentInteraction = G.sys.interaction?.current;
+    const currentInteraction = system?.interaction?.current;
     const currentPrompt = useMemo(() => asSimpleChoice(currentInteraction), [currentInteraction]);
 
     const isHandDiscardPrompt = useMemo(() => {
@@ -517,14 +523,14 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
         const opt = discardPlayOptions.find(o => o.card.uid === discardStripSelectedUid);
         if (!opt) return new Set();
         if (opt.allowedBaseIndices === 'all') {
-            return new Set(core.bases.map((_, i) => i));
+            return new Set((coreBases ?? []).map((_, i) => i));
         }
         return new Set(opt.allowedBaseIndices);
-    }, [discardStripSelectedUid, isDiscardMinionPrompt, discardMinionAllowedBases, discardPlayOptions, core.bases]);
+    }, [discardStripSelectedUid, isDiscardMinionPrompt, discardMinionAllowedBases, discardPlayOptions, coreBases]);
 
 
     // 响应窗口状态判断（meFirst 或 afterScoring）
-    const responseWindow = G.sys.responseWindow?.current;
+    const responseWindow = system?.responseWindow?.current;
     const isMeFirstResponse = useMemo(() => {
         if (!responseWindow || responseWindow.windowType !== 'meFirst') return false;
         const currentResponderId = responseWindow.responderQueue[responseWindow.currentResponderIndex];
@@ -774,13 +780,17 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
         );
     }, [t]);
 
-    // 能力反馈 toast（搜索失败等提示）
+    // 能力反馈 toast：失败提示，以及成功获得额外出牌额度的明确反馈。
     useEffect(() => {
         if (gameEvents.feedbacks.length === 0) return;
         for (const fb of gameEvents.feedbacks) {
-            // 只显示给当前玩家的反馈
             if (fb.playerId === playerID) {
-                toast(t(fb.messageKey, { defaultValue: '牌库中未找到符合条件的卡牌，已重洗牌库', ...fb.messageParams }));
+                const defaultMessage = fb.messageKey === 'ui.extra_minion_granted'
+                    ? '\u83b7\u5f97{{count}}\u6b21\u989d\u5916\u968f\u4ece\u673a\u4f1a'
+                    : fb.messageKey === 'ui.extra_action_granted'
+                    ? '\u83b7\u5f97{{count}}\u6b21\u989d\u5916\u884c\u52a8\u673a\u4f1a'
+                    : '\u724c\u5e93\u4e2d\u672a\u627e\u5230\u7b26\u5408\u6761\u4ef6\u7684\u5361\u724c\uff0c\u5df2\u91cd\u6d17\u724c\u5e93';
+                toast(t(fb.messageKey, { defaultValue: defaultMessage, ...fb.messageParams }));
             }
             gameEvents.removeFeedback(fb.id);
         }
@@ -790,7 +800,7 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
     useGameAudio({
         config: SMASHUP_AUDIO_CONFIG,
         gameId: SMASH_UP_MANIFEST.id,
-        G: G.core,
+        G: core,
         ctx: {
             currentPhase: phase,
             isGameOver: !!isGameOver,
@@ -799,11 +809,11 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
         meta: {
             currentPlayerId: currentPid,
         },
-        eventEntries: G.sys.eventStream.entries,
+        eventEntries,
     });
 
     // 教学系统集成
-    useTutorialBridge(G.sys.tutorial, dispatch);
+    useTutorialBridge(tutorialState, dispatch);
     const { isActive: isTutorialActive, currentStep: tutorialStep } = useTutorial();
     const isTutorialMode = isTutorialActive;
 
@@ -994,7 +1004,7 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
                 handlePlayMinion(selectedCardUid, index);
             }
         }
-    }, [selectedCardUid, selectedCardMode, handlePlayMinion, handlePlayOngoingAction, core.bases, t, isBaseSelectPrompt, selectableBaseIndices, currentPrompt, dispatch, meFirstPendingCard, deployableBaseIndices, deployBlockReason, discardStripSelectedUid, discardStripAllowedBases, isDiscardMinionPrompt, discardStripCards, meFirstEligibleBaseIndices, responseWindow, playerID, myPlayer]);
+    }, [selectedCardUid, selectedCardMode, handlePlayMinion, handlePlayOngoingAction, t, isBaseSelectPrompt, selectableBaseIndices, currentPrompt, dispatch, meFirstPendingCard, deployableBaseIndices, deployBlockReason, discardStripSelectedUid, discardStripAllowedBases, isDiscardMinionPrompt, discardStripCards, meFirstEligibleBaseIndices, responseWindow, playerID, myPlayer]);
 
     const handleCardClick = useCallback((card: CardInstance) => {
         // 手牌弃牌交互优先：直接响应 interaction

--- a/src/games/smashup/__tests__/newFactionAbilities.test.ts
+++ b/src/games/smashup/__tests__/newFactionAbilities.test.ts
@@ -25,7 +25,8 @@ import { clearBaseAbilityRegistry } from '../domain/baseAbilities';
 import { clearInteractionHandlers, getInteractionHandler } from '../domain/abilityInteractionHandlers';
 import { fireTriggers } from '../domain/ongoingEffects';
 import { reduce } from '../domain/reduce';
-import { processDestroyTriggers } from '../domain/reducer';
+import { execute, processDestroyTriggers } from '../domain/reducer';
+import { validate } from '../domain/commands';
 import { makeMinion, makeCard, makePlayer, makeState, makeMatchState, getInteractionsFromMS } from './helpers';
 import { runCommand, defaultTestRandom } from './testRunner';
 import type { MatchState } from '../../../engine/types';
@@ -1645,6 +1646,60 @@ describe('科学怪人派系能力', () => {
             e => e.type === SU_EVENTS.LIMIT_MODIFIED && (e as any).payload.limitType === 'minion',
         );
         expect(limitEvt).toBeDefined();
+    });
+
+    it('怪物 POD：没有+1力量指示物时不能发动天赋', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [
+                        makeMinion('monster1', 'frankenstein_the_monster_pod', '0', 5, { powerCounters: 0 }),
+                    ],
+                    ongoingActions: [],
+                },
+            ],
+        });
+
+        const result = validate(makeMatchState(core), {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { minionUid: 'monster1', baseIndex: 0 },
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('该随从当前无法发动天赋：没有+1力量指示物');
+    });
+
+    it('怪物 POD：没有+1力量指示物时 execute 不应误生成 TALENT_USED', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [
+                        makeMinion('monster1', 'frankenstein_the_monster_pod', '0', 5, { powerCounters: 0 }),
+                    ],
+                    ongoingActions: [],
+                },
+            ],
+        });
+
+        const events = execute(makeMatchState(core), {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { minionUid: 'monster1', baseIndex: 0 },
+        }, defaultTestRandom);
+
+        expect(events).toEqual([]);
+        expect(events.some(event => event.type === SU_EVENTS.TALENT_USED)).toBe(false);
     });
 
     it('愤怒的民众：若所选手牌已离开手牌，不应凭旧交互再塞回牌库', () => {

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -18,6 +18,7 @@ import {
     getActionLikeResponseWindowTiming,
     canUseBaseLimitedMinionQuota,
     canUseSameNameMinionQuota,
+    getMinionTalentActivationError,
     getMaxRemainingGlobalPowerLimitedQuota,
     mustUseBaseLimitedMinionQuota,
     mustUseGlobalPowerLimitedMinionQuota,
@@ -569,6 +570,10 @@ export function validate(
             const mDef = getCardDef(targetMinion.defId);
             if (!mDef || !('abilityTags' in mDef) || !mDef.abilityTags?.includes('talent')) {
                 return { valid: false, error: '该随从没有天赋能力' };
+            }
+            const talentActivationError = getMinionTalentActivationError(core, targetMinion, baseIndex);
+            if (talentActivationError) {
+                return { valid: false, error: talentActivationError };
             }
             return { valid: true };
         }

--- a/src/games/smashup/domain/reducer.ts
+++ b/src/games/smashup/domain/reducer.ts
@@ -55,7 +55,7 @@ import type { PlayerId } from '../../../engine/types';
 import { SU_COMMANDS, SU_EVENTS, STARTING_HAND_SIZE } from './types';
 import { getMinionDef, getMinionLikePower, getCardDef, getBaseDefIdsForFactions, getFusionDef } from '../data/cards';
 import type { ActionCardDef, FusionCardDef } from './types';
-import { buildDeck, drawCards, isCardMinionLike } from './utils';
+import { buildDeck, drawCards, getMinionTalentActivationError, isCardMinionLike } from './utils';
 import { autoMulligan } from '../../../engine/primitives/mulligan';
 import { maybeQueueStartingHandMulliganPrompt } from './mulliganHandlers';
 import { resolveOnPlay, resolveSpecial, resolveTalent, resolveOnDestroy } from './abilityRegistry';
@@ -541,6 +541,9 @@ function executeCommand(
             // 随从天赋
             const minion = base?.minions.find(m => m.uid === minionUid);
             if (!minion) return { events: [] };
+            if (getMinionTalentActivationError(core, minion, baseIndex)) {
+                return { events: [] };
+            }
 
             const talentEvt: TalentUsedEvent = {
                 type: SU_EVENTS.TALENT_USED,

--- a/src/games/smashup/domain/utils.ts
+++ b/src/games/smashup/domain/utils.ts
@@ -110,6 +110,27 @@ export function isActionLikeRespondableInWindow(
 }
 
 /**
+ * 获取随从天赋当前不可发动的原因。
+ *
+ * 这里只放“卡牌自身规则前置条件”，供命令校验、UI 高亮和 execute 兜底共用，
+ * 避免出现前端显示可点、点了却只吃掉一次天赋机会的分层不一致问题。
+ */
+export function getMinionTalentActivationError(
+    state: SmashUpCore,
+    minion: MinionOnBase,
+    baseIndex: number,
+): string | null {
+    void state;
+    void baseIndex;
+
+    if (matchesDefId(minion.defId, 'frankenstein_the_monster') && (minion.powerCounters ?? 0) < 1) {
+        return '该随从当前无法发动天赋：没有+1力量指示物';
+    }
+
+    return null;
+}
+
+/**
  * 判断同名额外随从额度对当前卡是否可用。
  *
  * - 没有同名额度 → false

--- a/src/games/smashup/ui/BaseZone.tsx
+++ b/src/games/smashup/ui/BaseZone.tsx
@@ -13,7 +13,7 @@ import { getBaseDef, getMinionDef, getCardDef, resolveCardName, resolveCardText 
 import { isSpecialLimitBlocked } from '../domain/abilityHelpers';
 import { getScoringEligibleBaseIndices } from '../domain/ongoingModifiers';
 import { getBaseRestrictions } from '../domain/ongoingEffects';
-import { matchesDefId } from '../domain/utils';
+import { getMinionTalentActivationError, matchesDefId } from '../domain/utils';
 import { getFactionMeta } from './factionMeta';
 import { CardPreview } from '../../../components/common/media/CardPreview';
 import { PLAYER_CONFIG } from './playerConfig';
@@ -549,10 +549,12 @@ const MinionCard: React.FC<{
     const canUseSecondTalentOnStandingStones =
         core.bases[baseIndex]?.defId === 'base_standing_stones' &&
         !core.standingStonesDoubleTalentMinionUid;
+    const hasTalentActivationPreconditionError = getMinionTalentActivationError(core, minion, baseIndex) !== null;
     const canUseTalent = hasTalent
         && isMyTurn
         && minion.controller === myPlayerId
         && tutorialAllowed
+        && !hasTalentActivationPreconditionError
         && (!minion.talentUsed || canUseSecondTalentOnStandingStones);
 
     // 场上随从 special 能力判定（如忍者侍从）
@@ -584,6 +586,7 @@ const MinionCard: React.FC<{
         : 'left-full flex-col pl-[0.6vw]';
     const minionActivationKey = `minion-${minion.uid}`;
     const isMinionActivationArmed = isActivationArmed(minionActivationKey);
+    const showTouchActivationHint = isCoarsePointer && isMinionActivationArmed && canActivate;
 
     const seed = minion.uid.charCodeAt(0) + index;
     const rotation = (seed % 6) - 3;
@@ -788,6 +791,12 @@ const MinionCard: React.FC<{
             )}
 
             {/* 附着的 ongoing 行动卡 - 角标 + hover 时弹出小卡片 */}
+            {showTouchActivationHint && (
+                <div className="absolute -bottom-[0.3vw] left-1/2 -translate-x-1/2 bg-amber-500 text-slate-900 text-[0.45vw] font-bold px-[0.35vw] py-[0.05vw] rounded-sm shadow-sm border border-white z-20 whitespace-nowrap pointer-events-none">
+                    {t('ui.tap_again_to_activate', { defaultValue: '\u518d\u6b21\u70b9\u51fb\u53d1\u52a8' })}
+                </div>
+            )}
+
             {hasAttachedActions && (
                 <>
                     <AttachedBadge count={minion.attachedActions.length} />

--- a/src/games/smashup/ui/useGameEvents.ts
+++ b/src/games/smashup/ui/useGameEvents.ts
@@ -15,7 +15,7 @@
 
 import { useCallback, useEffect, useState, useMemo } from 'react';
 import type { MatchState } from '../../../engine/types';
-import type { SmashUpCore } from '../domain/types';
+import type { SmashUpCore, LimitModifiedEvent } from '../domain/types';
 import { SU_EVENTS } from '../domain/types';
 import type { AbilityFeedbackEvent } from '../domain/types';
 import { getEventStreamEntries } from '../../../engine/systems/EventStreamSystem';
@@ -50,7 +50,7 @@ interface UseGameEventsParams {
   baseRefs: React.RefObject<Map<number, HTMLElement>>;
 }
 
-export function useGameEvents({ G, fxBus, baseRefs }: UseGameEventsParams) {
+export function useGameEvents({ G, myPlayerId, fxBus, baseRefs }: UseGameEventsParams) {
   const entries = getEventStreamEntries(G);
   const { consumeNew } = useEventStreamCursor({ entries });
 
@@ -136,6 +136,20 @@ export function useGameEvents({ G, fxBus, baseRefs }: UseGameEventsParams) {
           break;
         }
 
+        case SU_EVENTS.LIMIT_MODIFIED: {
+          const payload = (event as LimitModifiedEvent).payload;
+          if (payload.delta > 0 && payload.playerId === myPlayerId) {
+            setFeedbacks(prev => [...prev, {
+              id: `fb-${uidCounter++}`,
+              playerId: payload.playerId,
+              messageKey: payload.limitType === 'minion' ? 'ui.extra_minion_granted' : 'ui.extra_action_granted',
+              messageParams: { count: payload.delta },
+              tone: 'info',
+            }]);
+          }
+          break;
+        }
+
         case SU_EVENTS.BASE_SCORED: {
           const p = event.payload as {
             baseIndex: number; baseDefId: string;
@@ -162,7 +176,7 @@ export function useGameEvents({ G, fxBus, baseRefs }: UseGameEventsParams) {
         }
       }
     }
-  }, [G, consumeNew, fxBus, baseRefs, triggerDefIds, TRIGGER_CARRIER_EVENTS]);
+  }, [G, consumeNew, myPlayerId, fxBus, baseRefs, triggerDefIds, TRIGGER_CARRIER_EVENTS]);
 
   // 清除已完成的反馈
   const removeFeedback = useCallback((id: string) => {


### PR DESCRIPTION
﻿## 背景

POD 版科学怪人随从“怪物”在移动端有 `+1` 战斗力标记时，第一次点击会先进入武装态，但缺少明确反馈，用户体感像是“点了没反应”；没有 `+1` 战斗力标记时，UI 仍可能让人误以为可以发动天赋。

## 修复内容

- 用统一的 `getMinionTalentActivationError` 约束怪物天赋前置条件，确保没有 `+1` 战斗力标记时，命令校验、UI 可点击态和 execute 兜底行为一致。
- 移动端武装后补充“再次点击发动”提示，避免第一次点击看起来无反馈。
- 怪物成功发动后，补充“获得1次额外随从机会”反馈，明确告诉玩家效果已经生效。
- 补充领域测试与移动端 E2E，覆盖“无指示物不可发动”和“有指示物可发动并移除指示物/增加随从额度”两条关键路径。

## 验证

- `npx tsc -p tsconfig.json --noEmit --pretty false`
- `npm run test:e2e:ci -- e2e/smashup-4p-layout-test.e2e.ts`

## 证据

- `evidence/smashup-monster-pod-talent-e2e-test.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added touch activation hint tooltip for mobile users attempting minion talent actions.
  * Added toast notifications when gaining extra minion or action opportunities.

* **Bug Fixes**
  * Fixed minion talent validation to prevent activation without required power counters.
  * Improved game state stability during initialization and transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->