### PR TITLE
fix(smashup): 修复 Hideout POD 从牌库交换时错误回手

### DIFF
--- a/src/games/smashup/__tests__/baseFactionOngoing.test.ts
+++ b/src/games/smashup/__tests__/baseFactionOngoing.test.ts
@@ -15,6 +15,7 @@ import {
     registerTrigger,
     clearOngoingEffectRegistry,
     registerPodOngoingAliases,
+    interceptEvent,
     isMinionProtected,
     isOperationRestricted,
     fireTriggers,
@@ -1326,6 +1327,54 @@ describe('诡术师 ongoing 能力', () => {
             const state = makeState([base]);
 
             expect(isMinionProtected(state, myMinion, 0, '1', 'action')).toBe(false);
+        });
+
+        test('POD 版会阻止其他玩家把随从移动到此基地', () => {
+            const sourceBase = makeBase({
+                minions: [makeMinion({ defId: 'robot_zapbot', uid: 'm-1', controller: '1', owner: '1' })],
+            });
+            const targetBase = makeBase({
+                ongoingActions: [{ uid: 'ho-1', defId: 'trickster_hideout_pod', ownerId: '0' }],
+            });
+            const state = makeState([sourceBase, targetBase]);
+
+            const result = interceptEvent(state, {
+                type: SU_EVENTS.MINION_MOVED,
+                payload: {
+                    minionUid: 'm-1',
+                    minionDefId: 'robot_zapbot',
+                    fromBaseIndex: 0,
+                    toBaseIndex: 1,
+                    reason: 'test_move',
+                },
+                timestamp: 1000,
+            } as any);
+
+            expect(result).toBeNull();
+        });
+
+        test('POD 版允许拥有者把自己的随从移动到此基地', () => {
+            const sourceBase = makeBase({
+                minions: [makeMinion({ defId: 'trickster_a', uid: 'm-2', controller: '0', owner: '0' })],
+            });
+            const targetBase = makeBase({
+                ongoingActions: [{ uid: 'ho-1', defId: 'trickster_hideout_pod', ownerId: '0' }],
+            });
+            const state = makeState([sourceBase, targetBase]);
+
+            const result = interceptEvent(state, {
+                type: SU_EVENTS.MINION_MOVED,
+                payload: {
+                    minionUid: 'm-2',
+                    minionDefId: 'trickster_a',
+                    fromBaseIndex: 0,
+                    toBaseIndex: 1,
+                    reason: 'test_move',
+                },
+                timestamp: 1000,
+            } as any);
+
+            expect(result).toBeUndefined();
         });
     });
 

--- a/src/games/smashup/__tests__/ongoingTalent.test.ts
+++ b/src/games/smashup/__tests__/ongoingTalent.test.ts
@@ -520,6 +520,152 @@ describe('innsmouth_sacred_circle（宗教圆环 ongoing talent）', () => {
 });
 
 // ============================================================================
+// 藏身处 POD（trickster_hideout_pod）：换位 + 仅限基地持续战术
+// ============================================================================
+
+describe('trickster_hideout_pod（藏身处 POD ongoing talent）', () => {
+    it('只提供手牌或牌库中的基地持续战术作为交换目标', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [
+                        makeCard('h-smoke', 'ninja_smoke_bomb', 'action', '0'),
+                        makeCard('h-mist', 'trickster_enshrouding_mist_pod', 'action', '0'),
+                    ],
+                    deck: [
+                        makeCard('d-flame', 'trickster_flame_trap_pod', 'action', '0'),
+                        makeCard('d-mark', 'trickster_mark_of_sleep_pod', 'action', '0'),
+                    ],
+                }),
+                '1': makePlayer('1'),
+            },
+            bases: [{
+                defId: 'base_a',
+                minions: [],
+                ongoingActions: [makeOngoing('oa1', 'trickster_hideout_pod', '0')],
+            }],
+        });
+
+        const ms = makeMatchState(core);
+        execute(ms, {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { ongoingCardUid: 'oa1', baseIndex: 0 },
+        } as any, defaultRandom);
+
+        const interaction = getInteractionsFromMS(ms)[0];
+        expect(interaction?.data?.sourceId).toBe('trickster_hideout_pod_swap');
+
+        const candidateUids = (interaction?.data?.options ?? [])
+            .map((option: any) => option.value?.cardUid)
+            .filter((uid: string | undefined) => typeof uid === 'string');
+        expect(candidateUids).toEqual(['h-mist', 'd-flame']);
+    });
+
+    it('从手牌交换时把藏身处回到手牌，并继续给出消灭选项', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('h-flame', 'trickster_flame_trap_pod', 'action', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+            bases: [{
+                defId: 'base_a',
+                minions: [makeMinion('m-low', 'pirate_saucy_wench', '1', 2, { powerModifier: 0 })],
+                ongoingActions: [makeOngoing('oa1', 'trickster_hideout_pod', '0')],
+            }],
+        });
+
+        const ms = makeMatchState(core);
+        execute(ms, {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { ongoingCardUid: 'oa1', baseIndex: 0 },
+        } as any, defaultRandom);
+
+        const swapInteraction = getInteractionsFromMS(ms)[0];
+        const swapHandler = getInteractionHandler('trickster_hideout_pod_swap');
+        expect(swapHandler).toBeDefined();
+
+        const result = swapHandler!(
+            ms,
+            '0',
+            { zone: 'hand', cardUid: 'h-flame', defId: 'trickster_flame_trap_pod' },
+            swapInteraction?.data,
+            defaultRandom,
+            3000,
+        );
+
+        expect(result?.events ?? []).not.toContainEqual(expect.objectContaining({ type: SU_EVENTS.DECK_RESHUFFLED }));
+        expect(result?.state.core.players['0'].hand).toEqual([
+            expect.objectContaining({ uid: 'oa1', defId: 'trickster_hideout_pod', type: 'action' }),
+        ]);
+        expect(result?.state.core.bases[0].ongoingActions[0]).toEqual(
+            expect.objectContaining({ uid: 'h-flame', defId: 'trickster_flame_trap_pod', ownerId: '0' }),
+        );
+
+        const destroyInteraction = (result?.state.sys as any).interaction?.queue?.[0];
+        expect(destroyInteraction?.data?.sourceId).toBe('trickster_hideout_pod_destroy');
+        expect((destroyInteraction?.data?.options ?? []).some((option: any) => option.value?.minionUid === 'm-low')).toBe(true);
+    });
+
+    it('从牌库交换时把藏身处洗回牌库，而不是回手', () => {
+        const shuffleRandom: RandomFn = {
+            ...defaultRandom,
+            shuffle: (arr: any[]) => [...arr].reverse(),
+        };
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [],
+                    deck: [
+                        makeCard('d-flame', 'trickster_flame_trap_pod', 'action', '0'),
+                        makeCard('d-extra', 'trickster_enshrouding_mist_pod', 'action', '0'),
+                    ],
+                }),
+                '1': makePlayer('1'),
+            },
+            bases: [{
+                defId: 'base_a',
+                minions: [],
+                ongoingActions: [makeOngoing('oa1', 'trickster_hideout_pod', '0')],
+            }],
+        });
+
+        const ms = makeMatchState(core);
+        execute(ms, {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { ongoingCardUid: 'oa1', baseIndex: 0 },
+        } as any, defaultRandom);
+
+        const swapInteraction = getInteractionsFromMS(ms)[0];
+        const swapHandler = getInteractionHandler('trickster_hideout_pod_swap');
+        expect(swapHandler).toBeDefined();
+
+        const result = swapHandler!(
+            ms,
+            '0',
+            { zone: 'deck', cardUid: 'd-flame', defId: 'trickster_flame_trap_pod' },
+            swapInteraction?.data,
+            shuffleRandom,
+            3001,
+        );
+
+        expect(result?.state.core.players['0'].hand.some(card => card.uid === 'oa1')).toBe(false);
+        expect(result?.state.core.players['0'].deck.map(card => card.uid)).toEqual(['oa1', 'd-extra']);
+        expect(result?.state.core.bases[0].ongoingActions[0]).toEqual(
+            expect.objectContaining({ uid: 'd-flame', defId: 'trickster_flame_trap_pod', ownerId: '0' }),
+        );
+
+        const reshuffleEvent = (result?.events ?? []).find(event => event.type === SU_EVENTS.DECK_RESHUFFLED) as any;
+        expect(reshuffleEvent).toBeDefined();
+        expect(reshuffleEvent.payload.deckUids).toEqual(['oa1', 'd-extra']);
+    });
+});
+
+// ============================================================================
 // 随从天赋回归测试：确保原有随从天赋不受影响
 // ============================================================================
 

--- a/src/games/smashup/abilities/tricksters.ts
+++ b/src/games/smashup/abilities/tricksters.ts
@@ -17,7 +17,9 @@ import {
 } from '../domain/abilityHelpers';
 import { SU_EVENTS } from '../domain/types';
 import type {
+    CardInstance,
     CardsDiscardedEvent,
+    DeckReshuffledEvent,
     OngoingDetachedEvent,
     SmashUpEvent,
     LimitModifiedEvent,
@@ -750,7 +752,7 @@ export function registerTricksterInteractionHandlers(): void {
         return { state: { ...state, core: { ...state.core, bases: newBases } }, events: [] };
     });
 
-    registerInteractionHandler('trickster_hideout_pod_swap', (state, playerId, value, iData, _random, timestamp) => {
+    registerInteractionHandler('trickster_hideout_pod_swap', (state, playerId, value, iData, random, timestamp) => {
         if ((value as any).skip) return { state, events: [] };
         if ((value as any).__cancel__) return { state, events: [] };
         const { zone, cardUid, defId } = value as { zone: 'hand' | 'deck'; cardUid: string; defId: string };
@@ -765,11 +767,24 @@ export function registerTricksterInteractionHandlers(): void {
         const player = state.core.players[playerId];
         if (!player) return undefined;
 
-        // 1) 浠庢墜鐗?鐗屽簱绉婚櫎鐩爣鎴樻湳
+        const selectedCard = (zone === 'hand' ? player.hand : player.deck)
+            .find(card => card.uid === cardUid && card.defId === defId);
+        const selectedDef = getCardDef(defId);
+        if (
+            !selectedCard
+            || selectedCard.type !== 'action'
+            || selectedDef?.type !== 'action'
+            || selectedDef.subtype !== 'ongoing'
+            || ((selectedDef.ongoingTarget ?? 'base') !== 'base')
+        ) {
+            return { state, events: [] };
+        }
+
+        // 1) 从手牌/牌库移除目标战术
         const fromHand = zone === 'hand' ? player.hand.filter(c => c.uid !== cardUid) : player.hand;
         const fromDeck = zone === 'deck' ? player.deck.filter(c => c.uid !== cardUid) : player.deck;
 
-        // 2) 钘忚韩澶勪粠鍩哄湴绂诲満杩涙墜鐗岋紙swap 鐨勫彟涓€鍗婏級
+        // 2) 藏身处离开基地；从手牌换出则回手，从牌库换出则洗回牌库
         const hideoutCard: CardInstance = { uid: hideout.uid, defId: hideout.defId, type: 'action', owner: hideout.ownerId };
 
         // 3) 鐩爣鎴樻湳杩涘叆鍩哄湴 ongoingActions锛堜繚鎸?cardUid锛?
@@ -786,6 +801,9 @@ export function registerTricksterInteractionHandlers(): void {
             };
         });
 
+        const nextHand = zone === 'hand' ? [...fromHand, hideoutCard] : fromHand;
+        const nextDeck = zone === 'deck' ? random.shuffle([...fromDeck, hideoutCard]) : fromDeck;
+
         let nextState = {
             ...state,
             core: {
@@ -795,17 +813,26 @@ export function registerTricksterInteractionHandlers(): void {
                     ...state.core.players,
                     [playerId]: {
                         ...player,
-                        hand: [...fromHand, hideoutCard],
-                        deck: fromDeck,
+                        hand: nextHand,
+                        deck: nextDeck,
                     },
                 },
             },
         };
 
+        const events: SmashUpEvent[] = [];
+        if (zone === 'deck') {
+            events.push({
+                type: SU_EVENTS.DECK_RESHUFFLED,
+                payload: { playerId, deckUids: nextDeck.map(card => card.uid) },
+                timestamp,
+            } as DeckReshuffledEvent);
+        }
+
         // 4) 浜ゆ崲鍚庯細浣犲彲浠ユ秷鐏繖閲屼竴涓垬鏂楀姏鈮?鐨勯殢浠庯紙鍙€夛級
         const updatedBase = nextState.core.bases[ctx.baseIndex];
         const candidates = updatedBase.minions.filter(m => getMinionPower(nextState.core, m, ctx.baseIndex) <= 2);
-        if (candidates.length === 0) return { state: nextState, events: [] };
+        if (candidates.length === 0) return { state: nextState, events };
         const options = candidates.map((m, i) => {
             const mDef = getCardDef(m.defId) as MinionCardDef | undefined;
             const name = mDef?.name ?? m.defId;
@@ -822,7 +849,7 @@ export function registerTricksterInteractionHandlers(): void {
             { sourceId: 'trickster_hideout_pod_destroy', targetType: 'minion' },
         );
         nextState = queueInteraction(nextState, prompt);
-        return { state: nextState, events: [] };
+        return { state: nextState, events };
     });
 
     registerInteractionHandler('trickster_hideout_pod_destroy', (state, playerId, value, _iData, _random, timestamp) => {


### PR DESCRIPTION
## 变更内容
- 修复 `trickster_hideout_pod` 从牌库交换时仍把 Hideout 回到手牌的问题
- 从牌库交换时将 Hideout 洗回牌库，并保留手牌交换时回手的语义
- 补充回归测试，覆盖可交换目标过滤、手牌交换、牌库交换，以及移动拦截效果

## 验证
- `npm test -- src/games/smashup/__tests__/baseFactionOngoing.test.ts src/games/smashup/__tests__/ongoingTalent.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced hideout protection mechanics with improved card validation during swaps.
  * Corrected deck reshuffling behavior when swapping hideout cards from the player deck.
  * Refined event handling to properly maintain game state during action resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->