### PR TITLE
fix(smashup): 修复 Block the Path POD 交互选项值

### DIFF
--- a/src/games/smashup/__tests__/factionAbilities.test.ts
+++ b/src/games/smashup/__tests__/factionAbilities.test.ts
@@ -70,6 +70,53 @@ describe('trickster interaction regressions', () => {
         expect((destroyEvent as any).payload.minionUid).toBe('e1');
         expect(respondResult.finalState.core.bases[0].minions.some(m => m.uid === 'e1')).toBe(false);
     });
+
+    it('trickster_block_the_path_pod stores the selected blocked faction combo', () => {
+        const state = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('a_block', 'trickster_block_the_path_pod', 'action', '0')],
+                    factions: ['tricksters_pod', 'test_b'] as [string, string],
+                }),
+                '1': makePlayer('1', {
+                    factions: ['robots', 'zombies'] as [string, string],
+                }),
+            },
+            bases: [{ defId: 'b1', minions: [], ongoingActions: [] }],
+        });
+
+        const playResult = runCommand(makeMatchState(state), {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '0',
+            payload: { cardUid: 'a_block', targetBaseIndex: 0 },
+        } as any, defaultRandom);
+
+        expect(playResult.success).toBe(true);
+
+        const prompt = playResult.finalState.sys.interaction?.current as any;
+        expect(prompt?.data?.sourceId).toBe('trickster_block_the_path_pod');
+
+        const options = prompt?.data?.options ?? [];
+        const blockedOptions = options.filter((option: any) => option?.value?.blocked?.['1']);
+        expect(blockedOptions).toHaveLength(2);
+        expect(blockedOptions.map((option: any) => option.value.blocked['1'])).toEqual(['robots', 'zombies']);
+
+        const robotsOption = blockedOptions.find((option: any) => option?.value?.blocked?.['1'] === 'robots');
+        expect(robotsOption).toBeDefined();
+
+        const respondResult = runCommand(playResult.finalState, {
+            type: 'SYS_INTERACTION_RESPOND',
+            playerId: '0',
+            payload: { optionId: robotsOption.id },
+        } as any, defaultRandom);
+
+        expect(respondResult.success).toBe(true);
+
+        const ongoing = respondResult.finalState.core.bases[0].ongoingActions.find(
+            action => action.defId === 'trickster_block_the_path_pod',
+        );
+        expect(ongoing?.metadata?.blockedFactionsByPlayer).toEqual({ '1': 'robots' });
+    });
 });
 
 // ============================================================================

--- a/src/games/smashup/abilities/tricksters.ts
+++ b/src/games/smashup/abilities/tricksters.ts
@@ -1236,7 +1236,7 @@ function registerTricksterPodOngoingEffects(): void {
         const options = combos.map((c, i) => ({
             id: `combo-${i}`,
             label: c.label,
-            value: { blocked },
+            value: { blocked: c.blocked },
         }));
         const interaction = createSimpleChoice(
             `trickster_block_the_path_pod_${ctx.now}`,


### PR DESCRIPTION
## 背景
- 作者分支 `codex/smashup-pod-response-fixes` 上的 `trickster_block_the_path_pod` 旧实现里，交互选项把未定义变量 `blocked` 写进了 `value`
- 打出这张卡时会导致交互构造异常，卡无法正常打出

## 修复
- 将选项值改为当前组合的 `c.blocked`
- 补一条回归测试，覆盖交互选项值与 `blockedFactionsByPlayer` 回写

## 验证
- `npx vitest run src/games/smashup/__tests__/factionAbilities.test.ts`
- `npx vitest run src/games/smashup/__tests__/baseFactionOngoing.test.ts`