### PR TITLE
修复线上反馈并调整大杀四方横屏选派系页与桌面一致

### DIFF
--- a/e2e/smashup-faction-selection-spacing.e2e.ts
+++ b/e2e/smashup-faction-selection-spacing.e2e.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { gotoLocalSmashUp } from './smashup-debug-helpers';
+
+test.describe('SmashUp 派系选择页移动端间距', () => {
+  test('移动端压缩生效并输出截图证据', async ({ page }, testInfo) => {
+    const evidenceDir = join(process.cwd(), 'test-results', 'evidence-screenshots', 'smashup-faction-selection-spacing');
+    mkdirSync(evidenceDir, { recursive: true });
+
+    await page.setViewportSize({ width: 800, height: 450 });
+    await gotoLocalSmashUp(page);
+
+    const title = page.locator('h1').filter({ hasText: /Draft Your Factions|选择你的派系/i });
+    await expect(title).toBeVisible({ timeout: 30000 });
+
+    const grid = page.locator('.grid').first();
+    const cards = grid.locator('> div');
+    await expect(cards.first()).toBeVisible({ timeout: 10000 });
+
+    const mobileMetrics = await page.evaluate(() => {
+      const cards = Array.from(document.querySelectorAll('.grid > div')) as HTMLElement[];
+      const first = cards[0]?.getBoundingClientRect();
+      const second = cards[1]?.getBoundingClientRect();
+      return {
+        innerWidth: window.innerWidth,
+        docScrollWidth: document.documentElement.scrollWidth,
+        firstWidth: first?.width ?? 0,
+        horizontalGap: first && second ? second.left - first.right : 0,
+      };
+    });
+
+    expect(mobileMetrics.docScrollWidth, '移动端不应横向溢出').toBeLessThanOrEqual(mobileMetrics.innerWidth + 1);
+    expect(mobileMetrics.firstWidth, '移动端派系卡应成功渲染').toBeGreaterThan(0);
+    expect(mobileMetrics.horizontalGap, '移动端派系卡之间应保留可见间距').toBeGreaterThanOrEqual(0);
+
+    await page.screenshot({ path: join(evidenceDir, 'mobile-landscape.png'), fullPage: false });
+    await page.screenshot({ path: testInfo.outputPath('mobile-landscape.png'), fullPage: false });
+  });
+});

--- a/e2e/smashup-faction-selection-spacing.e2e.ts
+++ b/e2e/smashup-faction-selection-spacing.e2e.ts
@@ -4,37 +4,49 @@ import { join } from 'node:path';
 import { gotoLocalSmashUp } from './smashup-debug-helpers';
 
 test.describe('SmashUp 派系选择页移动端间距', () => {
-  test('移动端压缩生效并输出截图证据', async ({ page }, testInfo) => {
+  test('移动端压缩生效并输出移动端/桌面端参考截图', async ({ page }, testInfo) => {
     const evidenceDir = join(process.cwd(), 'test-results', 'evidence-screenshots', 'smashup-faction-selection-spacing');
     mkdirSync(evidenceDir, { recursive: true });
 
-    await page.setViewportSize({ width: 800, height: 450 });
-    await gotoLocalSmashUp(page);
-
     const title = page.locator('h1').filter({ hasText: /Draft Your Factions|选择你的派系/i });
-    await expect(title).toBeVisible({ timeout: 30000 });
-
     const grid = page.locator('.grid').first();
     const cards = grid.locator('> div');
+
+    await page.setViewportSize({ width: 800, height: 450 });
+    await gotoLocalSmashUp(page);
+    await expect(title).toBeVisible({ timeout: 30000 });
     await expect(cards.first()).toBeVisible({ timeout: 10000 });
 
     const mobileMetrics = await page.evaluate(() => {
       const cards = Array.from(document.querySelectorAll('.grid > div')) as HTMLElement[];
       const first = cards[0]?.getBoundingClientRect();
       const second = cards[1]?.getBoundingClientRect();
+      const third = cards[2]?.getBoundingClientRect();
       return {
         innerWidth: window.innerWidth,
         docScrollWidth: document.documentElement.scrollWidth,
         firstWidth: first?.width ?? 0,
         horizontalGap: first && second ? second.left - first.right : 0,
+        firstTop: first?.top ?? 0,
+        thirdTop: third?.top ?? 0,
       };
     });
 
     expect(mobileMetrics.docScrollWidth, '移动端不应横向溢出').toBeLessThanOrEqual(mobileMetrics.innerWidth + 1);
     expect(mobileMetrics.firstWidth, '移动端派系卡应成功渲染').toBeGreaterThan(0);
     expect(mobileMetrics.horizontalGap, '移动端派系卡之间应保留可见间距').toBeGreaterThanOrEqual(0);
+    expect(mobileMetrics.thirdTop, '手机横屏下第三张卡应换到下一行，避免一排三张过挤').toBeGreaterThan(mobileMetrics.firstTop + 4);
 
     await page.screenshot({ path: join(evidenceDir, 'mobile-landscape.png'), fullPage: false });
     await page.screenshot({ path: testInfo.outputPath('mobile-landscape.png'), fullPage: false });
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await gotoLocalSmashUp(page);
+    await expect(title).toBeVisible({ timeout: 30000 });
+    await expect(cards.first()).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({ path: join(evidenceDir, 'desktop-reference.png'), fullPage: false });
+    await page.screenshot({ path: testInfo.outputPath('desktop-reference.png'), fullPage: false });
   });
 });

--- a/src/games/smashup/__tests__/alien-probe-bug.test.ts
+++ b/src/games/smashup/__tests__/alien-probe-bug.test.ts
@@ -92,6 +92,45 @@ describe('Bug: alien_probe（探究）效果错误', () => {
         expect(player0.discard.find(c => c.uid === 'probe1')).toBeDefined();
     });
 
+    it('即使只有一张可选随从，也应创建交互而不是自动默认第一张', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('probe1', 'alien_probe', 'action', '0')],
+                    factions: ['aliens', 'dinosaurs'] as [string, string],
+                }),
+                '1': makePlayer('1', {
+                    hand: [
+                        makeCard('h1-1', 'pirate_first_mate', 'minion', '1'),
+                        makeCard('h1-2', 'pirate_broadside', 'action', '1'),
+                        makeCard('h1-3', 'alien_crop_circles', 'action', '1'),
+                    ],
+                    factions: ['pirates', 'minions_of_cthulhu'] as [string, string],
+                }),
+            },
+            bases: [
+                makeBase('base_the_mothership'),
+            ],
+        });
+        const state = makeMatchState(core);
+
+        const result = runCommand(state, {
+            type: SU_COMMANDS.PLAY_ACTION,
+            playerId: '0',
+            payload: { cardUid: 'probe1' },
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.events.some(e => e.type === SU_EVENTS.CARDS_DISCARDED)).toBe(false);
+        const interaction = asSimpleChoice(result.finalState.sys.interaction?.current);
+        expect(interaction).toBeDefined();
+        expect(interaction?.sourceId).toBe('alien_probe');
+        expect(interaction?.options.length).toBe(3);
+        expect(interaction?.options.find(opt => opt.id === 'h1-1')?.disabled).toBeFalsy();
+        expect(interaction?.options.find(opt => opt.id === 'h1-2')?.disabled).toBe(true);
+        expect(interaction?.options.find(opt => opt.id === 'h1-3')?.disabled).toBe(true);
+    });
+
     it('选择随从后，对手应该弃掉那张随从', () => {
         const core = makeState({
             players: {

--- a/src/games/smashup/__tests__/baseRestrictions.test.ts
+++ b/src/games/smashup/__tests__/baseRestrictions.test.ts
@@ -303,7 +303,7 @@ describe('base_secret_garden: 神秘花园力量限制', () => {
         expect(restricted).toBe(false);
     });
 
-    it('还有其他可用随从额度时，power>2 不应被神秘花园误拦截', () => {
+    it('还有其他可用普通额度时，power>2 不应被神秘花园误拦截', () => {
         const state = makeState({
             bases: [makeBase('base_secret_garden')],
             players: {
@@ -323,13 +323,33 @@ describe('base_secret_garden: 神秘花园力量限制', () => {
         expect(restricted).toBe(false);
     });
 
-    it('validate：消费过神秘花园≤2额度后，仍可用其他额度打出3战力随从到这里', () => {
+    it('使用全局额外随从额度时，power>2 也应被神秘花园拦截', () => {
         const state = makeState({
             bases: [makeBase('base_secret_garden')],
             players: {
                 '0': makePlayer('0', {
                     minionsPlayed: 1,
                     minionLimit: 2,
+                }),
+                '1': makePlayer('1'),
+            },
+        });
+
+        const restricted = isOperationRestricted(state, 0, '0', 'play_minion', {
+            minionDefId: 'alien_invader',
+            basePower: 4,
+            isExtraMinionPlayAttempt: true,
+        });
+        expect(restricted).toBe(true);
+    });
+
+    it('validate：使用普通随从额度打到神秘花园时，3战力仍可通过', () => {
+        const state = makeState({
+            bases: [makeBase('base_secret_garden')],
+            players: {
+                '0': makePlayer('0', {
+                    minionsPlayed: 0,
+                    minionLimit: 1,
                     baseLimitedMinionQuota: { 0: 0 },
                     hand: [makeCard('m1', 'killer_plant_water_lily', 'minion')],
                 }),
@@ -347,6 +367,32 @@ describe('base_secret_garden: 神秘花园力量限制', () => {
             payload: { cardUid: 'm1', baseIndex: 0 },
         } as any);
         expect(result.valid).toBe(true);
+    });
+
+    it('validate：机器人额外随从打到神秘花园时，3战力应被拒绝', () => {
+        const state = makeState({
+            bases: [makeBase('base_secret_garden')],
+            players: {
+                '0': makePlayer('0', {
+                    minionsPlayed: 1,
+                    minionLimit: 2,
+                    hand: [makeCard('m1', 'alien_invader', 'minion')],
+                }),
+                '1': makePlayer('1'),
+            },
+        });
+        const matchState: MatchState<SmashUpCore> = {
+            core: state,
+            sys: { phase: 'playCards' } as any,
+        };
+
+        const result = validate(matchState, {
+            type: SU_COMMANDS.PLAY_MINION,
+            playerId: '0',
+            payload: { cardUid: 'm1', baseIndex: 0 },
+        } as any);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('该基地禁止打出该随从');
     });
 });
 

--- a/src/games/smashup/__tests__/newBaseAbilities.test.ts
+++ b/src/games/smashup/__tests__/newBaseAbilities.test.ts
@@ -21,7 +21,8 @@ import {
 } from '../domain/baseAbilities';
 import { processDestroyTriggers } from '../domain/reducer';
 import type { BaseAbilityContext } from '../domain/baseAbilities';
-import type { SmashUpCore, MinionOnBase, CardInstance } from '../domain/types';
+import type { MatchState, RandomFn } from '../../../engine/types';
+import type { SmashUpCore, MinionOnBase, CardInstance, MinionDestroyedEvent } from '../domain/types';
 import { SU_EVENTS } from '../domain/types';
 import { SMASHUP_FACTION_IDS } from '../domain/ids';
 import { triggerBaseAbilityWithMS, getInteractionsFromResult, makeMatchState } from './helpers';
@@ -30,6 +31,13 @@ import { reduce } from '../domain/reduce';
 beforeAll(() => {
     initAllAbilities();
 });
+
+const dummyRandom: RandomFn = {
+    random: () => 0.5,
+    d: () => 1,
+    range: (min: number) => min,
+    shuffle: <T>(arr: T[]) => [...arr],
+};
 
 /** 构造最小测试状态 */
 function makeState(overrides: Partial<SmashUpCore> = {}): SmashUpCore {
@@ -201,6 +209,61 @@ describe('base_the_field_of_honor: 消灭者获1VP', () => {
         expect(vpEvents).toHaveLength(1);
         expect(vpEvents[0].payload.playerId).toBe('0');
         expect(vpEvents[0].payload.amount).toBe(1);
+    });
+
+    it('集成路径：destroyerId 缺失时，VP 仍应判给事件操作者而不是被消灭者', () => {
+        const victim = makeMinion('victim', '0', 3);
+        const core = makeState({
+            players: {
+                '0': {
+                    id: '0',
+                    vp: 0,
+                    hand: [],
+                    deck: [],
+                    discard: [],
+                    minionsPlayed: 0,
+                    minionLimit: 1,
+                    actionsPlayed: 0,
+                    actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.BEAR_CAVALRY, SMASHUP_FACTION_IDS.NINJAS],
+                },
+                '1': {
+                    id: '1',
+                    vp: 0,
+                    hand: [],
+                    deck: [],
+                    discard: [],
+                    minionsPlayed: 0,
+                    minionLimit: 1,
+                    actionsPlayed: 0,
+                    actionLimit: 1,
+                    factions: [SMASHUP_FACTION_IDS.BEAR_CAVALRY, SMASHUP_FACTION_IDS.NINJAS],
+                },
+            },
+            bases: [{
+                defId: 'base_the_field_of_honor',
+                minions: [victim],
+                ongoingActions: [],
+            }],
+        });
+        const ms: MatchState<SmashUpCore> = makeMatchState(core);
+        const destroyEvent: MinionDestroyedEvent = {
+            type: SU_EVENTS.MINION_DESTROYED,
+            payload: {
+                minionUid: 'victim',
+                minionDefId: victim.defId,
+                fromBaseIndex: 0,
+                ownerId: '0',
+                reason: 'integration_destroy',
+            },
+            timestamp: 1000,
+        };
+
+        const result = processDestroyTriggers([destroyEvent], ms, '1', dummyRandom, 1000);
+        const vpEvents = result.events.filter(e => e.type === SU_EVENTS.VP_AWARDED);
+        expect(vpEvents).toHaveLength(1);
+        expect((vpEvents[0] as any).payload.playerId).toBe('1');
+        expect((vpEvents[0] as any).payload.amount).toBe(1);
     });
 
     it('base_the_field_of_honor: destroy 自己的随从时不应得分', () => {

--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -369,10 +369,11 @@ describe('bear_cavalry_cub_scout 触发', () => {
 });
 
 describe('bear_cavalry_high_ground 触发', () => {
-    it('有己方随从时消灭移入的对手随从', () => {
+    it('有己方随从时消灭移入的对手随从，并记录消灭者', () => {
         const myMinion = makeMinion('my', 'test_minion', '0', 3, { powerModifier: 0 });
         const moved = makeMinion('moved', 'test_minion', '1', 5, { powerModifier: 0 });
         const destBase = makeBase({
+            defId: 'base_the_field_of_honor',
             minions: [myMinion],
             ongoingActions: [{ uid: 'hg-1', defId: 'bear_cavalry_high_ground', ownerId: '0' }],
         });
@@ -384,7 +385,9 @@ describe('bear_cavalry_high_ground 触发', () => {
             triggerMinionUid: 'moved', triggerMinionDefId: 'test_minion',
             random: dummyRandom, now: 0,
         });
-        expect(events.some(e => e.type === SU_EVENTS.MINION_DESTROYED)).toBe(true);
+        const destroyEvent = events.find(e => e.type === SU_EVENTS.MINION_DESTROYED) as any;
+        expect(destroyEvent).toBeDefined();
+        expect(destroyEvent.payload.destroyerId).toBe('0');
     });
 
     it('POD 版高地也会消灭移入的对手随从', () => {

--- a/src/games/smashup/abilities/aliens.ts
+++ b/src/games/smashup/abilities/aliens.ts
@@ -399,7 +399,7 @@ function alienProbe(ctx: AbilityContext): AbilityResult {
             `alien_probe_${ctx.now}`, ctx.playerId,
             '选择对手手牌中的一张随从，让其弃掉',
             allHandOptions,
-            { sourceId: 'alien_probe', targetType: 'generic' },
+            { sourceId: 'alien_probe', targetType: 'generic', autoResolveIfSingle: false },
         );
 
         // 添加自定义 optionsGenerator，确保刷新时检查对手的手牌而不是当前玩家的手牌

--- a/src/games/smashup/abilities/bear_cavalry.ts
+++ b/src/games/smashup/abilities/bear_cavalry.ts
@@ -600,7 +600,7 @@ function bearCavalryHighGroundTrigger(ctx: TriggerContext): SmashUpEvent[] {
                 movedMinion.defId,
                 destBaseIndex,
                 movedMinion.owner,
-                undefined,
+                ongoing.ownerId,
                 'bear_cavalry_high_ground',
                 ctx.now,
             ),

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -155,16 +155,17 @@ export function validate(
                     return { valid: false, error: '弃牌堆中没有该随从' };
                 }
                 const basePower = getMinionLikePower(discardCard.defId) ?? 0;
+                const isExtraMinionAttempt = isExtraMinionPlayAttempt(
+                    core,
+                    command.playerId,
+                    baseIndex,
+                    discardCard.defId,
+                    basePower,
+                    true,
+                    discardCheck.consumesNormalLimit,
+                );
                 const blockedByBearNecessitiesPod = hasActiveBearNecessitiesPodRestriction(core, command.playerId)
-                    && isExtraMinionPlayAttempt(
-                        core,
-                        command.playerId,
-                        baseIndex,
-                        discardCard.defId,
-                        basePower,
-                        true,
-                        discardCheck.consumesNormalLimit,
-                    );
+                    && isExtraMinionAttempt;
                 if (blockedByBearNecessitiesPod) {
                     return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
                 }
@@ -174,6 +175,7 @@ export function validate(
                     minionDefId: discardCard.defId,
                     basePower,
                     usesBaseLimitedMinionQuota,
+                    isExtraMinionPlayAttempt: isExtraMinionAttempt,
                 })) {
                     return { valid: false, error: '该基地禁止打出该随从' };
                 }
@@ -193,16 +195,17 @@ export function validate(
             const minionDef = getMinionDef(card.defId);
             const fusionDef = getFusionDef(card.defId);
             const basePower = (minionDef?.power ?? fusionDef?.minionPower) ?? 0;
+            const isExtraMinionAttempt = isExtraMinionPlayAttempt(
+                core,
+                command.playerId,
+                baseIndex,
+                card.defId,
+                basePower,
+                false,
+                true,
+            );
             const blockedByBearNecessitiesPod = hasActiveBearNecessitiesPodRestriction(core, command.playerId)
-                && isExtraMinionPlayAttempt(
-                    core,
-                    command.playerId,
-                    baseIndex,
-                    card.defId,
-                    basePower,
-                    false,
-                    true,
-                );
+                && isExtraMinionAttempt;
             if (blockedByBearNecessitiesPod) {
                 return { valid: false, error: '受黑熊口粮POD限制：你不能打出额外牌' };
             }
@@ -238,6 +241,7 @@ export function validate(
                 minionDefId: card.defId,
                 basePower,
                 usesBaseLimitedMinionQuota,
+                isExtraMinionPlayAttempt: isExtraMinionAttempt,
             })) {
                 return { valid: false, error: '该基地禁止打出该随从' };
             }

--- a/src/games/smashup/domain/ongoingEffects.ts
+++ b/src/games/smashup/domain/ongoingEffects.ts
@@ -855,6 +855,7 @@ export function isOperationRestricted(
             // 条件限制：extraPlayMinionPowerMax（额外出牌时力量 > limit 的随从被禁止）
             if (r.condition.extraPlayMinionPowerMax !== undefined && restrictionType === 'play_minion') {
                 const basePower = extra?.basePower as number | undefined;
+                const isExtraMinionPlay = extra?.isExtraMinionPlayAttempt as boolean | undefined;
                 const usingBaseLimitedQuota = (extra?.usesBaseLimitedMinionQuota as boolean | undefined)
                     ?? mustUseBaseLimitedMinionQuota(
                         state,
@@ -863,7 +864,7 @@ export function isOperationRestricted(
                         extra?.minionDefId as string | undefined,
                         basePower,
                     );
-                if (usingBaseLimitedQuota && basePower !== undefined && basePower > r.condition.extraPlayMinionPowerMax) {
+                if ((isExtraMinionPlay || usingBaseLimitedQuota) && basePower !== undefined && basePower > r.condition.extraPlayMinionPowerMax) {
                     return true;
                 }
             }

--- a/src/games/smashup/domain/reducer.ts
+++ b/src/games/smashup/domain/reducer.ts
@@ -704,7 +704,9 @@ export function processDestroyTriggers(
         const minion = base?.minions.find(m => m.uid === minionUid);
         // ✅ 优先从 state 读取 owner（兜底修复：即使事件中的 ownerId 错了也能修复）
         const ownerId = minion?.owner ?? eventOwnerId;
-        const destroyerId = eventDestroyerId ?? minion?.controller ?? ownerId;
+        // destroyerId 缺失时，回退到当前事件链的操作者，而不是被消灭随从的控制者。
+        // 否则像“荣誉之地”这类奖励消灭者的基地，会错误把 VP 判给受害者。
+        const destroyerId = eventDestroyerId ?? playerId;
 
         // === Phase 1: 先检查防止消灭触发器（基地能力 + ongoing） ===
         // 在触发 onDestroy 之前，先确认消灭是否会被防止

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -1070,7 +1070,7 @@ export interface MinionDestroyedEvent extends GameEvent<typeof SU_EVENTS.MINION_
         minionDefId: string;
         fromBaseIndex: number;
         ownerId: PlayerId;
-        destroyerId?: PlayerId;  // 消灭者（可选，如果没有则默认为 ownerId）
+        destroyerId?: PlayerId;  // 消灭者（可选，缺失时由事件处理流程按当前操作者推断）
         reason: string;
     };
 }

--- a/src/games/smashup/ui/FactionSelection.tsx
+++ b/src/games/smashup/ui/FactionSelection.tsx
@@ -122,9 +122,9 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                 </div>
             </motion.div>
 
-            {/* FACTION GRID - 增加垂直空间 */}
-            <div className="flex-1 w-full max-w-7xl overflow-y-auto px-6 py-4 relative z-10 custom-scrollbar">
-                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 pb-28">
+            {/* FACTION GRID - 移动端压紧间距，避免横屏手机下卡牌过疏 */}
+            <div className="flex-1 w-full max-w-7xl overflow-y-auto px-3 py-3 sm:px-4 sm:py-4 md:px-6 md:py-4 relative z-10 custom-scrollbar">
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 sm:gap-4 md:gap-6 pb-24 sm:pb-28">
                     {visibleFactions.map((faction, idx) => {
                         const isTaken = takenFactions.has(faction.id);
                         const isSelectedByMe = mySelections.includes(faction.id);
@@ -148,7 +148,7 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                                 `}
                             >
                                 {/* Card Stack Visual */}
-                                <div className="relative w-40 h-56 md:w-48 md:h-64 mb-4">
+                                <div className="relative w-32 h-44 sm:w-36 sm:h-52 md:w-48 md:h-64 mb-3 sm:mb-4">
                                     {/* Main Cover Card */}
                                     <div className={`
                                         absolute inset-0 rounded-sm overflow-hidden shadow-[3px_3px_12px_rgba(0,0,0,0.4)] border-[0.4vw] transition-all
@@ -364,8 +364,8 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
             </AnimatePresence>
 
             {/* FOOTER: Status Bar - Floating Score Sheet style */}
-            <div className="absolute bottom-6 inset-x-0 z-40 pointer-events-none">
-                <div className="max-w-7xl mx-auto flex items-end justify-center gap-8 px-6">
+            <div className="absolute bottom-3 sm:bottom-6 inset-x-0 z-40 pointer-events-none">
+                <div className="max-w-7xl mx-auto flex items-end justify-center gap-3 sm:gap-5 md:gap-8 px-3 sm:px-4 md:px-6">
                     {core.turnOrder.map((pid, pidx) => {
                         const selections = selectionState.playerSelections[pid] || [];
                         const isCurrent = pid === currentPlayerId;
@@ -377,22 +377,22 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                                 animate={{ y: 0, opacity: 1 }}
                                 transition={{ delay: 0.5 + pidx * 0.1 }}
                                 className={`
-                                    flex flex-col items-center gap-2 px-6 py-3 rounded-sm border-2 pointer-events-auto transition-all
+                                    flex flex-col items-center gap-1.5 sm:gap-2 px-3 py-2 sm:px-4 sm:py-2.5 md:px-6 md:py-3 rounded-sm border-2 pointer-events-auto transition-all
                                     ${isCurrent
-                                        ? 'bg-[#fef3c7] border-amber-500 shadow-[0_10px_25px_rgba(0,0,0,0.5)] -rotate-1 z-10 scale-110'
+                                        ? 'bg-[#fef3c7] border-amber-500 shadow-[0_10px_25px_rgba(0,0,0,0.5)] -rotate-1 z-10 scale-105 md:scale-110'
                                         : 'bg-white/90 border-slate-200 shadow-lg rotate-1 grayscale-[0.3]'}
                                 `}
                             >
                                 {/* Player Avatar Circle */}
                                 <div className={`
-                                    w-12 h-12 rounded-full flex items-center justify-center font-black text-lg text-white shadow-inner border-4 border-white
+                                    w-10 h-10 sm:w-11 sm:h-11 md:w-12 md:h-12 rounded-full flex items-center justify-center font-black text-sm sm:text-base md:text-lg text-white shadow-inner border-4 border-white
                                     ${pid === '0' ? 'bg-red-500' : pidx === 1 ? 'bg-blue-500' : 'bg-green-500'}
                                 `}>
                                     {t('ui.player_short', { id: pid })}
                                 </div>
 
                                 {/* Selections */}
-                                <div className="flex gap-2">
+                                <div className="flex gap-1.5 sm:gap-2">
                                     {[0, 1].map(i => {
                                         const fid = selections[i];
                                         const meta = fid ? FACTION_METADATA.find(f => f.id === fid) : null;
@@ -401,18 +401,18 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                                             <div
                                                 key={i}
                                                 className={`
-                                                    w-12 h-12 rounded-sm border-2 bg-slate-100 flex items-center justify-center overflow-hidden shadow-sm transition-all
+                                                    w-9 h-9 sm:w-10 sm:h-10 md:w-12 md:h-12 rounded-sm border-2 bg-slate-100 flex items-center justify-center overflow-hidden shadow-sm transition-all
                                                     ${!fid ? 'border-dashed border-slate-300 opacity-40' : 'border-slate-800 rotate-[-4deg]'}
                                                 `}
                                                 title={meta ? t(meta.nameKey) : undefined}
                                                 style={{ transform: fid ? `rotate(${(i * 10) - 5}deg)` : 'none' }}
                                             >
                                                 {meta?.icon ? (
-                                                    <div className="text-slate-900">
+                                                    <div className="text-slate-900 scale-90 sm:scale-100">
                                                         <meta.icon size={28} strokeWidth={2.5} />
                                                     </div>
                                                 ) : (
-                                                    <span className="text-xs text-slate-400 font-black">?</span>
+                                                    <span className="text-[10px] sm:text-xs text-slate-400 font-black">?</span>
                                                 )}
                                             </div>
                                         );
@@ -420,11 +420,11 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                                 </div>
 
                                 <div className="flex flex-col items-center">
-                                    <span className={`text-[11px] font-black uppercase tracking-tighter leading-none ${isCurrent ? 'text-amber-800' : 'text-slate-50'}`}>
+                                    <span className={`text-[10px] sm:text-[11px] font-black uppercase tracking-tight sm:tracking-tighter leading-none ${isCurrent ? 'text-amber-800' : 'text-slate-50'}`}>
                                         {t('ui.player_short', { id: pid })}
                                     </span>
                                     {isCurrent && (
-                                        <span className="text-[10px] font-black text-amber-600 uppercase tracking-widest mt-1 animate-pulse">
+                                        <span className="text-[9px] sm:text-[10px] font-black text-amber-600 uppercase tracking-[0.12em] sm:tracking-widest mt-0.5 sm:mt-1 animate-pulse">
                                             {t('ui.thinking')}
                                         </span>
                                     )}

--- a/src/games/smashup/ui/FactionSelection.tsx
+++ b/src/games/smashup/ui/FactionSelection.tsx
@@ -122,9 +122,9 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                 </div>
             </motion.div>
 
-            {/* FACTION GRID - 移动端压紧间距，避免横屏手机下卡牌过疏 */}
-            <div className="flex-1 w-full max-w-7xl overflow-y-auto px-3 py-3 sm:px-4 sm:py-4 md:px-6 md:py-4 relative z-10 custom-scrollbar">
-                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 sm:gap-4 md:gap-6 pb-24 sm:pb-28">
+            {/* FACTION GRID - 16:9 横屏下尽量对齐桌面端排布与密度 */}
+            <div className="flex-1 w-full max-w-7xl overflow-y-auto px-3 py-3 lg:px-6 lg:py-4 relative z-10 custom-scrollbar">
+                <div className="mx-auto grid w-full max-w-[920px] grid-cols-4 gap-3 lg:max-w-none xl:grid-cols-4 2xl:grid-cols-5 lg:gap-6 pb-24 lg:pb-28">
                     {visibleFactions.map((faction, idx) => {
                         const isTaken = takenFactions.has(faction.id);
                         const isSelectedByMe = mySelections.includes(faction.id);
@@ -143,16 +143,16 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                                 transition={{ delay: idx * 0.03 }}
                                 onClick={() => setFocusedFactionId(faction.id)}
                                 className={`
-                                    group relative flex flex-col items-center cursor-pointer
+                                    group relative flex w-full flex-col items-center cursor-pointer
                                     ${isTaken ? 'opacity-40 grayscale pointer-events-none' : 'z-10'}
                                 `}
                             >
                                 {/* Card Stack Visual */}
-                                <div className="relative w-32 h-44 sm:w-36 sm:h-52 md:w-48 md:h-64 mb-3 sm:mb-4">
+                                <div className="relative mb-2.5 w-full max-w-[148px] lg:max-w-[192px] aspect-[0.727] xl:max-w-[208px]">
                                     {/* Main Cover Card */}
                                     <div className={`
-                                        absolute inset-0 rounded-sm overflow-hidden shadow-[3px_3px_12px_rgba(0,0,0,0.4)] border-[0.4vw] transition-all
-                                        bg-white p-[0.3vw]
+                                        absolute inset-0 rounded-sm overflow-hidden shadow-[3px_3px_10px_rgba(0,0,0,0.38)] border-[4px] lg:border-[5px] transition-all
+                                        bg-white p-[3px] lg:p-[4px]
                                         ${isSelectedByMe
                                             ? 'border-green-500 scale-105 -translate-y-2'
                                             : isTaken
@@ -182,16 +182,16 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                                             <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/80 to-transparent" />
 
                                             {/* Faction Name on Card */}
-                                            <div className="absolute bottom-2 left-2 right-2 text-left">
-                                                <h3 className="text-white font-black text-sm md:text-base leading-none mb-1 drop-shadow-md uppercase italic tracking-tighter">
+                                            <div className="absolute bottom-1.5 left-1.5 right-1.5 lg:bottom-2 lg:left-2 lg:right-2 text-left">
+                                                <h3 className="text-white font-black text-[11px] lg:text-base leading-none mb-0.5 lg:mb-1 drop-shadow-md uppercase italic tracking-tight lg:tracking-tighter">
                                                     {t(faction.nameKey)}
                                                 </h3>
                                             </div>
                                         </div>
 
                                         {/* Faction Icon Badge - "Token" style */}
-                                        <div className="absolute -top-2 -right-2 z-40 w-10 h-10 bg-slate-900 border-2 border-white rounded-full flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
-                                            <faction.icon size={20} strokeWidth={2.5} style={{ color: faction.color }} />
+                                        <div className="absolute -top-1.5 -right-1.5 lg:-top-2 lg:-right-2 z-40 w-8 h-8 lg:w-10 lg:h-10 bg-slate-900 border-2 border-white rounded-full flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
+                                            <faction.icon size={16} strokeWidth={2.5} style={{ color: faction.color }} />
                                         </div>
                                     </div>
                                 </div>
@@ -221,7 +221,7 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                         <motion.div
                             layoutId={focusedFactionId}
                             className="relative w-full max-w-5xl h-[85vh] bg-[#fdfdfd] border-4 border-slate-800 shadow-[0_20px_50px_rgba(0,0,0,0.6)] rounded-sm overflow-hidden flex flex-col md:flex-row clip-path-jagged"
-                            style={{ backgroundImage: 'repeating-linear-gradient(0deg, transparent, transparent 1.5vw, #f1f5f9 1.5vw, #f1f5f9 1.6vw)' }}
+                            style={{ backgroundImage: 'repeating-linear-gradient(0deg, transparent, transparent 18px, #f1f5f9 18px, #f1f5f9 19px)' }}
                             initial={{ scale: 0.9, opacity: 0, rotate: -2 }}
                             animate={{ scale: 1, opacity: 1, rotate: 0 }}
                             exit={{ scale: 0.9, opacity: 0, rotate: 2 }}
@@ -321,7 +321,7 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                                         return cards.map((card, cidx) => (
                                             <div
                                                 key={card.id}
-                                                className="group relative aspect-[0.714] rounded-sm overflow-hidden bg-white p-[0.15vw] shadow-md border-2 border-slate-100 transition-all cursor-zoom-in hover:z-20 hover:scale-110 hover:shadow-xl"
+                                                className="group relative aspect-[0.714] rounded-sm overflow-hidden bg-white p-[2px] lg:p-[3px] shadow-md border-2 border-slate-100 transition-all cursor-zoom-in hover:z-20 hover:scale-110 hover:shadow-xl"
                                                 style={{ transform: `rotate(${(cidx % 5) - 2}deg)` }}
                                                 onClick={() => setViewingCard({ defId: card.id, type: card.type })}
                                             >
@@ -364,8 +364,8 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
             </AnimatePresence>
 
             {/* FOOTER: Status Bar - Floating Score Sheet style */}
-            <div className="absolute bottom-3 sm:bottom-6 inset-x-0 z-40 pointer-events-none">
-                <div className="max-w-7xl mx-auto flex items-end justify-center gap-3 sm:gap-5 md:gap-8 px-3 sm:px-4 md:px-6">
+            <div className="absolute bottom-3 inset-x-0 z-40 pointer-events-none">
+                <div className="max-w-7xl mx-auto flex items-end justify-center gap-3 px-3 lg:gap-8 lg:px-6">
                     {core.turnOrder.map((pid, pidx) => {
                         const selections = selectionState.playerSelections[pid] || [];
                         const isCurrent = pid === currentPlayerId;
@@ -377,9 +377,9 @@ export const FactionSelection: React.FC<Props> = ({ core, dispatch, playerID }) 
                                 animate={{ y: 0, opacity: 1 }}
                                 transition={{ delay: 0.5 + pidx * 0.1 }}
                                 className={`
-                                    flex flex-col items-center gap-1.5 sm:gap-2 px-3 py-2 sm:px-4 sm:py-2.5 md:px-6 md:py-3 rounded-sm border-2 pointer-events-auto transition-all
+                                    flex flex-col items-center gap-2 px-4 py-2.5 lg:px-6 lg:py-3 rounded-sm border-2 pointer-events-auto transition-all
                                     ${isCurrent
-                                        ? 'bg-[#fef3c7] border-amber-500 shadow-[0_10px_25px_rgba(0,0,0,0.5)] -rotate-1 z-10 scale-105 md:scale-110'
+                                        ? 'bg-[#fef3c7] border-amber-500 shadow-[0_10px_25px_rgba(0,0,0,0.5)] -rotate-1 z-10 scale-110'
                                         : 'bg-white/90 border-slate-200 shadow-lg rotate-1 grayscale-[0.3]'}
                                 `}
                             >


### PR DESCRIPTION
## 本次内容\n- 收口当前线上未关闭 Smash Up 反馈修复\n- 调整大杀四方横屏选派系页，使 16:9 移动端尽量与桌面端一致\n- 补充对应测试与截图验证\n\n## 验证\n- 增量质量门已通过（typecheck / eslint / i18n / changed tests）\n- E2E：e2e/smashup-faction-selection-spacing.e2e.ts\n\n## 备注\n- 本轮按单一 worktree 收口修改\n- 样式验收已补截图证据

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added end-to-end testing for faction selection layout validation across mobile landscape and desktop viewports.

* **Bug Fixes**
  * Fixed card game interaction issues with minion selection and play restrictions.
  * Improved faction selection card spacing and layout responsiveness.

* **Style**
  * Enhanced faction card sizing, padding, and typography responsiveness for better mobile and desktop display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->