### PR TITLE
修复：POD 武者之道在基地计分弃置时触发抽牌

### DIFF
--- a/src/games/smashup/__tests__/newFactionAbilities.test.ts
+++ b/src/games/smashup/__tests__/newFactionAbilities.test.ts
@@ -2522,6 +2522,50 @@ describe('Samurai abilities', () => {
         expect(result.events.some(event => event.type === SU_EVENTS.CARDS_DRAWN)).toBe(true);
     });
 
+    it('samurai_way_of_the_warrior_pod 在目标因基地结算进入弃牌堆时也会抽一张牌', () => {
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', {
+                    hand: [makeCard('warrior-pod-1', 'samurai_way_of_the_warrior_pod', 'action', '0')],
+                    deck: [makeCard('draw-pod-1', 'robot_microbot_alpha', 'minion', '0')],
+                }),
+                '1': makePlayer('1'),
+            },
+            bases: [{
+                defId: 'base_a',
+                minions: [makeMinion('ally-pod-1', 'samurai_ronin_pod', '0', 3)],
+                ongoingActions: [],
+            }],
+        });
+
+        const play = runCommand(
+            makeMatchState(core),
+            {
+                type: SU_COMMANDS.PLAY_ACTION,
+                playerId: '0',
+                payload: { cardUid: 'warrior-pod-1', targetBaseIndex: 0, targetMinionUid: 'ally-pod-1' },
+            },
+            defaultTestRandom,
+        );
+
+        const target = play.finalState.core.bases[0].minions.find(minion => minion.uid === 'ally-pod-1');
+        expect(target?.tempPowerModifier).toBe(3);
+
+        const result = fireTriggers(play.finalState.core, 'onMinionDiscardedFromBase', {
+            state: play.finalState.core,
+            matchState: play.finalState,
+            playerId: '0',
+            baseIndex: 0,
+            triggerMinion: target,
+            triggerMinionUid: 'ally-pod-1',
+            triggerMinionDefId: 'samurai_ronin_pod',
+            random: defaultTestRandom,
+            now: 1104,
+        });
+
+        expect(result.events.some(event => event.type === SU_EVENTS.CARDS_DRAWN)).toBe(true);
+    });
+
     it('samurai_way_of_the_warrior 在焦油坑把目标改放牌库底时不会抽牌', () => {
         const core = makeState({
             players: {

--- a/src/games/smashup/abilities/samurai.ts
+++ b/src/games/smashup/abilities/samurai.ts
@@ -44,6 +44,7 @@ export function registerSamuraiAbilities(): void {
     registerAbility('samurai_code_of_bushido', 'onPlay', samuraiCodeOfBushidoOnPlay);
     registerAbility('samurai_honor_the_ancestors', 'onPlay', samuraiHonorTheAncestorsOnPlay);
     registerAbility('samurai_way_of_the_warrior', 'onPlay', samuraiWayOfTheWarriorOnPlay);
+    registerAbility('samurai_way_of_the_warrior_pod', 'onPlay', samuraiWayOfTheWarriorOnPlay);
     registerAbility('samurai_heart_of_the_battle', 'special', samuraiHeartOfTheBattleSpecial);
 
     registerTrigger('samurai_samurai_chan', 'onMinionDestroyed', samuraiChanTrigger, { perInstance: true });
@@ -56,6 +57,8 @@ export function registerSamuraiAbilities(): void {
     registerTrigger('samurai_final_haiku', 'onMinionDiscardedFromBase', samuraiFinalHaikuTrigger, { perInstance: true });
     registerTrigger('samurai_way_of_the_warrior', 'onMinionDestroyed', samuraiWayOfTheWarriorTrigger, { global: true });
     registerTrigger('samurai_way_of_the_warrior', 'onMinionDiscardedFromBase', samuraiWayOfTheWarriorTrigger, { global: true });
+    registerTrigger('samurai_way_of_the_warrior_pod', 'onMinionDestroyed', samuraiWayOfTheWarriorTrigger, { global: true });
+    registerTrigger('samurai_way_of_the_warrior_pod', 'onMinionDiscardedFromBase', samuraiWayOfTheWarriorTrigger, { global: true });
     registerTrigger('samurai_honor_the_fallen', 'onMinionDestroyed', samuraiHonorTheFallenTrigger, {
         perInstance: true,
         sourceScope: 'triggerBase',


### PR DESCRIPTION
﻿## 背景
- 修复 Smash Up POD 武士行动牌 `Way of the Warrior` 在目标随从因基地计分结算进入弃牌堆时没有触发抽牌的问题。

## 改动
- 为 `samurai_way_of_the_warrior_pod` 注册与基础版一致的 onPlay 能力。
- 为 `samurai_way_of_the_warrior_pod` 注册进入弃牌堆相关触发器，覆盖被消灭和基地计分弃置两种离场路径。
- 新增回归测试，覆盖 POD 版在基地计分后进入弃牌堆时抽牌。

## 验证
- `npm run i18n:check`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/newFactionAbilities.test.ts --configLoader native -t samurai_way_of_the_warrior_pod`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the Samurai "Way of the Warrior" pod ability to correctly generate card draw events when target minions are discarded during base resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->