### PR TITLE
Chore/mobile adaptive spec split（接管 #42）

### DIFF
--- a/src/server/__tests__/ugcRegistration.integration.test.ts
+++ b/src/server/__tests__/ugcRegistration.integration.test.ts
@@ -1,10 +1,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { buildUgcServerGames } from '../ugcRegistration';
 import { getUgcPackageModel } from '../models/UgcPackage';
+import { MONGO_TEST_HOOK_TIMEOUT_MS, createSharedMongoMemoryServer } from '../testUtils/mongoMemory';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -37,12 +38,12 @@ describe('UGC 动态注册集成', () => {
         process.env.MONGO_URI = '';
         process.env.UGC_LOCAL_PATH = uploadDir;
         process.env.UGC_PUBLIC_URL_BASE = '/assets';
-        mongo = await MongoMemoryServer.create();
+        mongo = await createSharedMongoMemoryServer();
         const uri = mongo.getUri();
         await mongoose.connect(uri);
         mkdirSync(join(uploadDir, 'ugc', 'user-1', 'pkg-1'), { recursive: true });
         writeFileSync(join(uploadDir, 'ugc', 'user-1', 'pkg-1', 'domain.js'), buildDomainCode(), 'utf-8');
-    });
+    }, MONGO_TEST_HOOK_TIMEOUT_MS);
 
     beforeEach(async () => {
         const Model = getUgcPackageModel();

--- a/src/server/storage/__tests__/hybridStorage.test.ts
+++ b/src/server/storage/__tests__/hybridStorage.test.ts
@@ -1,9 +1,10 @@
 import { beforeAll, afterAll, beforeEach, describe, it, expect, vi } from 'vitest';
 import mongoose from 'mongoose';
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import type { MatchMetadata, StoredMatchState, CreateMatchData } from '../../../engine/transport/storage';
 import { mongoStorage } from '../MongoStorage';
 import { HybridStorage } from '../HybridStorage';
+import { MONGO_TEST_HOOK_TIMEOUT_MS, createSharedMongoMemoryServer } from '../../testUtils/mongoMemory';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
 
 const buildState = (setupData: Record<string, unknown>): StoredMatchState => ({
     G: { __setupData: setupData },
@@ -43,10 +44,10 @@ describe('HybridStorage 行为', () => {
     let hybrid: HybridStorage;
 
     beforeAll(async () => {
-        mongo = await MongoMemoryServer.create();
+        mongo = await createSharedMongoMemoryServer();
         await mongoose.connect(mongo.getUri(), { dbName: 'boardgame-test' });
         await mongoStorage.connect();
-    }, 60000); // 60 秒超时（MongoDB 内存服务器启动可能较慢）
+    }, MONGO_TEST_HOOK_TIMEOUT_MS);
 
     beforeEach(async () => {
         await mongoose.connection.db!.dropDatabase();

--- a/src/server/storage/__tests__/mongoStorage.test.ts
+++ b/src/server/storage/__tests__/mongoStorage.test.ts
@@ -1,53 +1,25 @@
 import { beforeAll, afterAll, beforeEach, describe, it, expect, vi } from 'vitest';
 import mongoose from 'mongoose';
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import type { MatchMetadata, StoredMatchState, CreateMatchData } from '../../../engine/transport/storage';
 import { mongoStorage } from '../MongoStorage';
 import { runStartupCleanupTasks, type StartupCleanupTask } from '../startupCleanup';
-
-const LOCAL_TEST_MONGO_URI = 'mongodb://127.0.0.1:27017';
+import { MONGO_TEST_HOOK_TIMEOUT_MS, resolvePreferredTestMongoUri } from '../../testUtils/mongoMemory';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
 
 const buildState = (setupData: Record<string, unknown>): StoredMatchState => ({
     G: { __setupData: setupData },
     _stateID: 0,
 });
 
-async function resolveTestMongoUri(): Promise<{ mongo: MongoMemoryServer | null; mongoUri: string }> {
-    const externalMongoUri = process.env.MONGO_URI;
-    if (externalMongoUri) {
-        return { mongo: null, mongoUri: externalMongoUri };
-    }
-
-    const probeConnection = mongoose.createConnection(LOCAL_TEST_MONGO_URI, {
-        dbName: 'admin',
-        serverSelectionTimeoutMS: 1500,
-    });
-
-    try {
-        await probeConnection.asPromise();
-        await probeConnection.close();
-        return { mongo: null, mongoUri: LOCAL_TEST_MONGO_URI };
-    } catch {
-        try {
-            await probeConnection.close();
-        } catch {
-            // ignore probe cleanup failure
-        }
-    }
-
-    const mongo = await MongoMemoryServer.create();
-    return { mongo, mongoUri: mongo.getUri() };
-}
-
 describe('MongoStorage.cleanupCorruptMatches', () => {
     let mongo: MongoMemoryServer | null = null;
 
     beforeAll(async () => {
-        const resolved = await resolveTestMongoUri();
+        const resolved = await resolvePreferredTestMongoUri();
         mongo = resolved.mongo;
         await mongoose.connect(resolved.mongoUri, { dbName: 'boardgame-test-corrupt-cleanup' });
         await mongoStorage.connect();
-    }, 60000);
+    }, MONGO_TEST_HOOK_TIMEOUT_MS);
 
     beforeEach(async () => {
         await mongoose.connection.db!.dropDatabase();
@@ -260,11 +232,11 @@ describe('MongoStorage 行为', () => {
     let mongo: MongoMemoryServer | null = null;
 
     beforeAll(async () => {
-        const resolved = await resolveTestMongoUri();
+        const resolved = await resolvePreferredTestMongoUri();
         mongo = resolved.mongo;
         await mongoose.connect(resolved.mongoUri, { dbName: 'boardgame-test' });
         await mongoStorage.connect();
-    }, 60000); // 60 秒超时（MongoDB 内存服务器启动可能较慢）
+    }, MONGO_TEST_HOOK_TIMEOUT_MS);
 
     beforeEach(async () => {
         await mongoose.connection.db!.dropDatabase();

--- a/src/server/testUtils/mongoMemory.ts
+++ b/src/server/testUtils/mongoMemory.ts
@@ -1,0 +1,70 @@
+import os from 'node:os';
+import path from 'node:path';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+const LOCAL_TEST_MONGO_URI = 'mongodb://127.0.0.1:27017';
+export const MONGO_TEST_HOOK_TIMEOUT_MS = 180000;
+
+function configureMongoMemoryServerEnv() {
+    process.env.MONGOMS_PREFER_GLOBAL_PATH ??= 'true';
+    process.env.MONGOMS_DOWNLOAD_DIR ??= path.join(os.homedir(), '.cache', 'mongodb-binaries');
+
+    // 允许开发者显式指定系统 mongod，避免任何下载。
+    if (process.env.TEST_MONGOD_PATH && !process.env.MONGOMS_SYSTEM_BINARY) {
+        process.env.MONGOMS_SYSTEM_BINARY = process.env.TEST_MONGOD_PATH;
+    }
+}
+
+async function delay(ms: number) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function createSharedMongoMemoryServer(retries = 3): Promise<MongoMemoryServer> {
+    configureMongoMemoryServerEnv();
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= retries; attempt += 1) {
+        try {
+            return await MongoMemoryServer.create();
+        } catch (error) {
+            lastError = error;
+            const code = error instanceof Error && 'code' in error ? String(error.code) : '';
+            const isRetryable = code === 'EBUSY' || code === 'ETXTBSY';
+            if (!isRetryable || attempt === retries) {
+                throw error;
+            }
+            await delay(attempt * 1000);
+        }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error('创建 MongoMemoryServer 失败');
+}
+
+export async function resolvePreferredTestMongoUri(): Promise<{ mongo: MongoMemoryServer | null; mongoUri: string }> {
+    const externalMongoUri = process.env.MONGO_URI;
+    if (externalMongoUri) {
+        return { mongo: null, mongoUri: externalMongoUri };
+    }
+
+    const probeConnection = mongoose.createConnection(LOCAL_TEST_MONGO_URI, {
+        dbName: 'admin',
+        serverSelectionTimeoutMS: 1500,
+    });
+
+    try {
+        await probeConnection.asPromise();
+        await probeConnection.close();
+        return { mongo: null, mongoUri: LOCAL_TEST_MONGO_URI };
+    } catch {
+        try {
+            await probeConnection.close();
+        } catch {
+            // ignore probe cleanup failure
+        }
+    }
+
+    const mongo = await createSharedMongoMemoryServer();
+    return { mongo, mongoUri: mongo.getUri() };
+}
+

--- a/vitest.config.api.ts
+++ b/vitest.config.api.ts
@@ -45,7 +45,7 @@ export default defineConfig({
             '**/.{idea,git,cache,output,temp}/**',
         ],
         testTimeout: 180000,
-        hookTimeout: 60000,
+        hookTimeout: 180000,
         setupFiles: [rootSetupFile, apiSetupFile],
     },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
             '**/.{idea,git,cache,output,temp}/**',
         ],
         testTimeout: 180000,
-        hookTimeout: 60000, // 60 秒 hook 超时（MongoDB 内存服务器启动可能较慢）
+        hookTimeout: 180000, // 首次拉起 mongodb-memory-server 可能需要下载/解压二进制，60 秒不够稳定。
         setupFiles: [rootSetupFile, apiSetupFile],
     },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,5 @@
+import os from 'node:os';
+import path from 'node:path';
 import { setAssetsBaseUrl } from './src/core/AssetLoader';
 import '@testing-library/jest-dom/vitest';
 
@@ -6,6 +8,13 @@ import '@testing-library/jest-dom/vitest';
 globalThis.__LOCALE_HASHES__ = {};
 // @ts-expect-error -- 全局变量由 Vite define 注入，测试环境手动补齐
 globalThis.__ASSET_HASHES__ = {};
+
+// 统一使用用户级缓存，避免不同 worktree 首次跑测试时重复走 mongodb-memory-server 下载逻辑。
+process.env.MONGOMS_PREFER_GLOBAL_PATH ??= 'true';
+process.env.MONGOMS_DOWNLOAD_DIR ??= path.join(os.homedir(), '.cache', 'mongodb-binaries');
+if (process.env.TEST_MONGOD_PATH && !process.env.MONGOMS_SYSTEM_BINARY) {
+    process.env.MONGOMS_SYSTEM_BINARY = process.env.TEST_MONGOD_PATH;
+}
 
 // Tests should be deterministic and not depend on external/CDN base URLs.
 setAssetsBaseUrl('/assets');


### PR DESCRIPTION
## 说明
- 接管原 PR #42：原 PR 来自 fork，当前 maintainerCanModify=false，无法将补修直接推回原 head 分支。
- 本 PR 搬运了 #42 当前内容，并补上本次审查发现的回归修复与 Mongo 内存测试基础设施修整。

## 包含内容
- 修复 CriticalImageGate、Home、useGameAudio、Cardia criticalImageResolver 等回归。
- 修复 Summoner Wars 若干 UI/动画时序问题。
- 将 mongodb-memory-server 测试基础设施统一到共享 helper，避免 worktree 和首次冷启动反复踩坑。

## 验证
- npm run quality:changed -- ci
- npm run quality:changed -- pre-push
- 相关 server Mongo 测试已单独通过

Closes #42