### PR TITLE
fix(smashup): 修复POD怪物天赋点击与弹窗卡图

### DIFF
--- a/e2e/smashup-4p-layout-test.e2e.ts
+++ b/e2e/smashup-4p-layout-test.e2e.ts
@@ -218,6 +218,78 @@ function buildFourPlayerMobileScene() {
     };
 }
 
+function buildMonsterWithoutCountersMobileScene() {
+    return {
+        gameId: 'smashup',
+        currentPlayer: '0' as const,
+        phase: 'playCards',
+        bases: [
+            {
+                defId: 'base_the_jungle',
+                breakpoint: 12,
+                minions: [
+                    {
+                        uid: 'p0-monster-no-counter',
+                        defId: 'frankenstein_the_monster_pod',
+                        owner: '0',
+                        controller: '0',
+                        powerCounters: 0,
+                        talentUsed: false,
+                    },
+                ],
+            },
+        ],
+        extra: {
+            core: {
+                turnOrder: ['0', '1'],
+                turnNumber: 3,
+                nextUid: 3000,
+                baseDeck: [],
+                players: {
+                    '0': createPlayerState('0', 0, ['frankenstein', 'aliens']),
+                    '1': createPlayerState('1', 0, ['pirates', 'ninjas']),
+                },
+            },
+        },
+    };
+}
+
+function buildMonsterWithCounterMobileScene() {
+    return {
+        gameId: 'smashup',
+        currentPlayer: '0' as const,
+        phase: 'playCards',
+        bases: [
+            {
+                defId: 'base_the_jungle',
+                breakpoint: 12,
+                minions: [
+                    {
+                        uid: 'p0-monster-with-counter',
+                        defId: 'frankenstein_the_monster_pod',
+                        owner: '0',
+                        controller: '0',
+                        powerCounters: 1,
+                        talentUsed: false,
+                    },
+                ],
+            },
+        ],
+        extra: {
+            core: {
+                turnOrder: ['0', '1'],
+                turnNumber: 3,
+                nextUid: 3001,
+                baseDeck: [],
+                players: {
+                    '0': createPlayerState('0', 0, ['frankenstein', 'aliens']),
+                    '1': createPlayerState('1', 0, ['pirates', 'ninjas']),
+                },
+            },
+        },
+    };
+}
+
 async function expectLocatorInsideViewport(
     locator: any,
     name: string,
@@ -545,5 +617,134 @@ test.describe('大杀四方四人局三基地同时计分', () => {
         await expect(endTurnActionButton).toBeVisible({ timeout: 5000 });
         await expect(endTurnHints).toBeVisible({ timeout: 5000 });
         await game.screenshot('13-desktop-end-turn-restored', testInfo);
+    });
+
+    test('移动端不会把没有+1力量指示物的怪物当成可发动天赋', async ({ page, game }, testInfo) => {
+        test.setTimeout(90000);
+
+        await page.setViewportSize({ width: 812, height: 375 });
+        await page.addInitScript(() => {
+            const query = '(pointer: coarse)';
+            const originalMatchMedia = window.matchMedia.bind(window);
+            window.matchMedia = ((media: string) => {
+                if (media !== query) {
+                    return originalMatchMedia(media);
+                }
+
+                return {
+                    matches: true,
+                    media,
+                    onchange: null,
+                    addListener: () => {},
+                    removeListener: () => {},
+                    addEventListener: () => {},
+                    removeEventListener: () => {},
+                    dispatchEvent: () => true,
+                } as MediaQueryList;
+            }) as typeof window.matchMedia;
+        });
+
+        await game.openTestGame('smashup', {
+            numPlayers: 2,
+            skipInitialization: true,
+        });
+        await game.setupScene(buildMonsterWithoutCountersMobileScene());
+
+        await page.waitForFunction(() => {
+            const state = (window as any).__BG_TEST_HARNESS__?.state?.get?.();
+            return window.innerWidth === 812
+                && window.matchMedia('(pointer: coarse)').matches
+                && state?.sys?.phase === 'playCards'
+                && state?.core?.bases?.[0]?.minions?.[0]?.uid === 'p0-monster-no-counter';
+        }, { timeout: 10000, polling: 200 });
+
+        const monster = page.locator('[data-minion-uid="p0-monster-no-counter"]');
+
+        await expect(monster).toBeVisible({ timeout: 15000 });
+        await expect(monster).toHaveAttribute('data-expanded', 'false');
+        await expect(monster).toHaveAttribute('data-activation-armed', 'false');
+
+        await clickCenter(monster, page);
+
+        await expect(monster).toHaveAttribute('data-expanded', 'false');
+        await expect(monster).toHaveAttribute('data-activation-armed', 'false');
+        await expect.poll(async () => {
+            const state = await game.getState();
+            return state.core.bases[0].minions.find((minion: any) => minion.uid === 'p0-monster-no-counter')?.talentUsed ?? false;
+        }, { timeout: 5000 }).toBe(false);
+
+        await game.screenshot('12-monster-without-counter-does-not-arm-talent', testInfo);
+    });
+
+    test('移动端有+1力量指示物的怪物发动天赋后会移除指示物并提示额外随从机会', async ({ page, game }, testInfo) => {
+        test.setTimeout(90000);
+
+        await page.setViewportSize({ width: 812, height: 375 });
+        await page.addInitScript(() => {
+            const query = '(pointer: coarse)';
+            const originalMatchMedia = window.matchMedia.bind(window);
+            window.matchMedia = ((media: string) => {
+                if (media !== query) {
+                    return originalMatchMedia(media);
+                }
+
+                return {
+                    matches: true,
+                    media,
+                    onchange: null,
+                    addListener: () => {},
+                    removeListener: () => {},
+                    addEventListener: () => {},
+                    removeEventListener: () => {},
+                    dispatchEvent: () => true,
+                } as MediaQueryList;
+            }) as typeof window.matchMedia;
+        });
+
+        await game.openTestGame('smashup', {
+            numPlayers: 2,
+            skipInitialization: true,
+        });
+        await game.setupScene(buildMonsterWithCounterMobileScene());
+
+        await page.waitForFunction(() => {
+            const state = (window as any).__BG_TEST_HARNESS__?.state?.get?.();
+            return window.innerWidth === 812
+                && window.matchMedia('(pointer: coarse)').matches
+                && state?.sys?.phase === 'playCards'
+                && state?.core?.bases?.[0]?.minions?.[0]?.uid === 'p0-monster-with-counter';
+        }, { timeout: 10000, polling: 200 });
+
+        const monster = page.locator('[data-minion-uid="p0-monster-with-counter"]');
+
+        await expect(monster).toBeVisible({ timeout: 15000 });
+        await expect(monster).toContainText('+1');
+        await expect(monster).toHaveAttribute('data-activation-armed', 'false');
+
+        await clickCenter(monster, page);
+        await expect(monster).toHaveAttribute('data-expanded', 'true');
+        await expect(monster).toHaveAttribute('data-activation-armed', 'true');
+        await expect(page.getByText('再次点击发动')).toBeVisible({ timeout: 5000 });
+
+        await clickCenter(monster, page);
+
+        await expect.poll(async () => {
+            const state = await game.getState();
+            const player = state.core.players['0'];
+            return {
+                powerCounters: state.core.bases[0].minions.find((minion: any) => minion.uid === 'p0-monster-with-counter')?.powerCounters ?? -1,
+                talentUsed: state.core.bases[0].minions.find((minion: any) => minion.uid === 'p0-monster-with-counter')?.talentUsed ?? false,
+                minionLimit: player.minionLimit,
+            };
+        }, { timeout: 5000 }).toEqual({
+            powerCounters: 0,
+            talentUsed: true,
+            minionLimit: 2,
+        });
+
+        await expect(page.getByText('获得1次额外随从机会')).toBeVisible({ timeout: 5000 });
+
+        await expect(monster).toHaveAttribute('data-activation-armed', 'false');
+        await game.screenshot('13-monster-with-counter-grants-extra-minion', testInfo);
     });
 });

--- a/evidence/smashup-monster-pod-talent-e2e-test.md
+++ b/evidence/smashup-monster-pod-talent-e2e-test.md
@@ -1,0 +1,60 @@
+# 大杀四方 POD 科学怪人「怪物」天赋点击验证
+
+## 问题描述
+
+用户反馈：POD 版科学怪人派系的「怪物」在准备发动天赋时，点击后看起来没有反应。
+本次修复聚焦两条路径：
+1. 没有 `+1` 力量指示物时，不应被当成可发动天赋。
+2. 有 `1` 个 `+1` 力量指示物时，触屏路径应先进入武装态，再在第二次点击时成功发动，并给出明确反馈。
+
+## 实现内容
+
+1. 统一了「怪物」天赋的前置条件判断：
+   - 领域校验层禁止无 `+1` 指示物时发动。
+   - execute 层增加兜底，避免误生成 `TALENT_USED`。
+   - UI 层不再把没有 `+1` 指示物的怪物渲染成可发动状态。
+2. 成功发动后补充明确反馈：
+   - 获得额外随从额度时弹出 `获得1次额外随从机会` toast。
+3. 触屏交互补充提示：
+   - 第一次点击进入武装态时显示 `再次点击发动`，避免用户误以为点击无效。
+4. 同步补了回归测试：
+   - Vitest：POD 怪物无指示物时的校验与 execute 兜底。
+   - Vitest：POD 弃牌/检索弹窗卡图预览统一走 `smashup-card-renderer`。
+   - Playwright：补了两条移动端怪物天赋交互用例。
+
+## 已执行验证
+
+```bash
+npx tsc -p tsconfig.json --noEmit --pretty false
+npx vitest run src/games/smashup/__tests__/ui-interaction-manual.test.ts src/games/smashup/__tests__/newFactionAbilities.test.ts
+```
+
+结果：
+- `tsc` 通过
+- 目标 Vitest 通过
+
+## E2E 阻塞情况
+
+尝试执行：
+
+```bash
+npm run test:e2e:ci -- e2e/smashup-4p-layout-test.e2e.ts
+```
+
+阻塞原因不是本次修复，而是测试环境在应用初始化阶段就失败，导致 `__BG_TEST_HARNESS__` 无法注册。
+
+失败上下文显示：
+
+```text
+Failed to resolve import "html2canvas" from "src/components/system/MobileEvidenceCaptureAgent.tsx"
+TypeError: Failed to fetch dynamically imported module: http://127.0.0.1:6174/src/components/system/MobileEvidenceCaptureAgent.tsx
+```
+
+因此：
+- 本次没有生成可用的 E2E 证据截图
+- 现有 Playwright 失败属于独立环境依赖问题，需先补齐 `html2canvas` 依赖或修复该动态导入链路后，才能继续验证新增用例
+
+## 结论
+
+这次 POD 修复的核心逻辑已经完成，并通过了类型检查和目标单测。
+E2E 仍需在修复 `MobileEvidenceCaptureAgent.tsx` 的 `html2canvas` 依赖问题后重新运行。

--- a/public/locales/en/game-smashup.json
+++ b/public/locales/en/game-smashup.json
@@ -125,7 +125,8 @@
     "fusion_choose_playas": "Choose how to play",
     "fusion_choose_playas_desc": "Fusion cards can be played as a Minion or an Action. Choose the type for this play.",
     "play_as_minion": "Play as Minion",
-    "play_as_action": "Play as Action"
+    "play_as_action": "Play as Action",
+    "tap_again_to_activate": "Tap again to activate"
   },
   "feedback": {
     "deck_search_no_match": "No matching card found in deck. Deck reshuffled.",

--- a/public/locales/zh-CN/game-smashup.json
+++ b/public/locales/zh-CN/game-smashup.json
@@ -125,7 +125,8 @@
     "fusion_choose_playas": "选择打出方式",
     "fusion_choose_playas_desc": "融合卡可以作为随从或战术打出。请选择本次打出的类型。",
     "play_as_minion": "作为随从",
-    "play_as_action": "作为战术"
+    "play_as_action": "作为战术",
+    "tap_again_to_activate": "再次点击发动"
   },
   "feedback": {
     "deck_search_no_match": "牌库中未找到符合条件的卡牌，已重洗牌库",

--- a/src/games/smashup/Board.tsx
+++ b/src/games/smashup/Board.tsx
@@ -114,10 +114,10 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
     const currentPid = core ? getCurrentPlayerId(core) : '0';
     const playerID = rawPlayerID;
     const isMyTurn = playerID === currentPid;
-    // 观战模式下默认显示玩家 0 的视角
-    const myPlayer = playerID && core ? core.players[playerID] : (core ? core.players['0'] : undefined);
-    const isGameOver = G?.sys.gameover;
     const rootPid = playerID || '0';
+    // 观战模式下默认显示玩家 0 的视角
+    const myPlayer = core ? core.players[rootPid] : undefined;
+    const isGameOver = G?.sys.gameover;
     const isWinner = !!isGameOver && isGameOver.winner === rootPid;
     const isMobileViewport = useMobileViewport();
     
@@ -181,7 +181,7 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
     }, []);
     
     // 对手玩家数据
-    const opponentPid = core.turnOrder.find(pid => pid !== playerID) || '1';
+    const opponentPid = core.turnOrder.find(pid => pid !== rootPid) || '1';
     const opponentPlayer = core.players[opponentPid];
     
     // 根据视角模式选择显示的玩家数据

--- a/src/games/smashup/Board.tsx
+++ b/src/games/smashup/Board.tsx
@@ -774,13 +774,17 @@ const SmashUpBoardInner: React.FC<Props> = ({ G, dispatch, playerID: rawPlayerID
         );
     }, [t]);
 
-    // 能力反馈 toast（搜索失败等提示）
+    // 能力反馈 toast：失败提示，以及成功获得额外出牌额度的明确反馈。
     useEffect(() => {
         if (gameEvents.feedbacks.length === 0) return;
         for (const fb of gameEvents.feedbacks) {
-            // 只显示给当前玩家的反馈
             if (fb.playerId === playerID) {
-                toast(t(fb.messageKey, { defaultValue: '牌库中未找到符合条件的卡牌，已重洗牌库', ...fb.messageParams }));
+                const defaultMessage = fb.messageKey === 'ui.extra_minion_granted'
+                    ? '获得{{count}}次额外随从机会'
+                    : fb.messageKey === 'ui.extra_action_granted'
+                    ? '获得{{count}}次额外行动机会'
+                    : '牌库中未找到符合条件的卡牌，已重洗牌库';
+                toast(t(fb.messageKey, { defaultValue: defaultMessage, ...fb.messageParams }));
             }
             gameEvents.removeFeedback(fb.id);
         }

--- a/src/games/smashup/__tests__/newFactionAbilities.test.ts
+++ b/src/games/smashup/__tests__/newFactionAbilities.test.ts
@@ -25,7 +25,8 @@ import { clearBaseAbilityRegistry } from '../domain/baseAbilities';
 import { clearInteractionHandlers, getInteractionHandler } from '../domain/abilityInteractionHandlers';
 import { fireTriggers } from '../domain/ongoingEffects';
 import { reduce } from '../domain/reduce';
-import { processDestroyTriggers } from '../domain/reducer';
+import { execute, processDestroyTriggers } from '../domain/reducer';
+import { validate } from '../domain/commands';
 import { makeMinion, makeCard, makePlayer, makeState, makeMatchState, getInteractionsFromMS } from './helpers';
 import { runCommand, defaultTestRandom } from './testRunner';
 import type { MatchState } from '../../../engine/types';
@@ -1645,6 +1646,60 @@ describe('科学怪人派系能力', () => {
             e => e.type === SU_EVENTS.LIMIT_MODIFIED && (e as any).payload.limitType === 'minion',
         );
         expect(limitEvt).toBeDefined();
+    });
+
+    it('怪物 POD：没有+1力量指示物时不能发动天赋', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [
+                        makeMinion('monster1', 'frankenstein_the_monster_pod', '0', 5, { powerCounters: 0 }),
+                    ],
+                    ongoingActions: [],
+                },
+            ],
+        });
+
+        const result = validate(makeMatchState(core), {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { minionUid: 'monster1', baseIndex: 0 },
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('该随从当前无法发动天赋：没有+1力量指示物');
+    });
+
+    it('怪物 POD：没有+1力量指示物时 execute 不应误生成 TALENT_USED', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0'),
+                '1': makePlayer('1'),
+            },
+            bases: [
+                {
+                    defId: 'base_a',
+                    minions: [
+                        makeMinion('monster1', 'frankenstein_the_monster_pod', '0', 5, { powerCounters: 0 }),
+                    ],
+                    ongoingActions: [],
+                },
+            ],
+        });
+
+        const events = execute(makeMatchState(core), {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { minionUid: 'monster1', baseIndex: 0 },
+        }, defaultTestRandom);
+
+        expect(events).toEqual([]);
+        expect(events.some(event => event.type === SU_EVENTS.TALENT_USED)).toBe(false);
     });
 
     it('愤怒的民众：若所选手牌已离开手牌，不应凭旧交互再塞回牌库', () => {

--- a/src/games/smashup/__tests__/ui-interaction-manual.test.ts
+++ b/src/games/smashup/__tests__/ui-interaction-manual.test.ts
@@ -5,7 +5,9 @@
  * 运行后会在控制台输出交互状态，可以手动检查。
  */
 
-import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { GameTestRunner } from '../../../engine/testing';
 import { SmashUpDomain } from '../domain';
 import { smashUpFlowHooks } from '../domain/index';
@@ -16,7 +18,7 @@ import {
 } from '../../../engine';
 import type { EngineSystem } from '../../../engine/systems/types';
 import { createSmashUpEventSystem } from '../domain/systems';
-import { asSimpleChoice } from '../../../engine/systems/InteractionSystem';
+import { asSimpleChoice, createSimpleChoice } from '../../../engine/systems/InteractionSystem';
 import type { SmashUpCore, CardInstance, MinionOnBase, BaseInPlay } from '../domain/types';
 import type { MatchState } from '../../../engine/types';
 import { initAllAbilities, resetAbilityInit } from '../abilities';
@@ -28,8 +30,23 @@ import { clearOngoingEffectRegistry } from '../domain/ongoingEffects';
 import { getCardDef } from '../data/cards';
 import { createInitialSystemState } from '../../../engine/pipeline';
 import { SU_COMMANDS } from '../domain/types';
+import { ToastProvider } from '../../../contexts/ToastContext';
+import { PromptOverlay } from '../ui/PromptOverlay';
+
+vi.mock('../../../components/common/media/CardPreview', () => ({
+    CardPreview: ({ previewRef }: { previewRef?: unknown }) => (
+        React.createElement('div', {
+            'data-testid': 'mock-card-preview',
+            'data-preview-ref': JSON.stringify(previewRef ?? null),
+        })
+    ),
+}));
 
 const PLAYER_IDS = ['0', '1'];
+
+afterEach(() => {
+    cleanup();
+});
 
 function makeCard(uid: string, defId: string, owner: string, type: 'minion' | 'action' = 'action'): CardInstance {
     return { uid, defId, owner, type };
@@ -126,6 +143,42 @@ beforeAll(() => {
 });
 
 describe('SmashUp UI 交互验证', () => {
+    it('PromptOverlay 的卡牌选择模式应始终走 smashup-card-renderer（POD 卡也一样）', () => {
+        const interaction = createSimpleChoice(
+            'pod-preview-check',
+            '0',
+            '选择要取回的卡牌',
+            [
+                {
+                    id: 'card-0',
+                    label: '僵尸领主',
+                    value: { cardUid: 'discard-1', defId: 'zombie_lord_pod' },
+                    displayMode: 'card' as const,
+                },
+            ],
+            { sourceId: 'zombie_grave_robbing', targetType: 'generic' },
+        );
+
+        render(
+            React.createElement(
+                ToastProvider,
+                null,
+                React.createElement(PromptOverlay, {
+                    interaction,
+                    dispatch: () => undefined,
+                    playerID: '0',
+                }),
+            ),
+        );
+
+        const preview = screen.getByTestId('mock-card-preview');
+        expect(JSON.parse(preview.getAttribute('data-preview-ref') ?? 'null')).toEqual({
+            type: 'renderer',
+            rendererId: 'smashup-card-renderer',
+            payload: { defId: 'zombie_lord_pod' },
+        });
+    });
+
     it('zombie_mall_crawl: 验证选项结构', () => {
         // 准备状态：手牌有 mall_crawl，牌库有多种卡牌
         const core = makeState({

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -18,6 +18,7 @@ import {
     getActionLikeResponseWindowTiming,
     canUseBaseLimitedMinionQuota,
     canUseSameNameMinionQuota,
+    getMinionTalentActivationError,
     getMaxRemainingGlobalPowerLimitedQuota,
     mustUseBaseLimitedMinionQuota,
     mustUseGlobalPowerLimitedMinionQuota,
@@ -569,6 +570,10 @@ export function validate(
             const mDef = getCardDef(targetMinion.defId);
             if (!mDef || !('abilityTags' in mDef) || !mDef.abilityTags?.includes('talent')) {
                 return { valid: false, error: '该随从没有天赋能力' };
+            }
+            const talentActivationError = getMinionTalentActivationError(core, targetMinion, baseIndex);
+            if (talentActivationError) {
+                return { valid: false, error: talentActivationError };
             }
             return { valid: true };
         }

--- a/src/games/smashup/domain/reducer.ts
+++ b/src/games/smashup/domain/reducer.ts
@@ -55,7 +55,7 @@ import type { PlayerId } from '../../../engine/types';
 import { SU_COMMANDS, SU_EVENTS, STARTING_HAND_SIZE } from './types';
 import { getMinionDef, getMinionLikePower, getCardDef, getBaseDefIdsForFactions, getFusionDef } from '../data/cards';
 import type { ActionCardDef, FusionCardDef } from './types';
-import { buildDeck, drawCards, isCardMinionLike } from './utils';
+import { buildDeck, drawCards, getMinionTalentActivationError, isCardMinionLike } from './utils';
 import { autoMulligan } from '../../../engine/primitives/mulligan';
 import { maybeQueueStartingHandMulliganPrompt } from './mulliganHandlers';
 import { resolveOnPlay, resolveSpecial, resolveTalent, resolveOnDestroy } from './abilityRegistry';
@@ -541,6 +541,9 @@ function executeCommand(
             // 随从天赋
             const minion = base?.minions.find(m => m.uid === minionUid);
             if (!minion) return { events: [] };
+            if (getMinionTalentActivationError(core, minion, baseIndex)) {
+                return { events: [] };
+            }
 
             const talentEvt: TalentUsedEvent = {
                 type: SU_EVENTS.TALENT_USED,

--- a/src/games/smashup/domain/utils.ts
+++ b/src/games/smashup/domain/utils.ts
@@ -30,6 +30,27 @@ export function matchesDefId(defId: string | undefined | null, baseDefId: string
     return defId === baseDefId || defId === `${baseDefId}_pod`;
 }
 
+/**
+ * 获取随从天赋当前不可发动的原因。
+ *
+ * 这里只放“卡牌自身规则前置条件”，供命令校验、UI 高亮和 execute 兜底共用，
+ * 避免出现前端显示可点、点了却没有实际效果的分层不一致问题。
+ */
+export function getMinionTalentActivationError(
+    state: SmashUpCore,
+    minion: MinionOnBase,
+    baseIndex: number,
+): string | null {
+    void state;
+    void baseIndex;
+
+    if (matchesDefId(minion.defId, 'frankenstein_the_monster') && (minion.powerCounters ?? 0) < 1) {
+        return '该随从当前无法发动天赋：没有+1力量指示物';
+    }
+
+    return null;
+}
+
 export function resolveLiveBaseIndex(
     state: { bases: Array<{ defId: string }> },
     baseIndex: number | undefined,

--- a/src/games/smashup/ui/BaseZone.tsx
+++ b/src/games/smashup/ui/BaseZone.tsx
@@ -13,7 +13,7 @@ import { getBaseDef, getMinionDef, getCardDef, resolveCardName, resolveCardText 
 import { isSpecialLimitBlocked } from '../domain/abilityHelpers';
 import { getScoringEligibleBaseIndices } from '../domain/ongoingModifiers';
 import { getBaseRestrictions } from '../domain/ongoingEffects';
-import { matchesDefId } from '../domain/utils';
+import { getMinionTalentActivationError, matchesDefId } from '../domain/utils';
 import { getFactionMeta } from './factionMeta';
 import { CardPreview } from '../../../components/common/media/CardPreview';
 import { PLAYER_CONFIG } from './playerConfig';
@@ -549,10 +549,12 @@ const MinionCard: React.FC<{
     const canUseSecondTalentOnStandingStones =
         core.bases[baseIndex]?.defId === 'base_standing_stones' &&
         !core.standingStonesDoubleTalentMinionUid;
+    const hasTalentActivationPreconditionError = getMinionTalentActivationError(core, minion, baseIndex) !== null;
     const canUseTalent = hasTalent
         && isMyTurn
         && minion.controller === myPlayerId
         && tutorialAllowed
+        && !hasTalentActivationPreconditionError
         && (!minion.talentUsed || canUseSecondTalentOnStandingStones);
 
     // 场上随从 special 能力判定（如忍者侍从）
@@ -584,6 +586,7 @@ const MinionCard: React.FC<{
         : 'left-full flex-col pl-[0.6vw]';
     const minionActivationKey = `minion-${minion.uid}`;
     const isMinionActivationArmed = isActivationArmed(minionActivationKey);
+    const showTouchActivationHint = isCoarsePointer && isMinionActivationArmed && canActivate;
 
     const seed = minion.uid.charCodeAt(0) + index;
     const rotation = (seed % 6) - 3;
@@ -788,6 +791,11 @@ const MinionCard: React.FC<{
             )}
 
             {/* 附着的 ongoing 行动卡 - 角标 + hover 时弹出小卡片 */}
+            {showTouchActivationHint && (
+                <div className="absolute -bottom-[0.3vw] left-1/2 -translate-x-1/2 bg-amber-500 text-slate-900 text-[0.45vw] font-bold px-[0.35vw] py-[0.05vw] rounded-sm shadow-sm border border-white z-20 whitespace-nowrap pointer-events-none">
+                    {t('ui.tap_again_to_activate', { defaultValue: '再次点击发动' })}
+                </div>
+            )}
             {hasAttachedActions && (
                 <>
                     <AttachedBadge count={minion.attachedActions.length} />

--- a/src/games/smashup/ui/PromptOverlay.tsx
+++ b/src/games/smashup/ui/PromptOverlay.tsx
@@ -44,6 +44,15 @@ interface Props {
     };
 }
 
+function buildRendererPreviewRef(defId: string | undefined): CardPreviewRef | undefined {
+    if (!defId) return undefined;
+    return {
+        type: 'renderer',
+        rendererId: 'smashup-card-renderer',
+        payload: { defId },
+    };
+}
+
 /** 从选项 value 中提取 defId（卡牌/随从/基地） */
 function extractDefId(value: unknown): string | undefined {
     if (!value || typeof value !== 'object') return undefined;
@@ -75,8 +84,7 @@ function isCardOption(option: { value: unknown; displayMode?: 'card' | 'button' 
 function extractContextPreview(prompt: any): CardPreviewRef | undefined {
     const ctx = prompt?.continuationContext as Record<string, unknown> | undefined;
     if (!ctx || typeof ctx.defId !== 'string') return undefined;
-    const def = getCardDef(ctx.defId as string) ?? getBaseDef(ctx.defId as string);
-    return def?.previewRef;
+    return buildRendererPreviewRef(ctx.defId);
 }
 
 /** 解析文本中嵌入的 i18n key（如 cards.xxx.name / cards.xxx.abilityText） */
@@ -651,7 +659,7 @@ export const PromptOverlay: React.FC<Props> = ({ interaction, dispatch, playerID
                             {cardOptions.map((option, idx) => {
                                 const defId = extractDefId(option.value);
                                 const def = defId ? (getCardDef(defId) ?? getBaseDef(defId)) : undefined;
-                                const previewRef = def?.previewRef;
+                                const previewRef = buildRendererPreviewRef(defId);
                                 const name = def ? resolveCardName(def, t) : option.label;
                                 const isSelected = selectedIds.includes(option.id);
                                 const isBase = !!getBaseDef(defId ?? '');

--- a/src/games/smashup/ui/useGameEvents.ts
+++ b/src/games/smashup/ui/useGameEvents.ts
@@ -15,7 +15,7 @@
 
 import { useCallback, useEffect, useState, useMemo } from 'react';
 import type { MatchState } from '../../../engine/types';
-import type { SmashUpCore } from '../domain/types';
+import type { SmashUpCore, LimitModifiedEvent } from '../domain/types';
 import { SU_EVENTS } from '../domain/types';
 import type { AbilityFeedbackEvent } from '../domain/types';
 import { getEventStreamEntries } from '../../../engine/systems/EventStreamSystem';
@@ -50,7 +50,7 @@ interface UseGameEventsParams {
   baseRefs: React.RefObject<Map<number, HTMLElement>>;
 }
 
-export function useGameEvents({ G, fxBus, baseRefs }: UseGameEventsParams) {
+export function useGameEvents({ G, myPlayerId, fxBus, baseRefs }: UseGameEventsParams) {
   const entries = getEventStreamEntries(G);
   const { consumeNew } = useEventStreamCursor({ entries });
 
@@ -160,9 +160,23 @@ export function useGameEvents({ G, fxBus, baseRefs }: UseGameEventsParams) {
           }]);
           break;
         }
+
+        case SU_EVENTS.LIMIT_MODIFIED: {
+          const payload = (event as LimitModifiedEvent).payload;
+          if (payload.delta > 0 && payload.playerId === myPlayerId) {
+            setFeedbacks(prev => [...prev, {
+              id: `fb-${uidCounter++}`,
+              playerId: payload.playerId,
+              messageKey: payload.limitType === 'minion' ? 'ui.extra_minion_granted' : 'ui.extra_action_granted',
+              messageParams: { count: payload.delta },
+              tone: 'info',
+            }]);
+          }
+          break;
+        }
       }
     }
-  }, [G, consumeNew, fxBus, baseRefs, triggerDefIds, TRIGGER_CARRIER_EVENTS]);
+  }, [G, consumeNew, myPlayerId, fxBus, baseRefs, triggerDefIds, TRIGGER_CARRIER_EVENTS]);
 
   // 清除已完成的反馈
   const removeFeedback = useCallback((id: string) => {

--- a/src/games/smashup/ui/useGameEvents.ts
+++ b/src/games/smashup/ui/useGameEvents.ts
@@ -163,7 +163,13 @@ export function useGameEvents({ G, myPlayerId, fxBus, baseRefs }: UseGameEventsP
 
         case SU_EVENTS.LIMIT_MODIFIED: {
           const payload = (event as LimitModifiedEvent).payload;
-          if (payload.delta > 0 && payload.playerId === myPlayerId) {
+          const isUnrestricted =
+            payload.restrictToBase === undefined &&
+            payload.powerMax === undefined &&
+            !payload.sameNameOnly &&
+            payload.sameNameDefId === undefined;
+
+          if (payload.delta > 0 && payload.playerId === myPlayerId && isUnrestricted) {
             setFeedbacks(prev => [...prev, {
               id: `fb-${uidCounter++}`,
               playerId: payload.playerId,


### PR DESCRIPTION
## 变更内容
- 修复 Smash Up POD 弃牌/检索弹窗仍显示基础版卡图的问题，统一改为走 smashup-card-renderer
- 修复 POD 科学怪人『怪物』在没有 +1 力量指示物时仍表现为可点击但无反应的问题
- 为触屏路径补充『再次点击发动』提示，并在成功发动后给出额外随从机会 toast
- 补充对应 Vitest 回归测试，以及移动端 E2E 用例

## 验证
- 
px tsc -p tsconfig.json --noEmit --pretty false
- 
px vitest run src/games/smashup/__tests__/ui-interaction-manual.test.ts src/games/smashup/__tests__/newFactionAbilities.test.ts
- 
pm run test:e2e:ci -- e2e/smashup-4p-layout-test.e2e.ts 未通过，但阻塞原因是现有测试环境缺少 html2canvas 依赖，导致 MobileEvidenceCaptureAgent.tsx 动态导入失败，详见 evidence 文档

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Touch guidance: “Tap again to activate” prompt on mobile; renderer-driven card previews; toasts when extra minion/action opportunities are granted

* **Bug Fixes**
  * Prevent talents from activating without required power counters; added execution guard to avoid erroneous talent state changes; UI no longer shows unarmed talents as activatable

* **Tests**
  * New unit and mobile E2E tests covering talent validation and touch interactions

* **Documentation**
  * Added evidence/validation doc for the talent click fix and test results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->