### PR TITLE
Fix Smash Up Madness return rules

### DIFF
--- a/src/games/smashup/__tests__/madnessDeck.test.ts
+++ b/src/games/smashup/__tests__/madnessDeck.test.ts
@@ -28,6 +28,7 @@ import {
     drawMadnessCards,
     returnMadnessCard,
     countMadnessCards,
+    countMadnessCardsForPlayer,
     madnessVpPenalty,
     hasCthulhuExpansionFaction,
 } from '../domain/abilityHelpers';
@@ -168,7 +169,7 @@ describe('Property 19: 疯狂牌库生命周期', () => {
             const cardUid = afterDraw.players['0'].hand[0].uid;
             const returnEvt = returnMadnessCard('0', cardUid, 'test', 2000);
             const afterReturn = reduce(afterDraw, returnEvt);
-            expect(afterReturn.madnessDeck!.length).toBe(29);
+            expect(afterReturn.madnessDeck!.length).toBe(30);
             expect(afterReturn.players['0'].hand.length).toBe(0);
         });
     });
@@ -187,6 +188,34 @@ describe('Property 19: 疯狂牌库生命周期', () => {
                 discard: [{ ...madnessCard, uid: 'mad3' }, normalCard],
             };
             expect(countMadnessCards(player)).toBe(3);
+        });
+
+        it('countMadnessCardsForPlayer 额外统计埋葬区中的疯狂卡', () => {
+            const core = makeCore({
+                players: {
+                    '0': {
+                        ...makePlayer('0', [SMASHUP_FACTION_IDS.MINIONS_OF_CTHULHU, SMASHUP_FACTION_IDS.ALIENS]),
+                        hand: [{ uid: 'mad1', defId: MADNESS_CARD_DEF_ID, type: 'action', owner: '0' }],
+                        deck: [{ uid: 'mad2', defId: MADNESS_CARD_DEF_ID, type: 'action', owner: '0' }],
+                        discard: [{ uid: 'mad3', defId: MADNESS_CARD_DEF_ID, type: 'action', owner: '0' }],
+                    },
+                    '1': makePlayer('1', [SMASHUP_FACTION_IDS.ELDER_THINGS, SMASHUP_FACTION_IDS.PIRATES]),
+                },
+                bases: [{
+                    defId: 'base_the_jungle',
+                    minions: [],
+                    ongoingActions: [],
+                    buriedCards: [{
+                        uid: 'buried-mad',
+                        defId: MADNESS_CARD_DEF_ID,
+                        trueOwnerId: '0',
+                        controllerId: '0',
+                        buriedFrom: 'hand',
+                    }],
+                }],
+            });
+
+            expect(countMadnessCardsForPlayer(core, '0')).toBe(4);
         });
 
         it('无疯狂卡时计数为 0', () => {

--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -12,7 +12,7 @@
  
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { SmashUpCore, PlayerState, MinionOnBase, BaseInPlay, TempPowerAddedEvent, MinionMovedEvent, MinionDestroyedEvent, MadnessDrawnEvent, MadnessReturnedEvent, CardsDrawnEvent, CardsDiscardedEvent, MinionReturnedEvent, BaseReplacedEvent, CardToDeckBottomEvent, CardInstance, LimitModifiedEvent, TurnStartedEvent } from '../domain/types';
+import type { SmashUpCore, PlayerState, MinionOnBase, BaseInPlay, TempPowerAddedEvent, MinionMovedEvent, MinionDestroyedEvent, MadnessDrawnEvent, MadnessReturnedEvent, CardsDrawnEvent, CardsDiscardedEvent, MinionReturnedEvent, BaseReplacedEvent, CardToDeckBottomEvent, CardInstance, TurnStartedEvent } from '../domain/types';
 import { countMadnessCards, madnessVpPenalty } from '../domain/abilityHelpers';
 import { triggerBaseAbility, triggerExtendedBaseAbility } from '../domain/baseAbilities';
 import { SU_EVENTS, MADNESS_CARD_DEF_ID } from '../domain/types';
@@ -2660,32 +2660,30 @@ describe('special_madness onPlay', () => {
         expect(drawEvt.payload.cardUids).toEqual(['d1', 'd2']);
     });
 
-    it('选择返回→返回疯狂牌并获得 1 个额外行动额度', () => {
+    it('选择返回→仅返回疯狂牌堆，不授予额外行动额度', () => {
         const state = makeState({
             players: {
-                '0': makePlayer('0'),
+                '0': makePlayer('0', {
+                    discard: [{ uid: 'mad-1', defId: MADNESS_CARD_DEF_ID, type: 'action', owner: '0' }],
+                }),
                 '1': makePlayer('1'),
             },
+            madnessDeck: [MADNESS_CARD_DEF_ID],
         });
         const handler = getInteractionHandler('special_madness');
         expect(handler).toBeDefined();
         const ms = { core: state, sys: { phase: 'playCards', interaction: { current: undefined, queue: [] } } } as any;
         const result = handler!(ms, '0', { action: 'return' }, { continuationContext: { cardUid: 'mad-1' } }, dummyRandom, 0);
-        expect(result.events.length).toBe(2);
+        expect(result.events.length).toBe(1);
         expect(result.events[0].type).toBe(SU_EVENTS.MADNESS_RETURNED);
         const retEvt = result.events[0] as MadnessReturnedEvent;
         expect(retEvt.payload.playerId).toBe('0');
         expect(retEvt.payload.cardUid).toBe('mad-1');
-        expect(result.events[1].type).toBe(SU_EVENTS.LIMIT_MODIFIED);
-        expect((result.events[1] as LimitModifiedEvent).payload).toMatchObject({
-            playerId: '0',
-            limitType: 'action',
-            delta: 1,
-            reason: 'special_madness',
-        });
 
         const next = result.events.reduce((core, event) => reduce(core, event as any), state);
-        expect(next.players['0'].actionLimit).toBe(state.players['0'].actionLimit + 1);
+        expect(next.players['0'].actionLimit).toBe(state.players['0'].actionLimit);
+        expect(next.players['0'].discard).toHaveLength(0);
+        expect(next.madnessDeck).toHaveLength(2);
     });
 });
 

--- a/src/games/smashup/__tests__/properties/coreProperties.test.ts
+++ b/src/games/smashup/__tests__/properties/coreProperties.test.ts
@@ -1106,7 +1106,7 @@ describe('Property 19: 疯狂牌库生命周期', () => {
         };
         const s = reduce(state, event as any);
         expect(s.players['0'].hand.length).toBe(0);
-        expect(s.madnessDeck!.length).toBe(29);
+        expect(s.madnessDeck!.length).toBe(30);
     });
 
     test('疯狂卡 VP 惩罚：每 2 张扣 1 VP', () => {

--- a/src/games/smashup/abilities/cthulhu.ts
+++ b/src/games/smashup/abilities/cthulhu.ts
@@ -696,10 +696,7 @@ export function registerCthulhuInteractionHandlers(): void {
         if (action === 'return') {
             return {
                 state,
-                events: [
-                    returnMadnessCard(playerId, ctx.cardUid, 'special_madness', timestamp),
-                    grantExtraAction(playerId, 'special_madness', timestamp),
-                ],
+                events: [returnMadnessCard(playerId, ctx.cardUid, 'special_madness', timestamp)],
             };
         }
         const player = state.core.players[playerId];

--- a/src/games/smashup/domain/abilityHelpers.ts
+++ b/src/games/smashup/domain/abilityHelpers.ts
@@ -1261,6 +1261,23 @@ export function countMadnessCards(player: { hand: { defId: string }[]; deck: { d
     return count;
 }
 
+/** 计算某位玩家整局持有的疯狂卡数量（含埋葬区） */
+export function countMadnessCardsForPlayer(state: SmashUpCore, playerId: PlayerId): number {
+    const player = state.players[playerId];
+    if (!player) return 0;
+
+    let count = countMadnessCards(player);
+    for (const base of state.bases) {
+        for (const buried of base.buriedCards ?? []) {
+            if (buried.controllerId === playerId && buried.defId === MADNESS_CARD_DEF_ID) {
+                count++;
+            }
+        }
+    }
+
+    return count;
+}
+
 /** 计算疯狂卡 VP 惩罚（每 2 张扣 1 VP） */
 export function madnessVpPenalty(madnessCount: number): number {
     return Math.floor(madnessCount / 2);

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -44,7 +44,7 @@ import { execute, reduce } from './reducer';
 import { getAllBaseDefIds, getBaseDef, getCardDef } from '../data/cards';
 import { drawCards } from './utils';
 import {
-    countMadnessCards,
+    countMadnessCardsForPlayer,
     madnessVpPenalty,
     fireMinionPlayedTriggers,
     getTitanByUid,
@@ -1884,8 +1884,8 @@ function isGameOver(state: SmashUpCore): GameOverResult | undefined {
     }
     // 骞冲眬锛氱柉鐙傚崱杈冨皯鑰呰儨锛堝厠鑻忛瞾鎵╁睍瑙勫垯锛?
     if (state.madnessDeck !== undefined) {
-        const madnessA = countMadnessCards(state.players[sorted[0]]);
-        const madnessB = countMadnessCards(state.players[sorted[1]]);
+        const madnessA = countMadnessCardsForPlayer(state, sorted[0]);
+        const madnessB = countMadnessCardsForPlayer(state, sorted[1]);
         if (madnessA !== madnessB) {
             return { winner: madnessA < madnessB ? sorted[0] : sorted[1], scores };
         }
@@ -1902,7 +1902,7 @@ export function getScores(state: SmashUpCore): Record<PlayerId, number> {
         let vp = player.vp;
         // P19: 鐤媯鍗?VP 鎯╃綒锛堟瘡 2 寮犳墸 1 VP锛?
         if (state.madnessDeck !== undefined) {
-            vp -= madnessVpPenalty(countMadnessCards(player));
+            vp -= madnessVpPenalty(countMadnessCardsForPlayer(state, pid));
         }
         scores[pid] = vp;
     }

--- a/src/games/smashup/domain/reduce.ts
+++ b/src/games/smashup/domain/reduce.ts
@@ -2357,8 +2357,11 @@ export function reduce(state: SmashUpCore, event: SmashUpEvent): SmashUpCore {
             // 从手牌或弃牌堆移除疯狂卡，放回疯狂牌库
             const newHand = player.hand.filter(c => c.uid !== cardUid);
             const newDiscard = player.discard.filter(c => c.uid !== cardUid);
+            const removedFromPlayerZone = newHand.length !== player.hand.length || newDiscard.length !== player.discard.length;
+            if (!removedFromPlayerZone) return state;
             return {
                 ...state,
+                madnessDeck: [...state.madnessDeck, MADNESS_CARD_DEF_ID],
                 players: {
                     ...state.players,
                     [playerId]: { ...player, hand: newHand, discard: newDiscard },


### PR DESCRIPTION
﻿## Summary
- stop granting an extra action when Madness is returned to the Madness deck
- restore returned Madness cards to the shared Madness supply
- count buried Madness cards in endgame scoring and tie-break resolution

## Verification
- npm run i18n:check
- node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/madnessDeck.test.ts --configLoader native
- node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/properties/coreProperties.test.ts --configLoader native -t Property19MadnessLifecycle
- node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/newOngoingAbilities.test.ts --configLoader native -t special_madness_onPlay


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed madness card counting to include cards located in bases.

* **Gameplay Adjustments**
  * Returning a madness card no longer grants a bonus action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->