### PR TITLE
smashup: fix deck reorder card previews

### DIFF
--- a/src/games/smashup/__tests__/newFactionAbilities.test.ts
+++ b/src/games/smashup/__tests__/newFactionAbilities.test.ts
@@ -407,6 +407,13 @@ describe('Vikings abilities', () => {
             defaultTestRandom,
         );
 
+        const initialOrderPrompt = getInteractionsFromMS(afterPlayer.finalState)[0] as any;
+        expect(initialOrderPrompt?.data?.sourceId).toBe('vikings_cast_the_runes_order');
+        expect(initialOrderPrompt.data.options.map((entry: any) => entry.value)).toEqual(expect.arrayContaining([
+            expect.objectContaining({ topCardUid: 'top-a', cardUid: 'top-a', defId: 'robot_microbot_beta' }),
+            expect.objectContaining({ topCardUid: 'top-b', cardUid: 'top-b', defId: 'wizard_summon' }),
+        ]));
+
         const refreshedState = refreshInteractionOptions({
             ...afterPlayer.finalState,
             core: {
@@ -1321,6 +1328,10 @@ describe('Cowboys abilities', () => {
 
         const orderPrompt = getInteractionsFromMS(afterChoice.finalState)[0] as any;
         expect(orderPrompt?.data?.sourceId).toBe('cowboys_gold_in_them_thar_hills_order');
+        expect(orderPrompt.data.options.map((entry: any) => entry.value)).toEqual(expect.arrayContaining([
+            expect.objectContaining({ topCardUid: 'top-a', cardUid: 'top-a', defId: 'robot_microbot_alpha' }),
+            expect.objectContaining({ topCardUid: 'top-c', cardUid: 'top-c', defId: 'robot_microbot_beta' }),
+        ]));
         const chooseTopC = orderPrompt.data.options.find((entry: any) => entry.value?.topCardUid === 'top-c');
         const afterOrder = runCommand(
             afterChoice.finalState,

--- a/src/games/smashup/__tests__/ui-interaction-manual.test.ts
+++ b/src/games/smashup/__tests__/ui-interaction-manual.test.ts
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, act } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { GameTestRunner } from '../../../engine/testing';
 import { SmashUpDomain } from '../domain';
@@ -200,6 +200,44 @@ describe('SmashUp UI 交互验证', () => {
             type: 'renderer',
             rendererId: 'smashup-card-renderer',
             payload: { defId: 'zombie_lord_pod' },
+        });
+    });
+
+    it('PromptOverlay 的排序卡牌选项只要带 defId，就应显示对应卡面而不是占位块', async () => {
+        const interaction = createSimpleChoice(
+            'deck-order-preview-check',
+            '0',
+            '选择放回牌库顶的顺序',
+            [
+                {
+                    id: 'card-0',
+                    label: '召唤',
+                    value: { topCardUid: 'top-b', cardUid: 'top-b', defId: 'wizard_summon' },
+                    displayMode: 'card' as const,
+                },
+            ],
+            { sourceId: 'vikings_cast_the_runes_order', targetType: 'generic' },
+        );
+
+        await act(async () => {
+            render(
+                React.createElement(
+                    ToastProvider,
+                    null,
+                    React.createElement(PromptOverlay, {
+                        interaction,
+                        dispatch: () => undefined,
+                        playerID: '0',
+                    }),
+                ),
+            );
+        });
+
+        const preview = screen.getByTestId('mock-card-preview');
+        expect(JSON.parse(preview.getAttribute('data-preview-ref') ?? 'null')).toEqual({
+            type: 'renderer',
+            rendererId: 'smashup-card-renderer',
+            payload: { defId: 'wizard_summon' },
         });
     });
 

--- a/src/games/smashup/abilities/cowboys.ts
+++ b/src/games/smashup/abilities/cowboys.ts
@@ -61,7 +61,7 @@ type StagecoachDestinationContinuation = {
 };
 type GoldChoice = { cardUid: string; defId: string };
 type GoldModeChoice = { mode: 'hand' | 'play' };
-type GoldOrderChoice = { topCardUid: string };
+type GoldOrderChoice = { topCardUid: string; cardUid?: string; defId?: string };
 type GoldPromptContext = {
     chosenCard: CardInstance;
     remainingCards: CardInstance[];
@@ -105,7 +105,7 @@ function buildGoldOrderOptions(
         .map((card, index) => ({
             id: `gold-order-${index}`,
             label: getCardDef(card.defId)?.name ?? card.defId,
-            value: { topCardUid: card.uid },
+            value: { topCardUid: card.uid, cardUid: card.uid, defId: card.defId },
             _source: 'static' as const,
             displayMode: 'card' as const,
         }));

--- a/src/games/smashup/abilities/vikings.ts
+++ b/src/games/smashup/abilities/vikings.ts
@@ -40,7 +40,7 @@ import { reduce } from '../domain/reduce';
 type PlayerChoice = { targetPlayerId: PlayerId };
 type HandChoice = { cardUid: string; defId: string };
 type MinionChoice = { minionUid: string; baseIndex: number };
-type CastRunesChoice = { topCardUid: string };
+type CastRunesChoice = { topCardUid: string; cardUid?: string; defId?: string };
 type RaidingPartyChoice = { cardUid: string; ownerId: PlayerId; defId: string; type: 'action' | 'minion' } | { skip: true };
 
 function getCurrentDeckTopSnapshotCards<T extends { uid: string; defId: string }>(
@@ -59,7 +59,7 @@ function buildCastTheRunesOrderOptions(
     return getCurrentDeckTopSnapshotCards(state, targetPlayerId, revealedCards).map((card, index) => ({
         id: `card-${index}`,
         label: getCardDef(card.defId)?.name ?? card.defId,
-        value: { topCardUid: card.uid },
+        value: { topCardUid: card.uid, cardUid: card.uid, defId: card.defId },
         _source: 'static' as const,
         displayMode: 'card' as const,
     }));


### PR DESCRIPTION
## Summary
- include card identity data in Smash Up deck reorder prompt options so PromptOverlay can render the real card preview
- cover both Vikings Cast the Runes and Cowboys Gold in Them Thar Hills reorder prompts
- add ability-level and PromptOverlay regression tests for reorder card previews

## Validation
- npm run i18n:check
- npm run test:smashup -- src/games/smashup/__tests__/newFactionAbilities.test.ts -t "vikings_cast_the_runes_order|cowboys_gold_in_them_thar_hills 可把所选牌抓到手里"
- npm run test:smashup -- src/games/smashup/__tests__/ui-interaction-manual.test.ts -t "PromptOverlay 的排序卡牌选项只要带 defId"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation of card interaction prompts for game abilities
  * Added test coverage for card preview rendering in order selection

* **Improvements**
  * Improved card information handling in order prompts to support better preview functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->