### PR TITLE
fix(smashup): 修复荣誉之地误判受害者得分

### DIFF
--- a/src/games/smashup/__tests__/newBaseAbilities.test.ts
+++ b/src/games/smashup/__tests__/newBaseAbilities.test.ts
@@ -21,7 +21,8 @@ import {
 } from '../domain/baseAbilities';
 import { processDestroyTriggers } from '../domain/reducer';
 import type { BaseAbilityContext } from '../domain/baseAbilities';
-import type { SmashUpCore, MinionOnBase, CardInstance } from '../domain/types';
+import type { MatchState, RandomFn } from '../../../engine/types';
+import type { SmashUpCore, MinionOnBase, CardInstance, MinionDestroyedEvent } from '../domain/types';
 import { SU_EVENTS } from '../domain/types';
 import { SMASHUP_FACTION_IDS } from '../domain/ids';
 import { triggerBaseAbilityWithMS, getInteractionsFromResult, makeMatchState } from './helpers';
@@ -30,6 +31,13 @@ import { reduce } from '../domain/reduce';
 beforeAll(() => {
     initAllAbilities();
 });
+
+const dummyRandom: RandomFn = {
+    random: () => 0.5,
+    d: () => 1,
+    range: (min: number) => min,
+    shuffle: <T>(arr: T[]) => [...arr],
+};
 
 /** 构造最小测试状态 */
 function makeState(overrides: Partial<SmashUpCore> = {}): SmashUpCore {
@@ -201,6 +209,61 @@ describe('base_the_field_of_honor: 消灭者获1VP', () => {
         expect(vpEvents).toHaveLength(1);
         expect(vpEvents[0].payload.playerId).toBe('0');
         expect(vpEvents[0].payload.amount).toBe(1);
+    });
+
+    it('集成路径：destroyerId 缺失时，VP 仍应判给事件操作者而不是被消灭者', () => {
+        const victim = makeMinion('victim', '0', 3);
+        const core = makeState({
+            players: {
+                '0': {
+                    id: '0',
+                    vp: 0,
+                    hand: [],
+                    deck: [],
+                    discard: [],
+                    minionsPlayed: 0,
+                    minionLimit: 1,
+                    actionsPlayed: 0,
+                    actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.BEAR_CAVALRY, SMASHUP_FACTION_IDS.NINJAS],
+                },
+                '1': {
+                    id: '1',
+                    vp: 0,
+                    hand: [],
+                    deck: [],
+                    discard: [],
+                    minionsPlayed: 0,
+                    minionLimit: 1,
+                    actionsPlayed: 0,
+                    actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.BEAR_CAVALRY, SMASHUP_FACTION_IDS.NINJAS],
+                },
+            },
+            bases: [{
+                defId: 'base_the_field_of_honor',
+                minions: [victim],
+                ongoingActions: [],
+            }],
+        });
+        const ms: MatchState<SmashUpCore> = makeMatchState(core);
+        const destroyEvent: MinionDestroyedEvent = {
+            type: SU_EVENTS.MINION_DESTROYED,
+            payload: {
+                minionUid: 'victim',
+                minionDefId: victim.defId,
+                fromBaseIndex: 0,
+                ownerId: '0',
+                reason: 'integration_destroy',
+            },
+            timestamp: 1000,
+        };
+
+        const result = processDestroyTriggers([destroyEvent], ms, '1', dummyRandom, 1000);
+        const vpEvents = result.events.filter(e => e.type === SU_EVENTS.VP_AWARDED);
+        expect(vpEvents).toHaveLength(1);
+        expect((vpEvents[0] as any).payload.playerId).toBe('1');
+        expect((vpEvents[0] as any).payload.amount).toBe(1);
     });
 
     it('base_the_field_of_honor: destroy 自己的随从时不应得分', () => {

--- a/src/games/smashup/domain/reducer.ts
+++ b/src/games/smashup/domain/reducer.ts
@@ -704,7 +704,9 @@ export function processDestroyTriggers(
         const minion = base?.minions.find(m => m.uid === minionUid);
         // ✅ 优先从 state 读取 owner（兜底修复：即使事件中的 ownerId 错了也能修复）
         const ownerId = minion?.owner ?? eventOwnerId;
-        const destroyerId = eventDestroyerId ?? minion?.controller ?? ownerId;
+        // destroyerId 缺失时，回退到当前事件链的操作者，而不是被消灭随从的控制者。
+        // 否则像“荣誉之地”这类奖励消灭者的基地，会错误把 VP 判给受害者。
+        const destroyerId = eventDestroyerId ?? playerId;
 
         // === Phase 1: 先检查防止消灭触发器（基地能力 + ongoing） ===
         // 在触发 onDestroy 之前，先确认消灭是否会被防止

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -1070,7 +1070,7 @@ export interface MinionDestroyedEvent extends GameEvent<typeof SU_EVENTS.MINION_
         minionDefId: string;
         fromBaseIndex: number;
         ownerId: PlayerId;
-        destroyerId?: PlayerId;  // 消灭者（可选，如果没有则默认为 ownerId）
+        destroyerId?: PlayerId;  // 消灭者（可选，缺失时由事件处理流程按当前操作者推断）
         reason: string;
     };
 }


### PR DESCRIPTION
## 变更
- 修复荣誉之地在 destroyerId 缺失时把 VP 错判给被消灭随从控制者的问题
- 将回退逻辑改为使用当前事件链操作者，而不是受害者控制者
- 补充集成回归测试，覆盖‘别人消灭我的随从时应由对手得分’的场景

## 验证
- npx vitest run src/games/smashup/__tests__/newBaseAbilities.test.ts
- npx vitest run src/games/smashup/__tests__/baseProtection.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced minion destruction event handling to correctly determine the destroyer from the current active player when not explicitly specified in the event payload.
  * Updated downstream trigger processing to use the inferred destroyer consistently across protection and effect evaluation.

* **Tests**
  * Added integration test coverage for base ability behaviors with minion destruction, validating proper effect attribution when destroyer information is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->