### PR TITLE
修复枪手决斗被野生保护区误拦截

### DIFF
--- a/src/games/smashup/__tests__/wildlifePreserveProtection.test.ts
+++ b/src/games/smashup/__tests__/wildlifePreserveProtection.test.ts
@@ -15,8 +15,9 @@ import { clearRegistry } from '../domain/abilityRegistry';
 import { clearBaseAbilityRegistry } from '../domain/baseAbilities';
 import { clearOngoingEffectRegistry, isMinionProtected } from '../domain/ongoingEffects';
 import { clearInteractionHandlers } from '../domain/abilityInteractionHandlers';
+import { startDuel } from '../domain/duel';
 import { runCommand } from './testRunner';
-import { makeMinion, makePlayer, makeState, makeMatchState, makeCard } from './helpers';
+import { findInteractionOption, makeMinion, makePlayer, makeState, makeMatchState, makeCard, resolveInteractionChain } from './helpers';
 import type { BaseInPlay, OngoingActionOnBase } from '../domain/types';
 import { SU_EVENTS, SU_COMMANDS } from '../domain/types';
 import { SMASHUP_FACTION_IDS } from '../domain/ids';
@@ -218,5 +219,48 @@ describe('wildlife_preserve: 交互解决路径中阻止行动卡效果', () => 
         const finalBase = respondResult.finalState.core.bases[0];
         const targetMinion = finalBase.minions.find(m => m.uid === 'target_m');
         expect(targetMinion).toBeUndefined(); // 随从已被消灭
+    });
+
+    it('wildlife_preserve 不应阻止枪手决斗消灭失败的敌方随从', () => {
+        const base = makeBase('test_base', {
+            minions: [
+                makeMinion('gun-1', 'cowboys_gunfighter', '0', 3, { powerModifier: 4 }),
+                makeMinion('enemy-1', 'alien_collector', '1', 2, { powerModifier: 1 }),
+            ],
+            ongoingActions: [makeOngoing('wp1', 'dino_wildlife_preserve', '1')],
+        });
+        const started = startDuel(makeMatchState(makeState({
+            bases: [base],
+            players: {
+                '0': makePlayer('0', {
+                    factions: [SMASHUP_FACTION_IDS.COWBOYS, SMASHUP_FACTION_IDS.WIZARDS],
+                }),
+                '1': makePlayer('1', {
+                    factions: [SMASHUP_FACTION_IDS.DINOSAURS, SMASHUP_FACTION_IDS.ALIENS],
+                }),
+            },
+        })), {
+            sourceId: 'cowboys_gunfighter',
+            sourcePlayerId: '0',
+            challengerMinionUid: 'gun-1',
+            challengedMinionUid: 'enemy-1',
+            outcome: 'destroy_loser',
+            destroyReason: 'cowboys_gunfighter',
+        }, 1000);
+
+        const resolved = resolveInteractionChain(started, (prompt) => {
+            const skip = findInteractionOption(prompt, option => option?.value?.skip === true);
+            if (!skip) {
+                throw new Error(`未找到可跳过的决斗选项: ${prompt?.data?.sourceId ?? 'unknown'}`);
+            }
+            return { optionId: skip.id };
+        });
+
+        const destroyEvents = resolved.events.filter(
+            event => event.type === SU_EVENTS.MINION_DESTROYED && (event as any).payload?.minionUid === 'enemy-1',
+        );
+        expect(destroyEvents).toHaveLength(1);
+        expect(resolved.finalState.core.bases[0].minions.some(m => m.uid === 'enemy-1')).toBe(false);
+        expect(resolved.finalState.core.bases[0].minions.some(m => m.uid === 'gun-1')).toBe(true);
     });
 });

--- a/src/games/smashup/domain/abilityHelpers.ts
+++ b/src/games/smashup/domain/abilityHelpers.ts
@@ -120,11 +120,12 @@ export function destroyMinion(
     ownerId: PlayerId,
     destroyerId: PlayerId | undefined,
     reason: string,
-    now: number
+    now: number,
+    sourceKind?: 'action' | 'nonAction',
 ): MinionDestroyedEvent {
     return {
         type: SU_EVENTS.MINION_DESTROYED,
-        payload: { minionUid, minionDefId, fromBaseIndex, ownerId, destroyerId, reason },
+        payload: { minionUid, minionDefId, fromBaseIndex, ownerId, destroyerId, reason, sourceKind } as MinionDestroyedEvent['payload'],
         timestamp: now,
     };
 }
@@ -370,6 +371,7 @@ export function buildValidatedDestroyEvents(
         destroyerId?: PlayerId;
         reason: string;
         now: number;
+        sourceKind?: 'action' | 'nonAction';
     },
 ): MinionDestroyedEvent[] {
     const minion = findMinionOnBase(state, params.fromBaseIndex, params.minionUid);
@@ -384,6 +386,7 @@ export function buildValidatedDestroyEvents(
             params.destroyerId,
             params.reason,
             params.now,
+            params.sourceKind,
         ),
     ];
 }

--- a/src/games/smashup/domain/duel.ts
+++ b/src/games/smashup/domain/duel.ts
@@ -650,6 +650,8 @@ function resolveDuelResult(
     const loser = winner?.uid === challengerFound.minion.uid ? challengedFound.minion : winner?.uid === challengedFound.minion.uid ? challengerFound.minion : undefined;
     const events: SmashUpEvent[] = [];
     let nextState = withActiveDuel(state, undefined);
+    const destroySourceId = duel.destroyReason ?? duel.sourceId;
+    const destroySourceKind = getCardDef(destroySourceId)?.type === 'action' ? 'action' : 'nonAction';
 
     if (duel.outcome === 'destroy_loser') {
         if (isTie) {
@@ -658,16 +660,18 @@ function resolveDuelResult(
                 minionDefId: challengerFound.minion.defId,
                 fromBaseIndex: baseIndex,
                 destroyerId: duel.sourcePlayerId,
-                reason: duel.destroyReason ?? duel.sourceId,
+                reason: destroySourceId,
                 now,
+                sourceKind: destroySourceKind,
             }));
             events.push(...buildValidatedDestroyEvents(state, {
                 minionUid: challengedFound.minion.uid,
                 minionDefId: challengedFound.minion.defId,
                 fromBaseIndex: baseIndex,
                 destroyerId: duel.sourcePlayerId,
-                reason: duel.destroyReason ?? duel.sourceId,
+                reason: destroySourceId,
                 now,
+                sourceKind: destroySourceKind,
             }));
         } else if (loser) {
             events.push(...buildValidatedDestroyEvents(state, {
@@ -675,8 +679,9 @@ function resolveDuelResult(
                 minionDefId: loser.defId,
                 fromBaseIndex: baseIndex,
                 destroyerId: duel.sourcePlayerId,
-                reason: duel.destroyReason ?? duel.sourceId,
+                reason: destroySourceId,
                 now,
+                sourceKind: destroySourceKind,
             }));
         }
     } else if (duel.outcome === 'vp_to_winner') {

--- a/src/games/smashup/domain/reducer.ts
+++ b/src/games/smashup/domain/reducer.ts
@@ -790,10 +790,13 @@ export function filterProtectedDestroyEvents(
         // 对于 reason='base_*' 的事件，把 source 视为“目标自己”，从而不会触发
         // “只有对手才会被拦截”的保护（如 deep_roots / elder_thing 等）。
         const effectiveSource = de.payload.reason?.startsWith('base_') ? minion.controller : rawSource;
+        const sourceKind = (de.payload as { sourceKind?: 'action' | 'nonAction' }).sourceKind;
         // 检查 destroy 保护和 action 保护
         if (isMinionProtected(core, minion, fromBaseIndex, effectiveSource, 'destroy')) continue;
         // 检查 'action' 和 'affect' 两种广义保护类型（tooth_and_claw 注册为 'affect'）
-        const actionProtected = isMinionProtected(core, minion, fromBaseIndex, effectiveSource, 'action');
+        const actionProtected = sourceKind === 'nonAction'
+            ? false
+            : isMinionProtected(core, minion, fromBaseIndex, effectiveSource, 'action');
         const affectProtected = isMinionProtected(core, minion, fromBaseIndex, effectiveSource, 'affect');
         if (actionProtected || affectProtected) {
             // 消耗型保护：发射自毁事件


### PR DESCRIPTION
## 说明
- 修复 Gunfighter 决斗结算被 Wildlife Preserve 的 action 保护误拦截的问题
- 仅让显式 action 来源继续受 action 保护影响，随从来源的决斗消灭不再被错误阻止
- 补充 Wildlife Preserve + Gunfighter 的回归测试

## 验证
- npm run i18n:check
- npx vitest run src/games/smashup/__tests__/wildlifePreserveProtection.test.ts
- pre-push changed-quality-gate（含 smashup 测试集）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for wildlife preserve behavior during duel resolution.

* **Bug Fixes**
  * Enhanced destroy event tracking and protection mechanics to ensure accurate game resolution during specific duel outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->