### PR TITLE
fix(smashup): correct madness unleashed extra action quota

### DIFF
--- a/e2e/smashup-response-window-pass-test.e2e.ts
+++ b/e2e/smashup-response-window-pass-test.e2e.ts
@@ -120,4 +120,131 @@ test.describe('大杀四方 - 响应窗口 Pass 测试', () => {
         console.log('[TEST] 窗口状态 3:', windowState3);
         expect(windowState3.hasWindow).toBe(false);
     });
+
+    test('疯狂解放：弃两张疯狂卡后应立即获得两个额外战术额度，并能继续打出两张行动卡', async ({ page, game }, testInfo) => {
+        test.setTimeout(60000);
+
+        await page.goto('/play/smashup');
+        await page.waitForFunction(
+            () => (window as any).__BG_TEST_HARNESS__?.state?.isRegistered(),
+            { timeout: 15000 },
+        );
+
+        await game.setupScene({
+            gameId: 'smashup',
+            player0: {
+                hand: [
+                    { uid: 'madness-unleashed', defId: 'cthulhu_madness_unleashed', type: 'action' },
+                    { uid: 'madness-1', defId: 'special_madness', type: 'action' },
+                    { uid: 'madness-2', defId: 'special_madness', type: 'action' },
+                    { uid: 'study-1', defId: 'wizard_mystic_studies', type: 'action' },
+                    { uid: 'study-2', defId: 'wizard_mystic_studies', type: 'action' },
+                ],
+                deck: [
+                    { uid: 'deck-1', defId: 'alien_invader', type: 'minion' },
+                    { uid: 'deck-2', defId: 'wizard_apprentice', type: 'minion' },
+                    { uid: 'deck-3', defId: 'pirate_first_mate', type: 'minion' },
+                    { uid: 'deck-4', defId: 'robot_microbot_alpha', type: 'minion' },
+                    { uid: 'deck-5', defId: 'zombie_walker', type: 'minion' },
+                    { uid: 'deck-6', defId: 'alien_scout', type: 'minion' },
+                ],
+                discard: [],
+                factions: ['minions_of_cthulhu', 'wizards'],
+                actionsPlayed: 0,
+                actionLimit: 1,
+                minionsPlayed: 0,
+                minionLimit: 1,
+            },
+            player1: {
+                hand: [],
+                deck: [],
+                discard: [],
+                factions: ['aliens', 'robots'],
+            },
+            bases: [
+                { defId: 'base_the_mothership', minions: [], ongoingActions: [] },
+                { defId: 'base_tortuga', minions: [], ongoingActions: [] },
+            ],
+            currentPlayer: '0',
+            phase: 'playCards',
+        });
+
+        await page.waitForTimeout(1200);
+
+        const waitForNoInteraction = async () => {
+            await expect.poll(async () => {
+                const state = await game.getState();
+                return state.sys.interaction?.current?.data?.sourceId ?? null;
+            }, { timeout: 10000 }).toBe(null);
+        };
+
+        const dismissSpotlightQueueIfPresent = async () => {
+            const spotlightQueue = page.getByTestId('card-spotlight-queue');
+            const isVisible = await spotlightQueue.isVisible({ timeout: 300 }).catch(() => false);
+            if (!isVisible) return;
+
+            await spotlightQueue.click({ force: true });
+            await expect(spotlightQueue).toBeHidden({ timeout: 5000 });
+        };
+
+        await game.playCard('cthulhu_madness_unleashed');
+        await game.waitForInteraction('cthulhu_madness_unleashed', 10000);
+
+        const promptState = await game.getState();
+        expect(promptState.sys.interaction.current.data.multi).toEqual({ min: 0, max: 2 });
+        const madnessOptions = (await game.getInteractionOptions()).filter((option: any) => option.value?.cardUid);
+        expect(madnessOptions).toHaveLength(2);
+        const confirmButton = page.getByRole('button', { name: /^(确认|Confirm)(?:\s*\(\d+\))?$/i });
+        const selectAllButton = page.getByRole('button', { name: /^(全选|Select All)$/i });
+
+        await game.screenshot('01-madness-unleashed-prompt', testInfo);
+
+        await selectAllButton.evaluate((button: HTMLButtonElement) => button.click());
+        await expect(confirmButton).toHaveText(/^(确认|Confirm)\s*\(2\)$/i);
+        await game.screenshot('01b-madness-unleashed-select-all', testInfo);
+
+        await confirmButton.evaluate((button: HTMLButtonElement) => button.click());
+        await waitForNoInteraction();
+
+        const actionQuota = page.locator('.group\\/action').first();
+        const actionQuotaText = await actionQuota.evaluate((node) => node.textContent?.replace(/\s+/g, '') ?? '');
+        expect(actionQuotaText).toMatch(/(战术|Action)2/i);
+        expect(actionQuotaText).toMatch(/(通用额度|GlobalQuota)2\/3/i);
+        expect(actionQuotaText).toMatch(/(含额外行动额度|Includesextraactionquota)\+2/i);
+        await game.screenshot('02-after-madness-unleashed-quota', testInfo);
+
+        await dismissSpotlightQueueIfPresent();
+        await game.playCard('wizard_mystic_studies');
+        await page.waitForTimeout(500);
+        await dismissSpotlightQueueIfPresent();
+        await game.playCard('wizard_mystic_studies');
+        await page.waitForTimeout(500);
+        await dismissSpotlightQueueIfPresent();
+
+        const finalState = await game.getState();
+        const player0 = finalState.core.players['0'];
+
+        expect(player0.actionsPlayed).toBe(3);
+        expect(player0.actionLimit).toBe(3);
+        expect(player0.discard.map((card: any) => card.uid).sort()).toEqual([
+            'madness-1',
+            'madness-2',
+            'madness-unleashed',
+            'study-1',
+            'study-2',
+        ]);
+        expect(player0.hand.map((card: any) => card.uid).sort()).toEqual([
+            'deck-1',
+            'deck-2',
+            'deck-3',
+            'deck-4',
+            'deck-5',
+            'deck-6',
+        ]);
+
+        const finalQuotaText = await actionQuota.evaluate((node) => node.textContent?.replace(/\s+/g, '') ?? '');
+        expect(finalQuotaText).toMatch(/(战术|Action)0/i);
+        expect(finalQuotaText).toMatch(/(通用额度|GlobalQuota)0\/3/i);
+        await game.screenshot('03-after-two-extra-actions', testInfo);
+    });
 });

--- a/evidence/smashup-madness-unleashed-e2e-test.md
+++ b/evidence/smashup-madness-unleashed-e2e-test.md
@@ -1,0 +1,112 @@
+# 大杀四方《疯狂解放》原版/POD 修复验证
+
+## 问题描述
+
+用户反馈《大杀四方》中，`疯狂解放 / Madness Unleashed / cthulhu_madness_unleashed` 在弃掉疯狂卡后，没有获得对应数量的额外战术额度。
+
+本次核对目标：
+
+1. 原版 `cthulhu_madness_unleashed` 是否会按弃牌数立即发放额外战术额度。
+2. POD 版 `cthulhu_madness_unleashed_pod` 是否存在相同问题。
+
+## 修复结论
+
+问题确认存在于 `src/games/smashup/abilities/cthulhu.ts` 的 `cthulhu_madness_unleashed` 交互处理链路中。
+
+修复后行为改为：
+
+1. 玩家一次性选择要弃掉的疯狂卡。
+2. 先统一弃掉所有选中的疯狂卡。
+3. 按弃牌数直接结算“每弃 1 张，抽 1 张牌并获得 1 个额外行动额度”。
+4. 不再额外弹出二次“要使用几次收益”的交互。
+
+由于 POD 版复用同一能力/交互别名链路，所以该修复同时覆盖原版与 POD 版。
+
+## 验证命令
+
+```bash
+npx vitest run src/games/smashup/__tests__/madnessPromptAbilities.test.ts
+npm run test:e2e:ci -- e2e/smashup-response-window-pass-test.e2e.ts
+```
+
+## 测试结果
+
+### 1. Vitest
+
+- `src/games/smashup/__tests__/madnessPromptAbilities.test.ts`
+- 结果：`22 passed`
+
+覆盖点：
+
+- 原版：弃 2 张疯狂卡后，立即弃牌、抽 2 张，并获得 2 个额外行动额度。
+- POD：弃 1 张疯狂卡后，立即获得 1 个额外行动额度。
+
+### 2. E2E
+
+- `e2e/smashup-response-window-pass-test.e2e.ts`
+- 结果：`2 passed`
+
+E2E 场景：
+
+1. P0 手牌中有 `疯狂解放`、2 张 `疯狂卡`、2 张 `Mystic Studies`。
+2. 通过 UI 打出 `疯狂解放`。
+3. 在多选弹窗中选择两张疯狂卡并确认。
+4. 立即检查 HUD：额外战术额度应变为 `+2`，总战术额度应为 `2/3`。
+5. 再连续打出两张 `Mystic Studies`，验证额外额度可被实际消费。
+
+说明：
+
+- 自动化里直接点卡牌选项和普通 pointer click 容易受当前拖拽/放大镜/Spotlight 展示层影响，因此用弹窗内的 `Select All / 全选` 按钮完成同一个 UI 选择流程，再点击确认。
+- 出牌后的 `CardSpotlightQueue` 是展示层遮罩，不影响实际状态；测试中会显式关闭后继续出牌。
+
+## 关键截图
+
+### 1. 选择两张疯狂卡后的交互阶段
+
+![疯狂解放交互](/D:/GA/BoardGame-main-clean/test-results/evidence-screenshots/smashup-response-window-pass-test.e2e/疯狂解放：弃两张疯狂卡后应立即获得两个额外战术额度，并能继续打出两张行动卡/01-madness-unleashed-prompt.png)
+
+截图路径：
+
+- `D:\GA\BoardGame-main-clean\test-results\evidence-screenshots\smashup-response-window-pass-test.e2e\疯狂解放：弃两张疯狂卡后应立即获得两个额外战术额度，并能继续打出两张行动卡\01-madness-unleashed-prompt.png`
+
+分析：
+
+- 画面进入 `疯狂解放` 的多选弹窗。
+- 测试已断言当前交互是 `multi: { min: 0, max: 2 }`，并且选项数为 2，和两张疯狂卡一致。
+
+### 2. 结算后立即显示 2 个额外战术额度
+
+![疯狂解放结算后额度](/D:/GA/BoardGame-main-clean/test-results/evidence-screenshots/smashup-response-window-pass-test.e2e/疯狂解放：弃两张疯狂卡后应立即获得两个额外战术额度，并能继续打出两张行动卡/02-after-madness-unleashed-quota.png)
+
+截图路径：
+
+- `D:\GA\BoardGame-main-clean\test-results\evidence-screenshots\smashup-response-window-pass-test.e2e\疯狂解放：弃两张疯狂卡后应立即获得两个额外战术额度，并能继续打出两张行动卡\02-after-madness-unleashed-quota.png`
+
+分析：
+
+- 顶部出现两条“获得1次额外行动机会”反馈。
+- 左下角牌库剩余从 `6` 变成 `4`，说明本次效果已经立即抽了 2 张。
+- 右侧 HUD 显示当前可用战术额度为 `2`，总额度为 `3`，与“基础 1 次 + 额外 2 次”一致。
+
+### 3. 两次额外战术额度被实际消费
+
+![消费两次额外战术后](/D:/GA/BoardGame-main-clean/test-results/evidence-screenshots/smashup-response-window-pass-test.e2e/疯狂解放：弃两张疯狂卡后应立即获得两个额外战术额度，并能继续打出两张行动卡/03-after-two-extra-actions.png)
+
+截图路径：
+
+- `D:\GA\BoardGame-main-clean\test-results\evidence-screenshots\smashup-response-window-pass-test.e2e\疯狂解放：弃两张疯狂卡后应立即获得两个额外战术额度，并能继续打出两张行动卡\03-after-two-extra-actions.png`
+
+分析：
+
+- 右侧 HUD 中战术剩余已变为 `0`，总额度仍是 `3`，说明两次额外额度已被两张 `Mystic Studies` 正常消耗。
+- 左下角牌库变为 `0`，最终手牌为 `deck-1` 到 `deck-6` 共 6 张，符合：
+  - `疯狂解放` 抽 2 张
+  - 两张 `Mystic Studies` 各抽 2 张
+
+## 最终结论
+
+`疯狂解放` 的问题已经修复，且原版与 POD 版都已覆盖验证：
+
+1. 原版：弃掉几张疯狂卡，就会立即获得对应数量的额外战术额度。
+2. POD：复用同一能力处理链路，单测已确认行为一致。
+3. E2E 已证明这些额外额度不仅显示正确，而且能够继续被实际出牌消耗。

--- a/src/games/smashup/__tests__/madnessPromptAbilities.test.ts
+++ b/src/games/smashup/__tests__/madnessPromptAbilities.test.ts
@@ -320,6 +320,105 @@ describe('克苏鲁之仆 - cthulhu_madness_unleashed（疯狂释放）', () => 
         // 疯狂卡仍在手牌（未弃）
         expect(state.players['0'].hand.some(c => c.uid === 'm1')).toBe(true);
     });
+
+    it('选2张疯狂卡后：立即弃牌、抽2张并获得2个额外行动额度', () => {
+        const state = makeStateWithMadness({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [
+                        makeCard('a1', 'cthulhu_madness_unleashed', 'action', '0'),
+                        makeCard('m1', MADNESS_CARD_DEF_ID, 'action', '0'),
+                        makeCard('m2', MADNESS_CARD_DEF_ID, 'action', '0'),
+                    ],
+                    deck: [
+                        makeCard('d1', 'test_minion_a', 'minion', '0'),
+                        makeCard('d2', 'test_action_a', 'action', '0'),
+                        makeCard('d3', 'test_minion_b', 'minion', '0'),
+                    ],
+                    actionLimit: 1,
+                    actionsPlayed: 0,
+                }),
+                '1': makePlayer('1'),
+            },
+        });
+
+        const playEvents = execPlayAction(state, '0', 'a1');
+        const afterPlay = applyEvents(state, playEvents);
+
+        const handler = getInteractionHandler('cthulhu_madness_unleashed');
+        expect(handler).toBeDefined();
+        const result = handler!(
+            makeMatchState(afterPlay),
+            '0',
+            [{ cardUid: 'm1' }, { cardUid: 'm2' }],
+            undefined,
+            defaultRandom,
+            1000,
+        );
+
+        expect((result as any).matchState).toBeUndefined();
+
+        const discardEvts = result.events.filter(e => e.type === SU_EVENTS.CARDS_DISCARDED);
+        expect(discardEvts.length).toBe(1);
+        expect((discardEvts[0] as any).payload.cardUids).toEqual(['m1', 'm2']);
+
+        const drawEvts = result.events.filter(e => e.type === SU_EVENTS.CARDS_DRAWN);
+        expect(drawEvts.length).toBe(1);
+        expect((drawEvts[0] as any).payload.count).toBe(2);
+        expect((drawEvts[0] as any).payload.cardUids).toEqual(['d1', 'd2']);
+
+        const limitEvts = result.events.filter(e => e.type === SU_EVENTS.LIMIT_MODIFIED);
+        expect(limitEvts.length).toBe(2);
+        expect(limitEvts.every((e: any) => e.payload.limitType === 'action')).toBe(true);
+
+        const finalState = applyEvents(afterPlay, result.events);
+        expect(finalState.players['0'].actionLimit).toBe(3);
+        expect(finalState.players['0'].actionsPlayed).toBe(1);
+        expect(finalState.players['0'].hand.map(c => c.uid).sort()).toEqual(['d1', 'd2']);
+        expect(finalState.players['0'].discard.map(c => c.uid).sort()).toEqual(['a1', 'm1', 'm2']);
+        expect(finalState.players['0'].actionLimit - finalState.players['0'].actionsPlayed).toBe(2);
+    });
+
+    it('POD 版同样会按弃掉的疯狂卡数量立即给予额外行动额度', () => {
+        const state = makeStateWithMadness({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [
+                        makeCard('a1', 'cthulhu_madness_unleashed_pod', 'action', '0'),
+                        makeCard('m1', MADNESS_CARD_DEF_ID, 'action', '0'),
+                    ],
+                    deck: [
+                        makeCard('d1', 'test_minion_a', 'minion', '0'),
+                        makeCard('d2', 'test_action_a', 'action', '0'),
+                    ],
+                    actionLimit: 1,
+                    actionsPlayed: 0,
+                }),
+                '1': makePlayer('1'),
+            },
+        });
+
+        const playEvents = execPlayAction(state, '0', 'a1');
+        const afterPlay = applyEvents(state, playEvents);
+
+        const handler = getInteractionHandler('cthulhu_madness_unleashed');
+        expect(handler).toBeDefined();
+        const result = handler!(
+            makeMatchState(afterPlay),
+            '0',
+            [{ cardUid: 'm1' }],
+            undefined,
+            defaultRandom,
+            1000,
+        );
+
+        const finalState = applyEvents(afterPlay, result.events);
+        expect(finalState.players['0'].actionLimit).toBe(2);
+        expect(finalState.players['0'].actionsPlayed).toBe(1);
+        expect(finalState.players['0'].hand.map(c => c.uid)).toEqual(['d1']);
+        expect(finalState.players['0'].discard.map(c => c.uid).sort()).toEqual(['a1', 'm1']);
+        expect(finalState.players['0'].actionLimit - finalState.players['0'].actionsPlayed).toBe(1);
+    });
 });
 
 

--- a/src/games/smashup/abilities/cthulhu.ts
+++ b/src/games/smashup/abilities/cthulhu.ts
@@ -218,24 +218,24 @@ function cthulhuCorruption(ctx: AbilityContext): AbilityResult {
 }
 
 /**
- * 疑狂释放 onPlay：弃掉手中任意数量的疑狂卡，每张 = ?张牌 + 额外行动
- * 
- * - 无疑狂卡时无效果
- * - 只有1张疑狂卡时自动弃掉?
- * - 多张疑狂卡时创建 Prompt 让玩家选择弃几张（多选，最?张）
+ * 疯狂解放 onPlay：弃掉手中任意数量的疯狂卡；每弃 1 张，就可以抽 1 张牌并获得 1 个额外行动额度。
+ *
+ * 官方 FAQ 明确：
+ * 1. 必须先决定并弃掉所有要弃的疯狂卡，再开始抽牌
+ * 2. 每次选择结算该收益时，抽牌和额外行动是绑定的一组收益，不应拆成二次确认
  */
 function cthulhuMadnessUnleashed(ctx: AbilityContext): AbilityResult {
     const player = ctx.state.players[ctx.playerId];
-    // 排除当前打出的卡，找手中的疑狂卡
+    // 排除当前打出的卡，找手中的疯狂卡
     const madnessInHand = player.hand.filter(
         c => c.defId === MADNESS_CARD_DEF_ID && c.uid !== ctx.cardUid
     );
     if (madnessInHand.length === 0) return { events: [buildAbilityFeedback(ctx.playerId, 'feedback.hand_empty', ctx.now)] };
 
-    // Prompt 选择弃几?
+    // 由玩家一次性选择要弃掉的疯狂卡数量（可为 0）
     const options = madnessInHand.map((c, i) => ({
         id: `madness-${i}`,
-        label: `疑狂卡?${i + 1}`,
+        label: `疯狂卡 ${i + 1}`,
         value: { cardUid: c.uid, defId: c.defId },
         _source: 'hand' as const,
         displayMode: 'card' as const,
@@ -246,7 +246,7 @@ function cthulhuMadnessUnleashed(ctx: AbilityContext): AbilityResult {
     ];
     const interaction = createSimpleChoice<CardChoiceValue | SkipChoiceValue>(
         `cthulhu_madness_unleashed_${ctx.now}`, ctx.playerId,
-        '选择要弃掉的疑狂卡（任意数量，可跳过）', promptOptions,
+        '选择要弃掉的疯狂卡（任意数量，可跳过）', promptOptions,
         { sourceId: 'cthulhu_madness_unleashed', targetType: 'hand', multi: { min: 0, max: madnessInHand.length } },
     );
     return { events: [], matchState: queueInteraction(ctx.matchState, interaction) };
@@ -726,48 +726,19 @@ export function registerCthulhuInteractionHandlers(): void {
         if (!Array.isArray(selectedCards) || selectedCards.length === 0) return { state, events: [] };
         const madnessUids = selectedCards.map(v => v.cardUid).filter(Boolean) as string[];
         if (madnessUids.length === 0) return { state, events: [] };
+        const player = state.core.players[playerId];
+        if (!player) return { state, events: [] };
         const events: SmashUpEvent[] = [];
 
-        // 1) 丢弃选中的疯狂卡到弃牌堆
+        // 1) 先一次性弃掉所有选中的疯狂卡
         events.push({
             type: SU_EVENTS.CARDS_DISCARDED,
             payload: { playerId, cardUids: madnessUids },
             timestamp,
         });
 
-        // 2) 让玩家选择要使用几次“抽牌+额外行动”的机会（0..N）
-        const maxOptions = madnessUids.length;
-        const options: PromptOption<{ count: number }>[] = [];
-        for (let k = 0; k <= maxOptions; k++) {
-            options.push({
-                id: `use-${k}`,
-                label: `使用 ${k} 次抽牌+额外行动`,
-                value: { count: k },
-                displayMode: 'button' as const,
-            });
-        }
-        const interaction = createSimpleChoice<{ count: number }>(
-            `cthulhu_madness_unleashed_apply_${timestamp}`,
-            playerId,
-            '选择要使用几次“抽牌+额外行动”的机会',
-            options,
-            { sourceId: 'cthulhu_madness_unleashed_apply', targetType: 'button' },
-        );
-
-        return { state, events, matchState: queueInteraction(state, interaction) };
-    });
-
-    // 疯狂释放：根据玩家选择的次数执行“抽 1 + 额外行动”
-    registerInteractionHandler('cthulhu_madness_unleashed_apply', (state, playerId, value, _iData, _random, timestamp) => {
-        const { count } = value as { count: number };
-        if (!count || count <= 0) return { state, events: [] };
-
-        const player = state.core.players[playerId];
-        if (!player) return { state, events: [] };
-
-        const drawCount = Math.min(count, player.deck.length);
-        const events: SmashUpEvent[] = [];
-
+        // 2) 按弃牌数直接结算“抽 1 + 额外行动”
+        const drawCount = Math.min(madnessUids.length, player.deck.length);
         if (drawCount > 0) {
             const drawnUids = player.deck.slice(0, drawCount).map(c => c.uid);
             events.push({
@@ -777,7 +748,7 @@ export function registerCthulhuInteractionHandlers(): void {
             } as CardsDrawnEvent);
         }
 
-        for (let i = 0; i < count; i++) {
+        for (let i = 0; i < madnessUids.length; i++) {
             events.push(grantExtraAction(playerId, 'cthulhu_madness_unleashed', timestamp));
         }
 


### PR DESCRIPTION
## 修复内容
- 修复 `疯狂解放 / Madness Unleashed` 弃掉疯狂卡后，没有按弃牌数量立即获得额外战术额度的问题
- 原版与 POD 版共用同一处理链路，因此一并修复

## 验证
- Vitest: `npx vitest run src/games/smashup/__tests__/madnessPromptAbilities.test.ts`
- E2E: `npm run test:e2e:ci -- e2e/smashup-response-window-pass-test.e2e.ts`
- 补充 E2E 证据文档：`evidence/smashup-madness-unleashed-e2e-test.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Madness Unleashed card ability: selecting and discarding madness cards now immediately grants rewards (card draw and extra action quota) without additional prompts.

* **Tests**
  * Added unit and end-to-end test coverage validating the corrected Madness Unleashed ability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->