### PR TITLE
修复 Smash Up 武士 POD 计分弃牌后未正确加分

### DIFF
--- a/src/games/smashup/__tests__/baseScoring.test.ts
+++ b/src/games/smashup/__tests__/baseScoring.test.ts
@@ -110,6 +110,43 @@ describe('基地记分与力量计算', () => {
             ]);
         });
 
+        it('scoreOneBase 会保留武士 POD 计分弃牌瞬间的有效战力并额外给 1VP', () => {
+            const state: SmashUpCore = {
+                players: {
+                    '0': makePlayer('0', { factions: [SMASHUP_FACTION_IDS.SAMURAI_POD, SMASHUP_FACTION_IDS.ALIENS] }),
+                    '1': makePlayer('1'),
+                },
+                turnOrder: PLAYER_IDS,
+                currentPlayerIndex: 0,
+                bases: [{
+                    defId: 'base_tar_pits',
+                    minions: [
+                        { uid: 'bushi-pod-1', defId: 'samurai_bushi_pod', controller: '0', owner: '0', basePower: 4, powerCounters: 1, powerModifier: 0, tempPowerModifier: 0, talentUsed: false, attachedActions: [] },
+                        { uid: 'ally-13', defId: 'ally_big', controller: '0', owner: '0', basePower: 13, powerCounters: 0, powerModifier: 0, tempPowerModifier: 0, talentUsed: false, attachedActions: [] },
+                    ],
+                    ongoingActions: [],
+                }],
+                baseDeck: [],
+                turnNumber: 1,
+                nextUid: 10,
+            };
+
+            const result = scoreOneBase(state, 0, [], '0', 1000);
+            const scoredEvent = result.events.find((event) => event.type === SU_EVENTS.BASE_SCORED) as any;
+            const bonusVpEvent = result.events.find((event) =>
+                event.type === SU_EVENTS.VP_AWARDED
+                && (event as any).payload?.reason === 'samurai_bushi'
+            ) as any;
+
+            expect(scoredEvent).toBeDefined();
+            expect(bonusVpEvent).toBeDefined();
+            expect(bonusVpEvent.payload.playerId).toBe('0');
+            expect(bonusVpEvent.payload.amount).toBe(1);
+
+            const finalState = result.events.reduce((acc, event) => SmashUpDomain.reduce(acc, event), state);
+            expect(finalState.players['0'].vp).toBe(scoredEvent.payload.rankings[0].vp + 1);
+        });
+
         it('reduce BASE_SCORED 正确分配 VP', () => {
             const { reduce } = SmashUpDomain;
             const state: SmashUpCore = {

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -346,6 +346,7 @@ export function scoreOneBase(
             baseIndex,
             triggerMinionUid: m.uid,
             triggerMinionDefId: m.defId,
+            triggerMinionPower: getEffectivePower(core, m, baseIndex),
             triggerMinion: m,
             random: rng,
             now,

--- a/src/games/smashup/domain/reducer.ts
+++ b/src/games/smashup/domain/reducer.ts
@@ -72,6 +72,7 @@ import { fireTriggers, collectTriggers, hasPlayerTurnRestriction, isMinionProtec
 import { maybeResolveReactionQueue } from './reactionQueue';
 import { canPlayFromDiscard } from './discardPlayability';
 import { reduce } from './reduce';
+import { getEffectivePower } from './ongoingModifiers';
 
 // ============================================================================
 // execute：命令 → 事件
@@ -925,6 +926,7 @@ export function processDestroyTriggers(
             baseIndex: fromBaseIndex,
             triggerMinionUid: minionUid,
             triggerMinionDefId: minionDefId,
+            triggerMinionPower: minion ? getEffectivePower(core, minion, fromBaseIndex) : undefined,
             triggerMinion: minion,
             destroyerId,
             reason: de.payload.reason,
@@ -995,6 +997,7 @@ export function processDestroyTriggers(
                 baseIndex: fromBaseIndex,
                 triggerMinionUid: minionUid,
                 triggerMinionDefId: minionDefId,
+                triggerMinionPower: minion ? getEffectivePower(core, minion, fromBaseIndex) : undefined,
                 triggerMinion: minion,
                 destroyerId,
                 reason: de.payload.reason,


### PR DESCRIPTION
## Summary
- preserve the effective power snapshot when minions leave play during scoring or destruction
- make Bushi POD award 1 VP when it reaches 5+ power before entering the discard pile
- add a scoring regression test covering the POD scenario

## Validation
- npm run i18n:check
- node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/baseScoring.test.ts --configLoader native

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Samurai minion power retention during base scoring to ensure accurate victory point awards.
  * Enhanced minion power tracking during base destruction events for improved game state accuracy.

* **Tests**
  * Added test coverage for Samurai minion behavior during base scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->