### PR TITLE
Fix Great Wolf Spirit POD titan behavior

### DIFF
--- a/src/games/smashup/__tests__/smashup.smoke.test.ts
+++ b/src/games/smashup/__tests__/smashup.smoke.test.ts
@@ -4319,12 +4319,14 @@ describe('smashup', () => {
             bases: [
                 makeBase({
                     minions: [
-                        makeMinion('wolf-used-1', 'werewolf_teenage_wolf', '0', 2, { talentUsed: true }),
-                        makeMinion('wolf-used-2', 'werewolf_howler', '0', 3, { talentUsed: true }),
+                        makeMinion('wolf-outside', 'werewolf_teenage_wolf', '0', 2, { talentUsed: true }),
                     ],
                 }),
                 makeBase({
-                    minions: [makeMinion('wolf-other', 'werewolf_howler', '0', 3)],
+                    minions: [
+                        makeMinion('wolf-gws-a', 'werewolf_teenage_wolf', '0', 2, { talentUsed: true }),
+                        makeMinion('wolf-gws-b', 'werewolf_teenage_wolf', '0', 2, { talentUsed: true }),
+                    ],
                 }),
             ],
             titans: [{
@@ -4340,30 +4342,44 @@ describe('smashup', () => {
         });
 
         const state = makeMatchState(core);
-        const firstExtraUse: SmashUpCommand = {
+        const sameBaseSecondUse: SmashUpCommand = {
             type: SU_COMMANDS.USE_TALENT,
             playerId: '0',
-            payload: { minionUid: 'wolf-used-1', baseIndex: 0 },
+            payload: { minionUid: 'wolf-gws-a', baseIndex: 1 },
             timestamp: 67,
         };
+        const outsideBaseSecondUse: SmashUpCommand = {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { minionUid: 'wolf-outside', baseIndex: 0 },
+            timestamp: 68,
+        };
 
-        expect(SmashUpDomain.validate(state, firstExtraUse).valid).toBe(true);
-        const events = SmashUpDomain.execute(state, firstExtraUse, FIXED_RANDOM);
+        expect(SmashUpDomain.validate(state, sameBaseSecondUse).valid).toBe(true);
+        expect(SmashUpDomain.validate(state, outsideBaseSecondUse).valid).toBe(false);
+        const events = SmashUpDomain.execute(state, sameBaseSecondUse, FIXED_RANDOM);
         expect(events.map(event => event.type)).toContain(SU_EVENTS.TALENT_USED);
         expect(events.map(event => event.type)).toContain(SU_EVENTS.TEMP_POWER_ADDED);
 
         const resolved = events.reduce((acc, event) => SmashUpDomain.reduce(acc, event), core);
-        expect(resolved.players['0'].extraTalentUsesConsumed).toBe(1);
+        expect(resolved.greatWolfSpiritDoubleTalentCardUids).toContain('wolf-gws-a');
 
-        const secondExtraAttempt = makeMatchState(resolved);
-        const blockedCommand: SmashUpCommand = {
+        const afterFirstSecondUse = makeMatchState(resolved);
+        const otherCardSecondUse: SmashUpCommand = {
             type: SU_COMMANDS.USE_TALENT,
             playerId: '0',
-            payload: { minionUid: 'wolf-used-2', baseIndex: 0 },
-            timestamp: 68,
+            payload: { minionUid: 'wolf-gws-b', baseIndex: 1 },
+            timestamp: 69,
+        };
+        const thirdUseAttempt: SmashUpCommand = {
+            type: SU_COMMANDS.USE_TALENT,
+            playerId: '0',
+            payload: { minionUid: 'wolf-gws-a', baseIndex: 1 },
+            timestamp: 70,
         };
 
-        expect(SmashUpDomain.validate(secondExtraAttempt, blockedCommand).valid).toBe(false);
+        expect(SmashUpDomain.validate(afterFirstSecondUse, otherCardSecondUse).valid).toBe(true);
+        expect(SmashUpDomain.validate(afterFirstSecondUse, thirdUseAttempt).valid).toBe(false);
     });
 
     it('巨狼之灵天赋会创建己方随从目标选择，并让目标直到回合结束获得 +1 战力', () => {
@@ -5136,5 +5152,76 @@ describe('smashup', () => {
         expect(finalPecos?.location).toMatchObject({ zone: 'base', baseIndex: 0 });
         expect(finalPecos?.metadata?.deferClashUntilDuelEnds).toBe(false);
         expect(finalArcane?.location.zone).toBe('setaside');
+    });
+    /*
+
+    it('宸ㄧ嫾涔嬬伒浼氬湪浣犵殑鍥炲悎寮€濮嬫椂鍒涘缓绉诲姩浜や簰锛屽苟鍙兘绉诲姩鍒颁綘涓ユ牸棰嗗厛鐨勫熀鍦?, () => {
+    */
+    it('Great Wolf Spirit creates a start-of-turn move interaction and only offers bases where you are strictly ahead', () => {
+        const core = makeState({
+            bases: [
+                makeBase({
+                    minions: [
+                        makeMinion('wolf-home', 'werewolf_teenage_wolf', '0', 3),
+                        makeMinion('enemy-home', 'ghosts_spectre', '1', 1),
+                    ],
+                }),
+                makeBase({
+                    minions: [
+                        makeMinion('wolf-destination', 'werewolf_howler', '0', 4),
+                        makeMinion('enemy-destination', 'ghosts_spectre', '1', 2),
+                    ],
+                }),
+                makeBase({
+                    minions: [
+                        makeMinion('wolf-tied', 'werewolf_howler', '0', 2),
+                        makeMinion('enemy-tied', 'ghosts_spectre', '1', 2),
+                    ],
+                }),
+            ],
+            titans: [{
+                uid: 't-gws',
+                defId: 'werewolves_great_wolf_spirit',
+                faction: SMASHUP_FACTION_IDS.WEREWOLVES,
+                ownerId: '0',
+                controllerId: '0',
+                powerCounters: 0,
+                talentUsed: false,
+                location: { zone: 'base', baseIndex: 0, enteredAt: 1 },
+            } satisfies TitanState],
+        });
+
+        const triggerResult = fireTriggers(core, 'onTurnStart', {
+            state: core,
+            matchState: makeMatchState(core, 'startTurn', '0'),
+            playerId: '0',
+            random: FIXED_RANDOM,
+            now: 71,
+        });
+
+        const currentInteraction = triggerResult.matchState?.sys.interaction?.current;
+        expect(currentInteraction?.data?.sourceId).toBe('titan_werewolves_great_wolf_spirit_move');
+        expect(currentInteraction?.data?.options.some((option: any) => option.value?.skip === true)).toBe(true);
+        expect(currentInteraction?.data?.options.some((option: any) => option.value?.baseIndex === 1)).toBe(true);
+        expect(currentInteraction?.data?.options.some((option: any) => option.value?.baseIndex === 2)).toBe(false);
+
+        const handler = getInteractionHandler('titan_werewolves_great_wolf_spirit_move');
+        expect(handler).toBeDefined();
+
+        const resolved = handler!(
+            triggerResult.matchState!,
+            '0',
+            { baseIndex: 1, baseDefId: core.bases[1].defId },
+            currentInteraction?.data as any,
+            FIXED_RANDOM,
+            72,
+        );
+        expect(resolved.events.map(event => event.type)).toEqual([SU_EVENTS.TITAN_MOVED]);
+
+        const moved = resolved.events.reduce((acc, event) => SmashUpDomain.reduce(acc, event), core);
+        expect(moved.titans?.find(candidate => candidate.uid === 't-gws')?.location).toMatchObject({
+            zone: 'base',
+            baseIndex: 1,
+        });
     });
 });

--- a/src/games/smashup/abilities/titans.ts
+++ b/src/games/smashup/abilities/titans.ts
@@ -1682,6 +1682,29 @@ function getGreatWolfSpiritTalentTargets(state: AbilityContext['state'], playerI
     );
 }
 
+function getGreatWolfSpiritMoveOptions(
+    state: AbilityContext['state'],
+    playerId: string,
+    currentBaseIndex: number,
+) {
+    return state.bases
+        .map((base, baseIndex) => {
+            if (baseIndex === currentBaseIndex) return null;
+            const myPower = getPlayerEffectivePowerOnBase(state, base, baseIndex, playerId);
+            if (myPower <= 0) return null;
+            const hasStrictlyMostPower = Object.keys(state.players).every(pid => {
+                if (pid === playerId) return true;
+                return getPlayerEffectivePowerOnBase(state, base, baseIndex, pid) < myPower;
+            });
+            if (!hasStrictlyMostPower) return null;
+            return {
+                baseIndex,
+                label: getBaseDef(base.defId)?.name ?? `Base ${baseIndex + 1}`,
+            };
+        })
+        .filter((value): value is { baseIndex: number; label: string } => value !== null);
+}
+
 function werewolvesGreatWolfSpiritSpecial(ctx: AbilityContext): AbilityResult {
     const eligibleBases = getGreatWolfSpiritEligibleBases(ctx.state, ctx.playerId);
     if (eligibleBases.length < 2) return { events: [] };
@@ -1704,6 +1727,41 @@ function werewolvesGreatWolfSpiritTalent(ctx: AbilityContext): AbilityResult {
         buildMinionTargetOptions(targets, { state: ctx.state, sourcePlayerId: ctx.playerId, sourceDefId: ctx.defId, effectType: 'buff' }),
         { sourceId: 'titan_werewolves_great_wolf_spirit_talent', targetType: 'minion' },
     );
+
+    return {
+        events: [],
+        matchState: queueInteraction(ctx.matchState, interaction),
+    };
+}
+
+function werewolvesGreatWolfSpiritOnTurnStart(ctx: TriggerContext): TriggerResult | SmashUpEvent[] {
+    if (!ctx.matchState) return [];
+
+    const titan = (ctx.state.titans ?? []).find(candidate =>
+        candidate.defId === 'werewolves_great_wolf_spirit'
+        && candidate.controllerId === ctx.playerId
+        && candidate.location.zone === 'base',
+    );
+    if (!titan || titan.location.zone !== 'base') return [];
+
+    const baseOptions = getGreatWolfSpiritMoveOptions(ctx.state, ctx.playerId, titan.location.baseIndex);
+    if (baseOptions.length === 0) return [];
+
+    const interaction = createSimpleChoice(
+        `titan_werewolves_great_wolf_spirit_move_${ctx.now}`,
+        ctx.playerId,
+        '巨狼之灵：你可以将此泰坦移动到一个你战力高于任何其他玩家的基地',
+        [
+            ...buildBaseTargetOptions(baseOptions, ctx.state),
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
+        ],
+        { sourceId: 'titan_werewolves_great_wolf_spirit_move', targetType: 'base', autoResolveIfSingle: false },
+    );
+    (interaction.data as { continuationContext?: unknown }).continuationContext = {
+        titanUid: titan.uid,
+        titanDefId: titan.defId,
+        fromBaseIndex: titan.location.baseIndex,
+    };
 
     return {
         events: [],
@@ -2575,6 +2633,7 @@ export function registerTitanAbilities(): void {
             : '此基地不满足巨狼之灵的进场条件';
     });
     registerAbility('werewolves_great_wolf_spirit', 'talent', werewolvesGreatWolfSpiritTalent);
+    registerTrigger('werewolves_great_wolf_spirit', 'onTurnStart', werewolvesGreatWolfSpiritOnTurnStart, { global: true, optional: true });
     registerTitanTalentValidator('werewolves_great_wolf_spirit', ({ state, titan, playerId }) => {
         if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getGreatWolfSpiritTalentTargets(state, playerId).length > 0
@@ -4188,6 +4247,39 @@ export function registerTitanInteractionHandlers(): void {
                     1,
                     'werewolves_great_wolf_spirit_talent',
                     timestamp,
+                ),
+            ],
+        };
+    });
+
+    registerInteractionHandler('titan_werewolves_great_wolf_spirit_move', (state, _playerId, value, data, _random, timestamp) => {
+        const selected = value as { skip?: boolean; baseIndex?: number; baseDefId?: string } | undefined;
+        const continuation = (data as {
+            continuationContext?: { titanUid?: string; titanDefId?: string; fromBaseIndex?: number };
+        } | undefined)?.continuationContext;
+        if (selected?.skip) {
+            return { state, events: [] };
+        }
+        if (
+            selected?.baseIndex === undefined
+            || !continuation?.titanUid
+            || !continuation.titanDefId
+            || continuation.fromBaseIndex === undefined
+        ) {
+            return { state, events: [] };
+        }
+
+        return {
+            state,
+            events: [
+                moveTitan(
+                    continuation.titanUid,
+                    continuation.titanDefId,
+                    continuation.fromBaseIndex,
+                    selected.baseIndex,
+                    'werewolves_great_wolf_spirit_move',
+                    timestamp,
+                    selected.baseDefId,
                 ),
             ],
         };

--- a/src/games/smashup/domain/commands.ts
+++ b/src/games/smashup/domain/commands.ts
@@ -138,17 +138,32 @@ function getRemainingExtraTalentUses(core: SmashUpCore, playerId: string): numbe
     const player = core.players[playerId];
     if (!player) return 0;
 
-    let allowance = 0;
-    const hasGreatWolfSpirit = (core.titans ?? []).some(titan =>
-        titan.defId === 'werewolves_great_wolf_spirit'
-        && titan.location.zone === 'base'
-        && titan.controllerId === playerId,
-    );
-    if (hasGreatWolfSpirit) {
-        allowance += 1;
-    }
-
+    const allowance = 0;
     return Math.max(0, allowance - (player.extraTalentUsesConsumed ?? 0));
+}
+
+function getGreatWolfSpiritBaseIndex(core: SmashUpCore, playerId: string): number | undefined {
+    const titan = (core.titans ?? []).find(candidate =>
+        candidate.defId === 'werewolves_great_wolf_spirit'
+        && candidate.location.zone === 'base'
+        && candidate.controllerId === playerId
+        && !(core.titanOngoingSuppressedUntilTurnEnd ?? []).includes(candidate.uid),
+    );
+    return titan?.location.zone === 'base' ? titan.location.baseIndex : undefined;
+}
+
+function canUseGreatWolfSpiritSecondTalent(
+    core: SmashUpCore,
+    playerId: string,
+    baseIndex: number,
+    cardUid: string,
+): boolean {
+    if (!isCurrentTurnPlayer(core, playerId)) return false;
+    const greatWolfSpiritBaseIndex = getGreatWolfSpiritBaseIndex(core, playerId);
+    if (greatWolfSpiritBaseIndex === undefined || greatWolfSpiritBaseIndex !== baseIndex) {
+        return false;
+    }
+    return !(core.greatWolfSpiritDoubleTalentCardUids ?? []).includes(cardUid);
 }
 
 function findAttachedTalentHostMinion(
@@ -756,7 +771,13 @@ export function validate(
                         targetBase.defId === 'base_standing_stones'
                         && hostMinion?.controller === command.playerId
                         && !core.standingStonesDoubleTalentMinionUid;
-                    if (!canUseStandingStonesDoubleTalent && getRemainingExtraTalentUses(core, command.playerId) <= 0) {
+                    const canUseGreatWolfSpiritDoubleTalent =
+                        canUseGreatWolfSpiritSecondTalent(core, command.playerId, baseIndex, ongoingCardUid);
+                    if (
+                        !canUseStandingStonesDoubleTalent
+                        && !canUseGreatWolfSpiritDoubleTalent
+                        && getRemainingExtraTalentUses(core, command.playerId) <= 0
+                    ) {
                         return { valid: false, error: '本回合天赋已使用' };
                     }
                 }
@@ -780,7 +801,12 @@ export function validate(
                     return { valid: false, error: '只能使用自己控制的泰坦的天赋' };
                 }
                 if (titan.talentUsed) {
-                    if (getRemainingExtraTalentUses(core, command.playerId) <= 0) {
+                    const canUseGreatWolfSpiritDoubleTalent =
+                        canUseGreatWolfSpiritSecondTalent(core, command.playerId, baseIndex, titanUid);
+                    if (
+                        !canUseGreatWolfSpiritDoubleTalent
+                        && getRemainingExtraTalentUses(core, command.playerId) <= 0
+                    ) {
                         return { valid: false, error: '本回合天赋已使用' };
                     }
                 }
@@ -812,8 +838,14 @@ export function validate(
                 // 巨石阵例外：允许一个随从每回合使用才能两次
                 const isStandingStones = targetBase.defId === 'base_standing_stones';
                 const doubleTalentAvailable = !core.standingStonesDoubleTalentMinionUid;
+                const greatWolfSpiritDoubleTalentAvailable =
+                    canUseGreatWolfSpiritSecondTalent(core, command.playerId, baseIndex, minionUid);
                 const extraTalentAvailable = getRemainingExtraTalentUses(core, command.playerId) > 0;
-                if (!(isStandingStones && doubleTalentAvailable) && !extraTalentAvailable) {
+                if (
+                    !(isStandingStones && doubleTalentAvailable)
+                    && !greatWolfSpiritDoubleTalentAvailable
+                    && !extraTalentAvailable
+                ) {
                     return { valid: false, error: '本回合天赋已使用' };
                 }
             }

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -1312,6 +1312,7 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 specialLimitUsed: undefined,
                 // 清空巨石阵双才能追踪
                 standingStonesDoubleTalentMinionUid: undefined,
+                greatWolfSpiritDoubleTalentCardUids: undefined,
                 // 清空计分后延迟 special 记录
                 pendingAfterScoringSpecials: undefined,
                 // 清空计分后等待基地替换完成的动作
@@ -2010,13 +2011,37 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
             if (consumedStandingStones) {
                 newStandingStonesUid = standingStonesHostMinionUid ?? minionUid;
             }
+            const talentCardUid = ongoingCardUid ?? titanUid ?? minionUid;
+            const greatWolfSpiritBaseIndex = (state.titans ?? []).find(titan =>
+                titan.defId === 'werewolves_great_wolf_spirit'
+                && titan.location.zone === 'base'
+                && titan.controllerId === playerId
+                && !(state.titanOngoingSuppressedUntilTurnEnd ?? []).includes(titan.uid),
+            )?.location.baseIndex;
+            const consumedGreatWolfSpirit =
+                reusedTalent
+                && !consumedStandingStones
+                && talentCardUid !== undefined
+                && greatWolfSpiritBaseIndex !== undefined
+                && baseIndex === greatWolfSpiritBaseIndex;
+            let newGreatWolfSpiritDoubleTalentCardUids = state.greatWolfSpiritDoubleTalentCardUids;
+            if (
+                consumedGreatWolfSpirit
+                && talentCardUid
+                && !(newGreatWolfSpiritDoubleTalentCardUids ?? []).includes(talentCardUid)
+            ) {
+                newGreatWolfSpiritDoubleTalentCardUids = [
+                    ...(newGreatWolfSpiritDoubleTalentCardUids ?? []),
+                    talentCardUid,
+                ];
+            }
             const newTitans = titanUid
                 ? (state.titans ?? []).map(titan =>
                     titan.uid === titanUid ? { ...titan, talentUsed: true } : titan,
                 )
                 : state.titans;
             const currentPlayer = state.players[playerId];
-            const nextPlayer = reusedTalent && !consumedStandingStones && currentPlayer
+            const nextPlayer = reusedTalent && !consumedStandingStones && !consumedGreatWolfSpirit && currentPlayer
                 ? {
                     ...currentPlayer,
                     extraTalentUsesConsumed: (currentPlayer.extraTalentUsesConsumed ?? 0) + 1,
@@ -2027,6 +2052,7 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
                 bases: newBases,
                 titans: newTitans,
                 standingStonesDoubleTalentMinionUid: newStandingStonesUid,
+                greatWolfSpiritDoubleTalentCardUids: newGreatWolfSpiritDoubleTalentCardUids,
                 players: nextPlayer
                     ? { ...state.players, [playerId]: nextPlayer }
                     : state.players,

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -693,6 +693,7 @@ export interface SmashUpCore {
     specialLimitUsed?: Record<string, number[]>;
     /** 巨石阵：本回合已使用双才能的随从 UID（每回合只有一个随从可用才能两次） */
     standingStonesDoubleTalentMinionUid?: string;
+    greatWolfSpiritDoubleTalentCardUids?: string[];
     /** 计分后触发的 special 延迟记录（回合开始自动清空） */
     pendingAfterScoringSpecials?: PendingAfterScoringSpecial[];
     /** 计分后需等待基地完成清场/替换后再落地的动作 */


### PR DESCRIPTION
## Summary
- scope Great Wolf Spirit's extra second Talent use to cards at its base only
- add the POD start-of-turn move interaction and handler
- update smoke coverage for base-scoped double Talent use and start-of-turn movement

## Validation
- npm run test -- src/games/smashup/__tests__/smashup.smoke.test.ts
- npm run i18n:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Great Wolf Spirit Titan now offers a start-of-turn move interaction, allowing it to relocate to bases where you have superior power.
  * Great Wolf Spirit now enables a second talent use on the same card instead of granting additional talent allowances.

* **Bug Fixes**
  * Corrected talent reuse validation logic to properly align with Great Wolf Spirit's double talent mechanic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->