### PR TITLE
Fix online AI timeout auto-end turn fallback

### DIFF
--- a/src/components/lobby/__tests__/GameDetailsModalJoinConfirm.test.ts
+++ b/src/components/lobby/__tests__/GameDetailsModalJoinConfirm.test.ts
@@ -608,8 +608,8 @@ describe('AI seat controller helpers', () => {
 
     it('AI controller 默认使用统一最小时长，并支持自定义覆盖', () => {
         expect(resolveAiMinimumActionDelayMs({ type: 'human' })).toBe(0);
-        expect(resolveAiMinimumActionDelayMs({ type: 'local-ai' })).toBe(200);
-        expect(resolveAiMinimumActionDelayMs({ type: 'remote-ai', providerId: 'astrbot' })).toBe(200);
+        expect(resolveAiMinimumActionDelayMs({ type: 'local-ai' })).toBe(400);
+        expect(resolveAiMinimumActionDelayMs({ type: 'remote-ai', providerId: 'astrbot' })).toBe(400);
         expect(resolveAiMinimumActionDelayMs({ type: 'local-ai', minimumActionDelayMs: 950 })).toBe(950);
     });
 

--- a/src/pages/__tests__/matchSeatValidation.test.ts
+++ b/src/pages/__tests__/matchSeatValidation.test.ts
@@ -1167,8 +1167,8 @@ describe('resolveForceEndTurnForStalledAi', () => {
         ]);
     });
 
-    it('无交互阻塞但轮到 AI 时，应直接 ADVANCE_PHASE', () => {
-        const candidate = resolveForceEndTurnForStalledAi({
+    it('仅凭轮到 AI 且共享态 8 秒未变化，不应直接强制 ADVANCE_PHASE', () => {
+        expect(resolveForceEndTurnForStalledAi({
             sharedState: {
                 core: {
                     activePlayerId: '1',
@@ -1189,12 +1189,7 @@ describe('resolveForceEndTurnForStalledAi', () => {
                 '1': { type: 'local-ai' },
             },
             seatStates: {},
-        });
-
-        expect(candidate?.reason).toBe('active-turn');
-        expect(candidate?.resolution.action.commands).toEqual([
-            { type: 'ADVANCE_PHASE', payload: {} },
-        ]);
+        })).toBeNull();
     });
 });
 

--- a/src/pages/onlineAiForceSkip.ts
+++ b/src/pages/onlineAiForceSkip.ts
@@ -30,7 +30,7 @@ export type ForceSkippableHiddenAiInteraction = {
 
 export type ForceEndTurnStalledAiResolution = {
     playerId: string;
-    reason: 'hidden-interaction' | 'visible-interaction' | 'response-window' | 'active-turn';
+    reason: 'hidden-interaction' | 'visible-interaction' | 'response-window';
     resolution: AiResolution;
 };
 
@@ -61,22 +61,6 @@ function buildAiBatchId(playerId: string, attemptKey: string): string {
     return `ai-${playerId}-${normalizedAttemptKey}`;
 }
 
-function resolveCurrentPlayerId(sharedState: MatchState<unknown> | null | undefined): string | null {
-    const core = sharedState?.core as {
-        activePlayerId?: unknown;
-        currentPlayer?: unknown;
-        turnOrder?: unknown;
-        currentPlayerIndex?: unknown;
-    } | undefined;
-    if (!core) return null;
-    if (typeof core.activePlayerId === 'string') return core.activePlayerId;
-    if (typeof core.currentPlayer === 'string') return core.currentPlayer;
-    if (Array.isArray(core.turnOrder) && typeof core.currentPlayerIndex === 'number') {
-        const current = core.turnOrder[core.currentPlayerIndex];
-        return typeof current === 'string' ? current : null;
-    }
-    return null;
-}
 
 function buildForceEndTurnResolution(args: {
     playerId: string;

--- a/src/pages/onlineAiForceSkip.ts
+++ b/src/pages/onlineAiForceSkip.ts
@@ -294,20 +294,6 @@ export function resolveForceEndTurnForStalledAi(args: {
             }),
         };
     }
-
-    const currentPlayerId = resolveCurrentPlayerId(args.sharedState);
-    if (currentPlayerId && args.seatControllers[currentPlayerId]?.type !== 'human') {
-        return {
-            playerId: currentPlayerId,
-            reason: 'active-turn',
-            resolution: buildForceEndTurnResolution({
-                playerId: currentPlayerId,
-                suffix: `active-turn:${currentPlayerId}`,
-                commands: [{ type: 'ADVANCE_PHASE', payload: {} }],
-            }),
-        };
-    }
-
     return null;
 }
 


### PR DESCRIPTION
## Summary
- remove the stale online AI recovery fallback that force-advanced phase solely because the shared state looked idle on an AI turn
- keep the forced recovery path limited to explicit stalled interaction or response-window cases
- update the seat validation regression test to assert this scenario now stays idle instead of auto-ending the turn

## Validation
- npm run test -- src/pages/__tests__/matchSeatValidation.test.ts
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI turn handling to avoid incorrectly forcing turn advancement when only AI activity is present, reducing stalled-game interruptions.
* **Chores**
  * Increased the default minimum action delay for AI opponents (affects local and specified remote AI) to provide smoother, more natural pacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->