### PR TITLE
fix(smashup): correct Priest of Anubis self buff

### DIFF
--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -1042,6 +1042,30 @@ describe('ancient_egyptians audit regressions', () => {
         expect(getEffectivePower(withOwnBuried, ownPriest, 0)).toBe(6);
     });
 
+    it('Priest of Anubis does not buff other minions on the base, and each Priest only gets its own +2', () => {
+        const priestA = makeMinion('priest-a', 'ancient_egyptians_priest_of_anubis', '0', 4, { powerModifier: 0 });
+        const priestB = makeMinion('priest-b', 'ancient_egyptians_priest_of_anubis', '0', 4, { powerModifier: 0 });
+        const ally = makeMinion('ally', 'ghost_apparition', '0', 3, { powerModifier: 0 });
+        const enemy = makeMinion('enemy', 'robot_warbot', '1', 5, { powerModifier: 0 });
+        const state = makeState({
+            bases: [makeBase({
+                minions: [priestA, priestB, ally, enemy],
+                buriedCards: [{
+                    uid: 'own-buried-shared',
+                    defId: 'robot_microbot_alpha',
+                    trueOwnerId: '0',
+                    controllerId: '0',
+                    buriedFrom: 'hand',
+                }],
+            })],
+        });
+
+        expect(getEffectivePower(state, priestA, 0)).toBe(6);
+        expect(getEffectivePower(state, priestB, 0)).toBe(6);
+        expect(getEffectivePower(state, ally, 0)).toBe(3);
+        expect(getEffectivePower(state, enemy, 0)).toBe(5);
+    });
+
     it('Priest of Anubis POD 也只在你有埋葬牌时获得 +2 力量', () => {
         const priest = makeMinion('priest-pod', 'ancient_egyptians_priest_of_anubis_pod', '0', 4, { powerModifier: 0 });
         const withOpponentBuried = makeState({

--- a/src/games/smashup/abilities/ongoing_modifiers.ts
+++ b/src/games/smashup/abilities/ongoing_modifiers.ts
@@ -250,13 +250,10 @@ function registerVampireModifiers(): void {
 function registerAncientEgyptiansModifiers(): void {
     // ��Ŭ��˹��˾������˻�����������Ƶ������ƣ����ڴ˻��ص��������+2����
     registerPowerModifier('ancient_egyptians_priest_of_anubis', (ctx: PowerModifierContext) => {
-        const alliedPriests = ctx.base.minions.filter(
-            m => matchesDefId(m, 'ancient_egyptians_priest_of_anubis') && m.controller === ctx.minion.controller,
-        );
-        if (alliedPriests.length === 0) return 0;
+        if (!matchesDefId(ctx.minion, 'ancient_egyptians_priest_of_anubis')) return 0;
         const hasOwnedBuried = (ctx.base.buriedCards ?? []).some(card => card.controllerId === ctx.minion.controller);
         if (!hasOwnedBuried) return 0;
-        return alliedPriests.length * 2;
+        return 2;
     }, { handlesPodInternally: true });
 
     registerOngoingPowerModifier('ancient_egyptians_ancient_curse', 'minion', 'self', -2);


### PR DESCRIPTION
﻿## Summary
- make Priest of Anubis only buff itself when its controller has a buried card here
- add a regression test proving other minions on the base do not receive the bonus

## Verification
- `npm run i18n:check`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/newOngoingAbilities.test.ts -t "Priest of Anubis" --configLoader native --environment node`
