### PR TITLE
修复大杀四方幼苗 POD 回合开始窗口时序

### DIFF
--- a/src/games/smashup/__tests__/buryEngine.test.ts
+++ b/src/games/smashup/__tests__/buryEngine.test.ts
@@ -89,6 +89,59 @@ describe('bury engine', () => {
         expect(res.finalState.core.bases[0].minions.some(m => m.uid === 'b1')).toBe(true);
     });
 
+    it('at startTurn, uncovering a buried onTurnStart minion should still resolve in the same window', () => {
+        const core = makeState({
+            turnOrder: ['0', '1'],
+            currentPlayerIndex: 1,
+            turnNumber: 1,
+            players: {
+                '0': makePlayer('0', {
+                    hand: [],
+                    deck: [{ uid: 'draw-1', defId: 'robot_warbot', type: 'minion', owner: '0' } as any],
+                    discard: [],
+                }),
+                '1': makePlayer('1', { hand: [], deck: [], discard: [] }),
+            },
+            bases: [{
+                defId: 'base_a',
+                minions: [],
+                ongoingActions: [],
+                buriedCards: [{
+                    uid: 'wl-buried',
+                    defId: 'killer_plant_water_lily_pod',
+                    trueOwnerId: '0',
+                    controllerId: '0',
+                    buriedFrom: 'hand',
+                }],
+            }],
+        });
+
+        const enter = runCommand(
+            makeMatchState(core),
+            { type: 'ADVANCE_PHASE' as any, playerId: '1', payload: {}, timestamp: 10 } as any,
+            defaultTestRandom,
+        );
+
+        const interaction = enter.finalState.sys.interaction.current as any;
+        expect(interaction?.data?.sourceId).toBe('bury_uncover_start_turn');
+        const option = interaction.data.options.find((entry: any) => entry.value?.cardUid === 'wl-buried');
+        expect(option).toBeTruthy();
+
+        const resolved = runCommand(
+            enter.finalState,
+            { type: INTERACTION_COMMANDS.RESPOND, playerId: '0', payload: { optionId: option.id }, timestamp: 11 } as any,
+            defaultTestRandom,
+        );
+
+        expect(resolved.success).toBe(true);
+        const drawEvents = resolved.events.filter(event => event.type === SU_EVENTS.CARDS_DRAWN);
+        expect(drawEvents).toHaveLength(1);
+        expect((drawEvents[0] as any).payload.cardUids).toEqual(['draw-1']);
+        expect(resolved.finalState.core.players['0'].hand.map(card => card.uid)).toEqual(['draw-1']);
+        expect(resolved.finalState.core.bases[0].minions.some(m => m.uid === 'wl-buried')).toBe(true);
+        expect(resolved.finalState.sys.phase).toBe('playCards');
+    });
+
     it('base cleared discards buried cards to true owners without uncovering', () => {
         const core = makeState({
             players: {

--- a/src/games/smashup/__tests__/killer-plant-pod-verification.test.ts
+++ b/src/games/smashup/__tests__/killer-plant-pod-verification.test.ts
@@ -161,6 +161,101 @@ describe('Killer Plants POD Card Logic Verification', () => {
         expect(minionUids).toContain('wl-1');
     });
 
+    it('???? playCards ??? Sprout POD ????? onTurnStart ??', () => {
+        const core = makeState({
+            currentPlayerIndex: 1,
+            bases: [{ defId: 'base1', minions: [], ongoingActions: [] } as any],
+            players: {
+                '0': makePlayer('0', {
+                    factions: [SMASHUP_FACTION_IDS.KILLER_PLANTS_POD, SMASHUP_FACTION_IDS.BEAR_CAVALRY_POD],
+                    hand: [makeCard('sprout-hand', 'killer_plant_sprout_pod', 'minion', '0')],
+                    deck: [makeCard('wl-1', 'killer_plant_water_lily_pod', 'minion', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+        });
+        const matchState = makeMatchState(core);
+        matchState.sys.phase = 'playCards';
+
+        const turnResult = runCommand(matchState, {
+            type: 'ADVANCE_PHASE' as any,
+            playerId: '1',
+            payload: undefined,
+            timestamp: 1002,
+        });
+
+        expect(turnResult.success).toBe(true);
+        expect(turnResult.finalState.sys.phase).toBe('playCards');
+        expect((turnResult.finalState.sys as any)._smashupStartTurnWindowActive).toBeUndefined();
+
+        const playResult = runCommand(turnResult.finalState, {
+            type: SU_COMMANDS.PLAY_MINION,
+            playerId: '0',
+            payload: { cardUid: 'sprout-hand', baseIndex: 0 },
+            timestamp: 1003,
+        });
+
+        expect(playResult.success).toBe(true);
+        expect(playResult.events.some(event => event.type === SU_EVENTS.MINION_DESTROYED)).toBe(false);
+        expect(playResult.events.some(event => event.type === SU_EVENTS.CARDS_DRAWN)).toBe(false);
+        expect(playResult.finalState.sys.interaction.current).toBeUndefined();
+        expect(playResult.finalState.core.bases[0].minions.map(minion => minion.uid)).toContain('sprout-hand');
+    });
+
+    it('???? playCards ?????????? Sprout POD ????? onTurnStart ??', () => {
+        const core = makeState({
+            currentPlayerIndex: 1,
+            bases: [{ defId: 'base1', minions: [], ongoingActions: [] } as any],
+            players: {
+                '0': makePlayer('0', {
+                    factions: [SMASHUP_FACTION_IDS.KILLER_PLANTS_POD, SMASHUP_FACTION_IDS.BEAR_CAVALRY_POD],
+                    hand: [makeCard('venus-hand', 'killer_plant_venus_man_trap_pod', 'minion', '0')],
+                    deck: [makeCard('sprout-deck', 'killer_plant_sprout_pod', 'minion', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+        });
+        const matchState = makeMatchState(core);
+        matchState.sys.phase = 'playCards';
+
+        const turnResult = runCommand(matchState, {
+            type: 'ADVANCE_PHASE' as any,
+            playerId: '1',
+            payload: undefined,
+            timestamp: 1004,
+        });
+
+        expect(turnResult.success).toBe(true);
+        expect(turnResult.finalState.sys.phase).toBe('playCards');
+        expect((turnResult.finalState.sys as any)._smashupStartTurnWindowActive).toBeUndefined();
+
+        const playVenusResult = runCommand(turnResult.finalState, {
+            type: SU_COMMANDS.PLAY_MINION,
+            playerId: '0',
+            payload: { cardUid: 'venus-hand', baseIndex: 0 },
+            timestamp: 1005,
+        });
+
+        expect(playVenusResult.success).toBe(true);
+
+        const talentResult = runCommand(playVenusResult.finalState, {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { minionUid: 'venus-hand', baseIndex: 0 },
+            timestamp: 1006,
+        });
+
+        expect(talentResult.success).toBe(true);
+        const drawEvents = talentResult.events.filter(event => event.type === SU_EVENTS.CARDS_DRAWN);
+        expect(drawEvents).toHaveLength(1);
+        expect((drawEvents[0] as any).payload.cardUids).toEqual(['sprout-deck']);
+        expect(talentResult.events.some(event => event.type === SU_EVENTS.MINION_DESTROYED)).toBe(false);
+        expect(talentResult.finalState.sys.interaction.current).toBeUndefined();
+        const finalMinionUids = talentResult.finalState.core.bases[0].minions.map(minion => minion.uid);
+        expect(finalMinionUids).toContain('venus-hand');
+        expect(finalMinionUids).toContain('sprout-deck');
+    });
+
     it('Water Lily played by Sprout on the same start-turn window should draw immediately', () => {
         const base = {
             defId: 'base1',

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -1699,6 +1699,20 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
             }
         }
 
+        if (to === 'playCards' && from === 'startTurn' && (state.sys as any)._smashupStartTurnWindowActive) {
+            return {
+                events,
+                updatedState: {
+                    ...state,
+                    sys: {
+                        ...state.sys,
+                        _smashupStartTurnWindowActive: undefined,
+                        _waitForStartTurnInteractionReduce: undefined,
+                    } as any,
+                },
+            } as PhaseEnterResult;
+        }
+
         return events;
     },
 
@@ -1727,6 +1741,9 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
 
         // startTurn 鑷姩鎺ㄨ繘鍒?playCards
         if (phase === 'startTurn') {
+            if ((state.sys as any)._waitForStartTurnInteractionReduce) {
+                return undefined;
+            }
             return { autoContinue: true, playerId: pid };
         }
 

--- a/src/games/smashup/domain/systems.ts
+++ b/src/games/smashup/domain/systems.ts
@@ -117,6 +117,7 @@ export function createSmashUpEventSystem(): EngineSystem<SmashUpCore> {
             let newState = state;
             const nextEvents: GameEvent[] = [];
             const pendingReduceFlag = '_waitForPostScoringReduce';
+            const pendingStartTurnInteractionReduceFlag = '_waitForStartTurnInteractionReduce';
             let latestTimestamp = 0;
 
             // 同一轮 afterEvents 中，后续系统看不到本轮新发出事件的 reduce 结果。
@@ -128,6 +129,16 @@ export function createSmashUpEventSystem(): EngineSystem<SmashUpCore> {
                     sys: {
                         ...newState.sys,
                         [pendingReduceFlag]: undefined,
+                    } as typeof newState.sys,
+                };
+            }
+
+            if ((newState.sys as any)[pendingStartTurnInteractionReduceFlag]) {
+                newState = {
+                    ...newState,
+                    sys: {
+                        ...newState.sys,
+                        [pendingStartTurnInteractionReduceFlag]: undefined,
                     } as typeof newState.sys,
                 };
             }
@@ -150,6 +161,10 @@ export function createSmashUpEventSystem(): EngineSystem<SmashUpCore> {
                     if (payload.sourceId) {
                         const handler = getInteractionHandler(payload.sourceId);
                         if (handler) {
+                            const startTurnWindowActive =
+                                newState.sys.phase === 'startTurn'
+                                || Boolean((newState.sys as any)._smashupStartTurnWindowActive);
+
                             const result = handler(
                                 newState,
                                 payload.playerId,
@@ -176,6 +191,19 @@ export function createSmashUpEventSystem(): EngineSystem<SmashUpCore> {
                                 // 这里如果手动先调用 interceptEvent，会让同一批事件在轮末 reduce 时再次被拦截，
                                 // 导致像 Cthulhu 这类“交互返回 MADNESS_DRAWN，再由拦截器补标记”的链路被重复处理。
                                 nextEvents.push(...result.events as SmashUpEvent[]);
+
+                                const producedMinionPlayed = result.events.some(
+                                    (resultEvent) => resultEvent.type === SU_EVENT_TYPES.MINION_PLAYED,
+                                );
+                                if (startTurnWindowActive && producedMinionPlayed) {
+                                    newState = {
+                                        ...newState,
+                                        sys: {
+                                            ...newState.sys,
+                                            [pendingStartTurnInteractionReduceFlag]: true,
+                                        } as typeof newState.sys,
+                                    };
+                                }
 
                                 // 补发延迟的 BASE_CLEARED/BASE_REPLACED 事件
                                 // afterScoring 基地能力创建交互时，清除事件被延迟到交互解决后发出，


### PR DESCRIPTION
## 变更内容
- 修复幼苗 POD 在非 startTurn 场景下被直接打出时仍立即按 onTurnStart 触发的问题
- 保留 startTurn 交互链中继续打出随从时的 onTurnStart 窗口语义
- 补充 Sprout POD、Venus Man-Trap POD 与 bury uncover startTurn 的回归测试

## 验证
- node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/killer-plant-pod-verification.test.ts src/games/smashup/__tests__/turnTransitionInteractionBug.test.ts src/games/smashup/__tests__/buryEngine.test.ts --configLoader native

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interaction resolution timing during turn start phase to ensure buried minions uncover and process within the correct phase window.
  * Fixed Killer Plants POD "Sprout" behavior during card play to prevent incorrect event triggering.

* **Tests**
  * Added comprehensive test coverage for start-turn interaction resolution with card drawing.
  * Added test coverage for Killer Plants POD card play mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->