### PR TITLE
修复 Smash Up 乱码文本

### DIFF
--- a/src/games/smashup/__tests__/smashup.smoke.test.ts
+++ b/src/games/smashup/__tests__/smashup.smoke.test.ts
@@ -1778,7 +1778,7 @@ describe('smashup', () => {
         }
     });
 
-    it('alien_terraform 绗笁姝ュ厑璁搁€夋嫨鍙浣滈殢浠庢墦鍑虹殑 set-aside 娉板潶', () => {
+    it('alien_terraform 第三步允许选择可视作随从打出的 set-aside 泰坦', () => {
         const tricksterTitan: TitanState = {
             uid: 't1',
             defId: 'tricksters_big_funny_giant',
@@ -2225,7 +2225,7 @@ describe('smashup', () => {
         expect(resolved.players['0'].baseLimitedMinionQuota?.[0]).toBe(1);
     });
 
-    it('鍏冻姝荤鍦ㄥ繁鏂归殢浠庢嫢鏈?7 鏋?+1 鎴樺姏鏍囪鏃跺彲浠?special 浠庣墝搴撴梺杩涘満', () => {
+    it('六足死神在你的随从上共有 6 枚或更多 +1 标记时可弃 1 张牌进场', () => {
         const titanDraft: SmashUpCommand[] = [
             { type: SU_COMMANDS.SELECT_FACTION, playerId: '0', payload: { factionId: SMASHUP_FACTION_IDS.GIANT_ANTS } },
             { type: SU_COMMANDS.SELECT_FACTION, playerId: '1', payload: { factionId: SMASHUP_FACTION_IDS.GHOSTS } },
@@ -2235,7 +2235,7 @@ describe('smashup', () => {
 
         const runner = createRunner();
         const result = runner.run({
-            name: '鍏冻姝荤杩涘満',
+            name: '六足死神进场',
             commands: titanDraft,
         });
 
@@ -2277,7 +2277,7 @@ describe('smashup', () => {
         });
     });
 
-    it('鍏冻姝荤浼氬湪鏈夐殢浠庤繘鍏ュ純鐗屽爢鏃惰幏寰?1 鏋?+1 鎴樺姏鏍囪', () => {
+    it('六足死神在随从将被消灭进弃牌堆前可选择转移 1 枚 +1 标记', () => {
         const core = makeState({
             bases: [
                 makeBase({
@@ -2322,7 +2322,7 @@ describe('smashup', () => {
         expect(titan?.powerCounters).toBe(1);
     });
 
-    it('鍏冻姝荤浼氬湪鍩哄湴璁″垎娓呭満寮冪疆闅忎粠鏃惰幏寰?1 鏋?+1 鎴樺姏鏍囪', () => {
+    it('六足死神在基地计分弃置随从前也可选择转移 1 枚 +1 标记', () => {
         const scoredMinion = makeMinion('scored-ant', 'giant_ant_worker', '0', 2, { powerCounters: 3 });
         const core = makeState({
             bases: [
@@ -2361,7 +2361,7 @@ describe('smashup', () => {
         expect(titan?.powerCounters).toBe(1);
     });
 
-    it('鍏冻姝荤澶╄祴浼氭巿浜堥澶栬鍔ㄩ搴?', () => {
+    it('六足死神天赋会授予额外行动额度', () => {
         const core = makeState({
             bases: [makeBase()],
             players: {
@@ -2406,7 +2406,7 @@ describe('smashup', () => {
         const resolved = events.reduce((acc, event) => SmashUpDomain.reduce(acc, event), core);
         expect(resolved.players['0'].actionLimit).toBe(2);
     });
-    it('澶х唺搴ф弧瓒虫潯浠跺悗鍙€氳繃 special 浠庣墝搴撴梺杩涘満', () => {
+    it('黑熊骑兵泰坦满足条件后可通过 special 从牌库旁进场', () => {
         const titanDraft: SmashUpCommand[] = [
             { type: SU_COMMANDS.SELECT_FACTION, playerId: '0', payload: { factionId: SMASHUP_FACTION_IDS.BEAR_CAVALRY } },
             { type: SU_COMMANDS.SELECT_FACTION, playerId: '1', payload: { factionId: SMASHUP_FACTION_IDS.GHOSTS } },
@@ -2416,7 +2416,7 @@ describe('smashup', () => {
 
         const runner = createRunner();
         const result = runner.run({
-            name: '澶х唺搴ц繘鍦?',
+            name: '黑熊骑兵进场',
             commands: titanDraft,
         });
 
@@ -2456,7 +2456,7 @@ describe('smashup', () => {
         });
     });
 
-    it('澶х唺搴уぉ璧嬩細鍏堝姞 1 鏋?+1 鏍囪鍐嶈姹傞€夋嫨鏂板熀鍦?', () => {
+    it('黑熊骑兵泰坦天赋在两个分支都可用时会先创建模式选择交互', () => {
         const core = makeState({
             bases: [makeBase(), makeBase()],
             titans: [{
@@ -2492,7 +2492,7 @@ describe('smashup', () => {
         expect(state.sys.interaction?.current?.data?.sourceId).toBe('titan_bear_cavalry_major_ursa_choose_destination');
     });
 
-    it('澶х唺搴хЩ鍔ㄥ悗鍙户缁€夋嫨瀵规墜 3 鎴栨洿浣庨殢浠庡苟绉诲姩鍒板叾浠栧熀鍦?', () => {
+    it('黑熊骑兵移动后可继续选择对手 3 或更低随从并移动到其他基地', () => {
         const core = makeState({
             bases: [
                 makeBase(),
@@ -5808,10 +5808,6 @@ describe('smashup', () => {
         expect(finalPecos?.metadata?.deferClashUntilDuelEnds).toBe(false);
         expect(finalArcane?.location.zone).toBe('setaside');
     });
-    /*
-
-    it('宸ㄧ嫾涔嬬伒浼氬湪浣犵殑鍥炲悎寮€濮嬫椂鍒涘缓绉诲姩浜や簰锛屽苟鍙兘绉诲姩鍒颁綘涓ユ牸棰嗗厛鐨勫熀鍦?, () => {
-    */
     it('Great Wolf Spirit creates a start-of-turn move interaction and only offers bases where you are strictly ahead', () => {
         const core = makeState({
             bases: [

--- a/src/games/smashup/abilities/ongoing_modifiers.ts
+++ b/src/games/smashup/abilities/ongoing_modifiers.ts
@@ -1,7 +1,7 @@
 /**
  * 大杀四方 - 持续力量修正能力注册
  *
- * 将各派系�?ongoing 力量修正注册�?ongoingModifiers 系统�?
+ * 将各派系的 ongoing 力量修正注册到 ongoingModifiers 系统中
  * （在 initAllAbilities() 中调用）
  */
 
@@ -19,14 +19,14 @@ import { isBaseAbilitySuppressed } from '../domain/ongoingEffects';
 // ============================================================================
 
 /**
- * 检查随从是否匹配指定的 defId（包�?POD 版本�?
+ * 检查随从是否匹配指定的 defId（包括 POD 版本）
  */
 function matchesDefId(minion: MinionOnBase, baseDefId: string): boolean {
     return minion.defId === baseDefId || minion.defId === baseDefId + '_pod';
 }
 
 /**
- * 计算场上匹配指定 defId 的随从数量（包括 POD 版本�?
+ * 计算场上匹配指定 defId 的随从数量（包括 POD 版本）
  */
 function countMinionsWithDefId(
     state: SmashUpCore,
@@ -48,25 +48,25 @@ function countMinionsWithDefId(
 
 function registerDinosaurModifiers(): void {
     // 重装剑龙：其他玩家回合时 +2 力量
-    // 原版：永久被�?ongoing，不需要使用天�?
+    // 原版：永久被动 ongoing，不需要使用天赋
     // POD 版：需要先使用天赋（talentUsed=true），然后在别人回合时 +2
     registerPowerModifier('dino_armor_stego', (ctx: PowerModifierContext) => {
         const baseId = ctx.minion.defId.replace(/_pod$/, '');
         if (baseId !== 'dino_armor_stego') return 0;
-        // 当前回合不是自己的回合时�?+2
+        // 当前回合不是自己的回合时 +2
         const currentPlayer = ctx.state.turnOrder[ctx.state.currentPlayerIndex];
         if (currentPlayer === ctx.minion.controller) return 0;
-        // POD 版需�?talentUsed 标记�?true 才生�?
+        // POD 版需要 talentUsed 标记为 true 才生效
         const isPod = ctx.minion.defId.endsWith('_pod');
         if (isPod && !ctx.minion.talentUsed) return 0;
         return 2;
     }, { handlesPodInternally: true });
 
-    // 战争猛禄龙：同基地每个己方战争猛禔龙（含自身�?1 力量
+    // 战争猛龙：同基地每个己方战争猛龙（含自身）+1 力量
     registerPowerModifier('dino_war_raptor', (ctx: PowerModifierContext) => {
         const baseId = ctx.minion.defId.replace(/_pod$/, '');
         if (baseId !== 'dino_war_raptor') return 0;
-        // �?war_raptor �?war_raptor_pod 都算入同派系
+        // war_raptor 和 war_raptor_pod 都算入同派系
         const raptorCount = ctx.base.minions.filter(
             m => ['dino_war_raptor', 'dino_war_raptor_pod'].includes(m.defId) && m.controller === ctx.minion.controller
         ).length;
@@ -78,12 +78,12 @@ function registerDinosaurModifiers(): void {
 }
 
 // ============================================================================
-// 机器人派�?
+// 机器人派系
 // ============================================================================
 
 function registerRobotModifiers(): void {
-    // 微型机阿尔法号：每个其他己方随从（视为微型机�?1 力量
-    // "你的所有随从均视为微型�? �?计算场上所有己方其他随从数�?
+    // 微型机阿尔法号：每个其他己方随从（视为微型机）+1 力量
+    // “你的所有随从均视为微型机”，因此计算场上所有己方其他随从数量
     registerPowerModifier('robot_microbot_alpha', (ctx: PowerModifierContext) => {
         const baseId = ctx.minion.defId.replace(/_pod$/, '');
         if (baseId !== 'robot_microbot_alpha') return 0;
@@ -99,13 +99,13 @@ function registerRobotModifiers(): void {
         return otherMinionCount;
     }, { handlesPodInternally: true });
 
-    // 微型机修理�?ongoing：己方每个微型机 +1 力量
-    // 描述�?你的每个微型机的力量+1"
+    // 微型机修理工 ongoing：己方每个微型机 +1 力量
+    // 描述：“你的每个微型机的力量 +1”
     // alpha 在场时所有己方随从视为微型机；alpha 不在场时仅原始微型机受益
     registerPowerModifier('robot_microbot_fixer', (ctx: PowerModifierContext) => {
         // 目标随从必须是微型机才能受益
         if (!isMicrobot(ctx.state, ctx.minion)) return 0;
-        // 计算场上与目标随从同控制者的修理者数量（包括 POD 版本�?
+        // 计算场上与目标随从同控制者的修理工数量（包括 POD 版本）
         return countMinionsWithDefId(ctx.state, 'robot_microbot_fixer', ctx.minion.controller);
     }, { handlesPodInternally: true });
 }
@@ -115,7 +115,7 @@ function registerRobotModifiers(): void {
 // ============================================================================
 
 function registerGhostModifiers(): void {
-    // 不散阴魂：如果你只有2张或更少的手牌，本随�?3 力量
+    // 不散阴魂：如果你只有 2 张或更少的手牌，本随从 +3 力量
     registerPowerModifier('ghost_haunting', (ctx: PowerModifierContext) => {
         if (!matchesDefId(ctx.minion, 'ghost_haunting')) return 0;
         const player = ctx.state.players[ctx.minion.controller];
@@ -123,7 +123,7 @@ function registerGhostModifiers(): void {
         return player.hand.length <= 2 ? 3 : 0;
     }, { handlesPodInternally: true });
 
-    // 通灵之门（ongoing 行动卡附着在基地上）：手牌�?时同基地己方随从每张 +2 力量
+    // 通灵之门（ongoing 行动卡附着在基地上）：手牌 2 张或更少时同基地己方随从每张 +2 力量
     registerOngoingPowerModifier('ghost_door_to_the_beyond', 'base', 'ownerMinions', 2, (ctx) => {
         const player = ctx.state.players[ctx.minion.controller];
         return !!player && player.hand.length <= 2;
@@ -131,7 +131,7 @@ function registerGhostModifiers(): void {
 }
 
 // ============================================================================
-// 忍者派�?
+// 忍者派系
 // ============================================================================
 
 function registerNinjaModifiers(): void {
@@ -140,19 +140,19 @@ function registerNinjaModifiers(): void {
 }
 
 // ============================================================================
-// 食人花派�?
+// 食人花派系
 // ============================================================================
 
 function registerKillerPlantModifiers(): void {
-    // 催眠孢子（ongoing 行动卡打出到基地上）：每张对其他玩家在此基地的随�?-1 力量
+    // 催眠孢子（ongoing 行动卡打出到基地上）：每张对其他玩家在此基地的随从 -1 力量
     registerOngoingPowerModifier('killer_plant_sleep_spores', 'base', 'opponentMinions', -1);
 
     // 过度生长（ongoing 行动卡附着在基地上）：
-    // 规则�?持续：自你的回合开始时，将本基地的爆破点降低到0点�?
-    // 实现方式：onTurnStart 触发器产�?BREAKPOINT_MODIFIED 事件（tempBreakpointModifiers，回合结束自动清零）
-    // 注册�?killer_plants.ts �?registerKillerPlantAbilities() �?
+    // 规则：持续：自你的回合开始时，将本基地的爆破点降低到 0 点
+    // 实现方式：onTurnStart 触发器产生 BREAKPOINT_MODIFIED 事件（tempBreakpointModifiers，回合结束自动清零）
+    // 注册在 killer_plants.ts 的 registerKillerPlantAbilities() 中
 
-    // 注册派系自定义力量修正（Weed Eater POD�?
+    // 注册派系自定义力量修正（Weed Eater POD）
     registerKillerPlantAbilitiesModifiers();
 }
 
@@ -161,8 +161,8 @@ function registerKillerPlantModifiers(): void {
 // ============================================================================
 
 function registerSteampunkModifiers(): void {
-    // 蒸汽人：本基地有至少一个己方战术时 +1 力量（flat +1，非 scaling�?
-    // 描述：「持续：+1力量如果你本基地有至少一个你的战术附属在它上面。�?
+    // 蒸汽人：本基地有至少一个己方战术时 +1 力量（flat +1，非 scaling）
+    // 描述：「持续：如果你在本基地至少有一个你的战术附着在它上面，则 +1 力量。」
     registerPowerModifier('steampunk_steam_man', (ctx: PowerModifierContext) => {
         const baseId = ctx.minion.defId.replace(/_pod$/, '');
         if (baseId !== 'steampunk_steam_man') return 0;
@@ -182,14 +182,14 @@ function registerSteampunkModifiers(): void {
         return 0;
     }, { handlesPodInternally: true });
 
-    // 蒸汽机车（ongoing 行动卡附着在基地上）：拥有者在此基地有随从时，每张 +5 总力�?
-    // 注意：这�?BasePowerModifier，ctx.playerId 是正在计算总力量的玩家
-    // ctx.ongoing 是当前正在评估的 ongoing �?
+    // 蒸汽机车（ongoing 行动卡附着在基地上）：拥有者在此基地有随从时，每张 +5 总力量
+    // 注意：这是 BasePowerModifier，ctx.playerId 是正在计算总力量的玩家
+    // ctx.ongoing 是当前正在评估的 ongoing 卡
     registerBasePowerModifier('steampunk_aggromotive', (ctx) => {
-        // 只有当前 ongoing 卡的拥有者才能获得加�?
+        // 只有当前 ongoing 卡的拥有者才能获得加成
         if (!ctx.ongoing || ctx.ongoing.ownerId !== ctx.playerId) return 0;
         
-        // 检查该玩家在此基地是否有随�?
+        // 检查该玩家在此基地是否有随从
         const hasMinion = ctx.base.minions.some(m => m.controller === ctx.playerId);
         
         return hasMinion ? 5 : 0;
@@ -204,9 +204,9 @@ function registerSteampunkModifiers(): void {
 // ============================================================================
 
 function registerBearCavalryModifiers(): void {
-    // 极地突击队：基地上唯一己方随从�?+2 力量（不可消灭，后者需�?ongoing 保护系统�?
+    // 极地突击队：基地上唯一己方随从时 +2 力量（不可消灭由 ongoing 保护系统处理）
     registerPowerModifier('bear_cavalry_polar_commando', (ctx: PowerModifierContext) => {
-        // POD 版没有该 ongoing 效果（POD 版只�?talent 效果�?
+        // POD 版没有该 ongoing 效果（POD 版只有 talent 效果）
         if (ctx.minion.defId === 'bear_cavalry_polar_commando_pod') return 0;
         if (ctx.minion.defId !== 'bear_cavalry_polar_commando') return 0;
         const myMinionCount = ctx.base.minions.filter(
@@ -216,7 +216,7 @@ function registerBearCavalryModifiers(): void {
     });
 
     // Bearing Down POD（ongoing 行动卡附着在基地上）：动态调整爆破点
-    // 规则：每个在此基地有随从的玩�?+2 爆破点；如果本回合你曾把对手随从移动到此基地，则改为每个玩家 -2
+    // 规则：每个在此基地有随从的玩家 +2 爆破点；如果本回合你曾把对手随从移动到此基地，则改为每个玩家 -2
     registerBreakpointModifier('bear_cavalry_bearing_down_pod', (ctx) => {
         const card = ctx.base.ongoingActions.find(a => a.defId === 'bear_cavalry_bearing_down_pod');
         if (!card) return 0;
@@ -239,7 +239,7 @@ function registerElderThingModifiers(): void {
 }
 
 // ============================================================================
-// 吸血鬼派�?
+// 吸血鬼派系
 // ============================================================================
 
 function registerVampireModifiers(): void {
@@ -248,7 +248,7 @@ function registerVampireModifiers(): void {
 }
 
 function registerAncientEgyptiansModifiers(): void {
-    // ��Ŭ��˹��˾������˻�����������Ƶ������ƣ����ڴ˻��ص��������+2����
+    // 阿努比斯祭司：如果本基地有你的埋葬牌，本随从 +2 力量
     registerPowerModifier('ancient_egyptians_priest_of_anubis', (ctx: PowerModifierContext) => {
         if (!matchesDefId(ctx.minion, 'ancient_egyptians_priest_of_anubis')) return 0;
         const hasOwnedBuried = (ctx.base.buriedCards ?? []).some(card => card.controllerId === ctx.minion.controller);
@@ -270,7 +270,7 @@ function registerBaseModifiers(): void {
         }
         const baseDef = getBaseDef(ctx.base.defId);
         return baseDef?.minionPowerBonus ?? 0;
-    }, { handlesPodInternally: true }); // 标记已处�?POD（通用修正器，不需�?POD 别名�?
+    }, { handlesPodInternally: true }); // 标记已处理 POD（通用修正器，不需要 POD 别名）
 }
 
 // ============================================================================
@@ -297,4 +297,3 @@ export function registerAllOngoingModifiers(): void {
     registerAncientEgyptiansModifiers();
     registerWerewolfModifiers();
 }
-

--- a/src/games/smashup/abilities/titans.ts
+++ b/src/games/smashup/abilities/titans.ts
@@ -1,11 +1,11 @@
 /**
- * 澶ф潃鍥涙柟 - 娉板潶鑳藉姏鎺ュ叆
+ * 大杀四方 - 泰坦能力接入
  *
- * 褰撳墠宸叉寮忔墦閫氾細
- * - 濂舵补娉¤姍缇庝汉
- * - 澶ц‘
- * - 濂ユ湳瀹堟姢鑰?
- * - 椴滆棰嗕富
+ * 当前已正式打通：
+ * - 奶油泡芙美人
+ * - 大衮
+ * - 奥术守护者
+ * - 鲜血领主
  */
 
 import type { MatchState } from '../../../engine/types';
@@ -108,7 +108,7 @@ function getOtherBaseOptions(state: AbilityContext['state'], excludedBaseIndex: 
         .filter(({ index }) => index !== excludedBaseIndex)
         .map(({ base, index }) => ({
             baseIndex: index,
-            label: getBaseDef(base.defId)?.name ?? `閸╁搫婀?${index + 1}`,
+            label: getBaseDef(base.defId)?.name ?? `基地 ${index + 1}`,
         }));
 }
 
@@ -159,7 +159,7 @@ function getHillOwnedMinionsControlledByOthers(
                 defId: minion.defId,
                 baseIndex: index,
                 controllerId: minion.controller,
-                label: `${getCardDef(minion.defId)?.name ?? minion.defId} @ ${getBaseDef(base.defId)?.name ?? `鍩哄湴 ${index + 1}`}`,
+                label: `${getCardDef(minion.defId)?.name ?? minion.defId} @ ${getBaseDef(base.defId)?.name ?? `基地 ${index + 1}`}`,
             })));
 }
 
@@ -172,7 +172,7 @@ function getHillGiveControlTargets(state: AbilityContext['state'], playerId: str
                 defId: minion.defId,
                 baseIndex,
                 controllerId: minion.controller,
-                label: `${getCardDef(minion.defId)?.name ?? minion.defId} @ ${getBaseDef(base.defId)?.name ?? `鍩哄湴 ${baseIndex + 1}`}`,
+                label: `${getCardDef(minion.defId)?.name ?? minion.defId} @ ${getBaseDef(base.defId)?.name ?? `基地 ${baseIndex + 1}`}`,
             })));
 }
 
@@ -337,10 +337,10 @@ function kaijuGorgodzollaOnActionPlayed(ctx: TriggerContext): TriggerResult | Sm
     const interaction = createSimpleChoice(
         `titan_kaiju_gorgodzolla_draw_${titan.uid}_${ctx.now}`,
         ctx.playerId,
-        '鍝ヤ綈鎷夛細浣犲彲浠ユ娊 1 寮犵墝',
+        'Gorgodzolla：你可以抽 1 张牌',
         [
-            { id: 'draw', label: '鎶?1 寮犵墝', value: { draw: true }, displayMode: 'button' as const },
-            { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+            { id: 'draw', label: '抽 1 张牌', value: { draw: true }, displayMode: 'button' as const },
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
         ],
         { sourceId: 'titan_kaiju_gorgodzolla_draw', targetType: 'button' },
     );
@@ -617,8 +617,8 @@ function ignoblesTheHillThatStrollsOnMinionAffected(ctx: TriggerContext): Trigge
         ctx.playerId,
         'The Hill That Strolls: place a +1 power counter on that minion?',
         [
-            { id: 'place', label: '鏀剧疆鏍囪', value: { place: true }, displayMode: 'button' as const },
-            { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+            { id: 'place', label: '放置标记', value: { place: true }, displayMode: 'button' as const },
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
         ],
         { sourceId: 'titan_ignobles_the_hill_that_strolls_counter', targetType: 'button' },
     );
@@ -843,7 +843,7 @@ function ghostsCreampuffManTalent(ctx: AbilityContext): AbilityResult {
     const interaction = createSimpleChoice(
         `titan_ghosts_creampuff_man_discard_${ctx.now}`,
         ctx.playerId,
-        '濂舵补娉¤姍缇庝汉锛氬純缃?1 寮犵墝',
+        '奶油泡芙美人：弃置 1 张牌',
         discardOptions,
         { sourceId: 'titan_ghosts_creampuff_man_discard', targetType: 'hand' },
     );
@@ -955,7 +955,7 @@ function getMergaconEligibleBases(state: AbilityContext['state'], playerId: stri
         .map((base, baseIndex) => ({
             baseIndex,
             ownMinionCount: base.minions.filter(minion => minion.controller === playerId).length,
-            label: getBaseDef(base.defId)?.name ?? `鍩哄湴 ${baseIndex + 1}`,
+            label: getBaseDef(base.defId)?.name ?? `基地 ${baseIndex + 1}`,
         }))
         .filter(candidate => candidate.ownMinionCount >= 2)
         .map(({ baseIndex, label }) => ({ baseIndex, label }));
@@ -966,7 +966,7 @@ function getEmperorPenguinEligibleBases(state: AbilityContext['state'], playerId
         .map((base, baseIndex) => ({
             baseIndex,
             ownMinionCount: base.minions.filter(minion => minion.controller === playerId).length,
-            label: getBaseDef(base.defId)?.name ?? `鍩哄湴 ${baseIndex + 1}`,
+            label: getBaseDef(base.defId)?.name ?? `基地 ${baseIndex + 1}`,
         }))
         .filter(candidate => candidate.ownMinionCount >= 3)
         .map(({ baseIndex, label }) => ({ baseIndex, label }));
@@ -977,7 +977,7 @@ function getMoonZeroThreeEligibleBases(state: AbilityContext['state'], playerId:
         .map((base, baseIndex) => ({
             baseIndex,
             hasOnlyOwnMinions: base.minions.every(minion => minion.controller === playerId),
-            label: getBaseDef(base.defId)?.name ?? `鍩哄湴 ${baseIndex + 1}`,
+            label: getBaseDef(base.defId)?.name ?? `基地 ${baseIndex + 1}`,
         }))
         .filter(candidate => candidate.hasOnlyOwnMinions)
         .map(({ baseIndex, label }) => ({ baseIndex, label }));
@@ -1023,7 +1023,7 @@ function queueTimeBoxPlayInteraction(
     const baseOptions = buildBaseTargetOptions(
         state.bases.map((base, baseIndex) => ({
             baseIndex,
-            label: getBaseDef(base.defId)?.name ?? `鍩哄湴 ${baseIndex + 1}`,
+            label: getBaseDef(base.defId)?.name ?? `基地 ${baseIndex + 1}`,
         })),
         state,
     );
@@ -1035,7 +1035,7 @@ function queueTimeBoxPlayInteraction(
         prompt,
         [
             ...baseOptions,
-            { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
         ],
         { sourceId: 'titan_time_travelers_time_box_play', targetType: 'base', autoResolveIfSingle: false },
     );
@@ -1069,7 +1069,7 @@ function buildTimeBoxCounterProgress(ctx: TriggerContext, reason: string): Trigg
             ctx.playerId,
             titan,
             ctx.now,
-            '鏃堕棿鐩掑瓙锛氭槸鍚︾Щ闄ゅ叏閮ㄨ鏁板櫒骞舵墦鍑哄埌涓€涓熀鍦帮紵',
+            '时间盒子：是否移除全部计数器并打出到一个基地？',
         );
         return nextMatchState ? { events, matchState: nextMatchState } : { events };
     }
@@ -1140,7 +1140,7 @@ function pecosBillOnDuelStarted(ctx: TriggerContext): TriggerResult | SmashUpEve
                 _source: 'hand' as const,
                 displayMode: 'card' as const,
             })),
-            { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
         ],
         { sourceId: 'titan_pecos_bill_duel_start', targetType: 'hand', autoRefresh: 'hand' },
     );
@@ -1204,7 +1204,7 @@ function sphinxOnTurnStart(ctx: TriggerContext) {
                 value: choice,
                 displayMode: 'card' as const,
             })),
-            { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
         ],
         { sourceId: 'titan_sphinx_start_turn', targetType: 'generic', autoResolveIfSingle: false },
     );
@@ -1238,7 +1238,7 @@ function sphinxAfterScoring(ctx: {
         const interaction = createSimpleChoice(
             `titan_sphinx_after_scoring_${titan.uid}_${ctx.now}`,
             titan.controllerId,
-            '鐙韩浜洪潰鍍忥細浣犲彲浠ュ皢姝ゅ涓€寮犱綘鐨勫煁钁墝绉诲洖鎵嬬墝',
+            '狮身人面像：你可以将此处一张你的埋葬牌移回手牌',
             [
                 ...buriedChoices.map((choice) => ({
                     id: `buried-${choice.cardUid}`,
@@ -1246,7 +1246,7 @@ function sphinxAfterScoring(ctx: {
                     value: choice,
                     displayMode: 'card' as const,
                 })),
-                { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+                { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
             ],
             { sourceId: 'titan_sphinx_after_scoring', targetType: 'generic' },
         );
@@ -1272,7 +1272,7 @@ function sphinxTalent(ctx: AbilityContext): AbilityResult {
     const interaction = createSimpleChoice(
         `titan_sphinx_talent_${ctx.now}`,
         ctx.playerId,
-        '鐙韩浜洪潰鍍忥細閫夋嫨涓€寮犳墜鐗屽煁钁湪姝ゅ',
+        '狮身人面像：选择一张手牌埋葬在此处',
         player.hand.map((card) => ({
             id: `hand-${card.uid}`,
             label: getCardDef(card.defId)?.name ?? card.defId,
@@ -1366,10 +1366,10 @@ function penguinsEmperorPenguinOnTurnStart(ctx: TriggerContext) {
     const interaction = createSimpleChoice(
         `titan_penguins_emperor_penguin_play_${ctx.now}`,
         ctx.playerId,
-        '浼侀箙甯濈殗锛氶€夋嫨瑕佽繘鍦虹殑鍩哄湴',
+        '帝企鹅：选择要进场的基地',
         [
             ...baseOptions,
-            { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
         ],
         { sourceId: 'titan_penguins_emperor_penguin_play', targetType: 'base', autoResolveIfSingle: false },
     );
@@ -1482,10 +1482,10 @@ function changerbotsMergaconOnTurnStart(ctx: TriggerContext) {
     const interaction = createSimpleChoice(
         `titan_changerbots_mergacon_play_${ctx.now}`,
         ctx.playerId,
-        '鍚堜綋鏈哄櫒浜猴細閫夋嫨瑕佽繘鍦虹殑鍩哄湴',
+        '合体机器人：选择要进场的基地',
         [
             ...baseOptions,
-            { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+            { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
         ],
         { sourceId: 'titan_changerbots_mergacon_play', targetType: 'base', autoResolveIfSingle: false },
     );
@@ -1572,17 +1572,17 @@ function cthulhuTitanTalent(ctx: AbilityContext): AbilityResult {
     const interaction = createSimpleChoice<CthulhuTitanTalentChoiceValue>(
         `titan_cthulhu_cthulhu_titan_talent_choice_${ctx.now}`,
         ctx.playerId,
-        '鍏嬭嫃椴侊細閫夋嫨瑕佹墽琛岀殑澶╄祴鏁堟灉',
+        '克苏鲁：选择要执行的天赋效果',
         [
             {
                 id: 'draw',
-                label: '鎶戒竴寮犵柉鐙傚崱',
+                label: '抽一张疯狂卡',
                 value: { choice: 'draw' },
                 displayMode: 'button' as const,
             },
             {
                 id: 'give',
-                label: '缁欏彟涓€浣嶇帺瀹朵竴寮犵柉鐙傚崱',
+                label: '给另一位玩家一张疯狂卡',
                 value: { choice: 'give' },
                 displayMode: 'button' as const,
             },
@@ -1669,7 +1669,7 @@ function getGreatWolfSpiritEligibleBases(state: AbilityContext['state'], playerI
             if (!hasHighestPower) return null;
             return {
                 baseIndex,
-                label: getBaseDef(base.defId)?.name ?? `鍩哄湴 ${baseIndex + 1}`,
+                label: getBaseDef(base.defId)?.name ?? `基地 ${baseIndex + 1}`,
             };
         })
         .filter((value): value is { baseIndex: number; label: string } => value !== null);
@@ -1683,7 +1683,7 @@ function getGreatWolfSpiritTalentTargets(state: AbilityContext['state'], playerI
                 uid: minion.uid,
                 defId: minion.defId,
                 baseIndex,
-                label: `${getCardDef(minion.defId)?.name ?? minion.defId} (${getBaseDef(base.defId)?.name ?? `鍩哄湴 ${baseIndex + 1}`})`,
+                label: `${getCardDef(minion.defId)?.name ?? minion.defId} (${getBaseDef(base.defId)?.name ?? `基地 ${baseIndex + 1}`})`,
             })),
     );
 }
@@ -2058,7 +2058,7 @@ function ittyCrittersRainborocTalent(ctx: AbilityContext): AbilityResult {
     const interaction = createSimpleChoice(
         `titan_itty_critters_rainboroc_choose_discard_${ctx.now}`,
         ctx.playerId,
-        '褰╄櫣楦燂細閫夋嫨寮冪墝鍫嗕腑涓€涓垬鍔?2 鎴栨洿浣庣殑闅忎粠娲楀洖鐗屽簱',
+        '彩虹鸟：选择弃牌堆中一个战力 2 或更低的随从洗回牌库',
         discardable.map(card => ({
             id: `rainboroc-discard-${card.uid}`,
             label: getCardDef(card.defId)?.name ?? card.defId,
@@ -2095,10 +2095,10 @@ function piratesTheKrakenAfterScoring(ctx: {
         const interaction = createSimpleChoice(
             `titan_pirates_the_kraken_play_replacement_${titan.uid}_${ctx.now}`,
             titan.ownerId,
-            '娴锋€厠鎷夎偗锛氭槸鍚﹀皢鍏舵墦鍑哄埌鏇挎崲鐨勫熀鍦帮紵',
+            '海怪克拉肯：是否将其打出到替换的基地？',
             [
-                { id: 'play', label: '鎵撳嚭娴锋€厠鎷夎偗', value: { play: true }, displayMode: 'button' as const },
-                { id: 'skip', label: '璺宠繃', value: { skip: true }, displayMode: 'button' as const },
+                { id: 'play', label: '打出海怪克拉肯', value: { play: true }, displayMode: 'button' as const },
+                { id: 'skip', label: '跳过', value: { skip: true }, displayMode: 'button' as const },
             ],
             { sourceId: 'titan_pirates_the_kraken_play_replacement', targetType: 'button' },
         );
@@ -2184,7 +2184,7 @@ function giantAntsDeathOnSixLegsSpecial(ctx: AbilityContext): AbilityResult {
     const interaction = createSimpleChoice(
         `titan_giant_ants_death_on_six_legs_special_${ctx.now}`,
         ctx.playerId,
-        'Death on Six Legs锛氬純 1 寮犵墝鏉ユ墦鍑烘娉板潶',
+        '六足死神：弃 1 张牌来打出此泰坦',
         player.hand.map(card => ({
             id: `hand-${card.uid}`,
             label: getCardDef(card.defId)?.name ?? card.defId,
@@ -2400,7 +2400,7 @@ function queueVampireAncientLordSpecialInteraction(
     const options = [
         {
             id: 'skip',
-            label: '淇濈暀鍦ㄩ殢浠庝笂',
+            label: '保留在随从上',
             value: { mode: 'skip', minionUid, baseIndex, titanUid: titan.uid },
             displayMode: 'button' as const,
         },
@@ -2424,7 +2424,7 @@ function queueVampireAncientLordSpecialInteraction(
     const interaction = createSimpleChoice(
         `titan_vampires_ancient_lord_special_${now}`,
         playerId,
-        '椴滆棰嗕富锛氶€夋嫨鏄惁鎶婂叾涓?1 鏋?+1 鎴樻枟鍔涙爣璁版敼鏀惧埌姝ゆ嘲鍧︿笂',
+        '鲜血领主：选择是否把其中 1 枚 +1 战力标记改放到此泰坦上',
         options,
         { sourceId: 'titan_vampires_ancient_lord_special', targetType: 'generic' },
     );
@@ -2550,7 +2550,7 @@ function queueDeathOnSixLegsTransferInteraction(
             },
             {
                 id: 'skip',
-                label: '璺宠繃',
+                label: '跳过',
                 value: { skip: true, titanUid: titan.uid, minionUid, baseIndex },
                 displayMode: 'button' as const,
             },
@@ -2601,7 +2601,7 @@ function getAllBaseOptions(state: AbilityContext['state']) {
     return buildBaseTargetOptions(
         state.bases.map((base, baseIndex) => ({
             baseIndex,
-            label: getBaseDef(base.defId)?.name ?? `鍩哄湴 ${baseIndex + 1}`,
+            label: getBaseDef(base.defId)?.name ?? `基地 ${baseIndex + 1}`,
         })),
         state,
     );
@@ -2683,7 +2683,7 @@ function fortTitanosaurusOnActionPlayed(ctx: TriggerContext): TriggerResult | Sm
         const minionName = getCardDef(target.minion.defId)?.name ?? target.minion.defId;
         options.unshift({
             id: 'minion-only',
-            label: `鍙粰 ${minionName} 鏀剧疆`,
+            label: `只给 ${minionName} 放置`,
             value: { mode: 'minion' },
             displayMode: 'button' as const,
         });
@@ -2781,7 +2781,7 @@ function invisibleNinjaOnTurnStart(ctx: TriggerContext): TriggerResult | SmashUp
     const interaction = createSimpleChoice(
         `titan_ninjas_invisible_ninja_start_turn_${ctx.now}`,
         ctx.playerId,
-        'Invisible Ninja锛氫綘鍙互娑堢伃姝ゆ嘲鍧︼紝棰濆鎵撳嚭 1 寮犳垬鏂楀姏 3 鎴栦互涓嬬殑闅忎粠',
+        'Invisible Ninja：你可以消灭此泰坦，额外打出 1 张战斗力 3 或以下的随从',
         [
             { id: 'destroy', label: 'Destroy it and gain the extra minion play', value: { destroyTitan: true }, displayMode: 'button' as const },
             { id: 'skip', label: 'Skip', value: { skip: true }, displayMode: 'button' as const },
@@ -2806,7 +2806,7 @@ function invisibleNinjaSpecial(ctx: AbilityContext): AbilityResult {
     const interaction = createSimpleChoice(
         `titan_ninjas_invisible_ninja_special_${ctx.now}`,
         ctx.playerId,
-        'Invisible Ninja锛氬純 1 寮犵墝鏉ユ墦鍑烘娉板潶',
+        'Invisible Ninja：弃 1 张牌来打出此泰坦',
         player.hand.map(card => ({
             id: `hand-${card.uid}`,
             label: getCardDef(card.defId)?.name ?? card.defId,
@@ -2854,7 +2854,7 @@ function invisibleNinjaTriggered(ctx: TriggerContext): TriggerResult | SmashUpEv
     const interaction = createSimpleChoice(
         `titan_ninjas_invisible_ninja_ongoing_${ctx.now}`,
         ctx.playerId,
-        'Invisible Ninja锛氶€夋嫨瑕佹娊鐨勭墝',
+        'Invisible Ninja：选择要抽的牌',
         peek.cards.map(card => ({
             id: `deck-${card.uid}`,
             label: getCardDef(card.defId)?.name ?? card.defId,
@@ -2925,7 +2925,7 @@ function queueKillerKudzuRecycleInteraction(
     const interaction = createSimpleChoice(
         `titan_killer_plants_killer_kudzu_recycle_${now}`,
         playerId,
-        'Killer Kudzu锛氶€夋嫨鑷冲 2 寮犲純鐗屽爢涓殑闅忎粠娲楀洖鐗屽簱',
+        'Killer Kudzu：选择至多 2 张弃牌堆中的随从洗回牌库',
         options,
         {
             sourceId: 'titan_killer_plants_killer_kudzu_recycle',
@@ -2957,7 +2957,7 @@ function killerKudzuOnTitanRemovedFromPlay(ctx: TriggerContext): TriggerResult |
     const interaction = createSimpleChoice(
         `titan_killer_plants_killer_kudzu_removed_${ctx.now}`,
         ctx.playerId,
-        'Killer Kudzu锛氶€夋嫨鏁堟灉',
+        'Killer Kudzu：选择效果',
         [
             { id: 'recycle', label: 'Shuffle up to 2 minions back', value: { recycle: true }, displayMode: 'button' as const },
             { id: 'draw', label: 'Draw 2 cards', value: { draw: true }, displayMode: 'button' as const },
@@ -2996,7 +2996,7 @@ function killerKudzuTalent(ctx: AbilityContext): AbilityResult {
     const interaction = createSimpleChoice(
         `titan_killer_plants_killer_kudzu_talent_${ctx.now}`,
         ctx.playerId,
-        'Killer Kudzu锛氶€夋嫨瑕佷粠寮冪墝鍫嗘墦鍑虹殑闅忎粠',
+        'Killer Kudzu：选择要从弃牌堆打出的随从',
         candidates,
         { sourceId: 'titan_killer_plants_killer_kudzu_talent', targetType: 'generic', autoRefresh: 'discard', responseValidationMode: 'live' },
     );
@@ -3021,7 +3021,7 @@ function getTheBrideBoxTargets(state: AbilityContext['state'], playerId: string,
                 uid: card.uid,
                 defId: card.defId,
                 from: 'hand' as const,
-                label: `${getCardDef(card.defId)?.name ?? card.defId}锛堟墜鐗岋級`,
+                label: `${getCardDef(card.defId)?.name ?? card.defId}（手牌）`,
             })),
         ...player.discard
             .filter(card => card.type === 'minion' && card.uid !== excludedUid)
@@ -3083,13 +3083,13 @@ function buildTheBrideStartBranchOptions(
     const options: Array<{ id: string; label: string; value: { kind: BrideEffectKind }; displayMode: 'button' }> = [];
     const requireSecondChoice = usedKinds.length === 0;
     if (!usedKinds.includes('box') && buildTheBrideStartTargetOptions(state, playerId, 'box', excludedUid, requireSecondChoice).length > 0) {
-        options.push({ id: 'box', label: '鏀捐繘鐩掍腑', value: { kind: 'box' }, displayMode: 'button' });
+        options.push({ id: 'box', label: '放进盒中', value: { kind: 'box' }, displayMode: 'button' });
     }
     if (!usedKinds.includes('destroy') && buildTheBrideStartTargetOptions(state, playerId, 'destroy', excludedUid, requireSecondChoice).length > 0) {
-        options.push({ id: 'destroy', label: '娑堢伃宸辨柟闅忎粠', value: { kind: 'destroy' }, displayMode: 'button' });
+        options.push({ id: 'destroy', label: '消灭己方随从', value: { kind: 'destroy' }, displayMode: 'button' });
     }
     if (!usedKinds.includes('removeCounter') && buildTheBrideStartTargetOptions(state, playerId, 'removeCounter', excludedUid, requireSecondChoice).length > 0) {
-        options.push({ id: 'removeCounter', label: '绉婚櫎 +1 鏍囪', value: { kind: 'removeCounter' }, displayMode: 'button' });
+        options.push({ id: 'removeCounter', label: '移除 +1 标记', value: { kind: 'removeCounter' }, displayMode: 'button' });
     }
     return options;
 }
@@ -3295,7 +3295,7 @@ export function registerTitanAbilities(): void {
             : 'You must play it on a base where you have a minion and destroy one of your minions there';
     });
     registerTitanTalentValidator('dinosaurs_fort_titanosaurus', ({ titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return titan.powerCounters >= 4 ? null : 'This titan needs at least 4 +1 power counters';
     });
     registerTrigger('dinosaurs_fort_titanosaurus', 'onActionPlayed', fortTitanosaurusOnActionPlayed, { optional: true, baseScoped: false });
@@ -3309,11 +3309,11 @@ export function registerTitanAbilities(): void {
             return 'This titan must not have been in play at the start of your turn';
         }
         if ((state.players[playerId]?.hand.length ?? 0) === 0) {
-            return '浣犻渶瑕佸純 1 寮犵墝鏉ユ墦鍑烘娉板潶';
+            return '你需要弃 1 张牌来打出此泰坦';
         }
         return getBaseIndicesWithOwnMinions(state, playerId).includes(baseIndex)
             ? null
-            : '浣犲彧鑳藉皢鍏舵墦鍒版湁浣犻殢浠庣殑鍩哄湴';
+            : '你只能将其打到有你随从的基地';
     });
     registerTrigger('ninjas_invisible_ninja', 'onTurnStart', invisibleNinjaOnTurnStart, { global: true });
     registerTrigger('ninjas_invisible_ninja', 'onMinionDestroyed', invisibleNinjaTriggered, { optional: true, baseScoped: false });
@@ -3324,21 +3324,21 @@ export function registerTitanAbilities(): void {
     registerTitanSpecialValidator('killer_plants_killer_kudzu', ({ titan }) =>
         titan.location.zone === 'setaside' && titan.powerCounters >= 3 ? null : 'This titan must be set aside with at least 3 counters');
     registerTitanTalentValidator('killer_plants_killer_kudzu', ({ state, playerId, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         const player = state.players[playerId];
         const hasCandidate = player?.discard.some(card => {
             if (card.type !== 'minion') return false;
             const def = getCardDef(card.defId) as MinionCardDef | undefined;
             return (def?.power ?? 0) <= titan.powerCounters;
         }) ?? false;
-        return hasCandidate ? null : '浣犵殑寮冪墝鍫嗕腑娌℃湁绗﹀悎鎴樻枟鍔涙潯浠剁殑闅忎粠';
+        return hasCandidate ? null : '你的弃牌堆中没有符合战斗力条件的随从';
     });
     registerTrigger('killer_plants_killer_kudzu', 'onTurnStart', killerKudzuOnTurnStart, { global: true });
     registerTrigger('killer_plants_killer_kudzu', 'onTitanRemovedFromPlay', killerKudzuOnTitanRemovedFromPlay, { optional: true, global: true });
 
     registerAbility('frankenstein_the_bride', 'talent', theBrideTalent);
     registerTitanTalentValidator('frankenstein_the_bride', ({ state, playerId, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         const addCounterTargets = getTheBrideDestroyTargets(state, playerId).filter(target => target.baseIndex === titan.location.baseIndex);
         const extraActionOptions = buildTheBrideExtraActionOptions(state, playerId);
         return (addCounterTargets.length > 0 || extraActionOptions.length > 0)
@@ -3351,40 +3351,40 @@ export function registerTitanAbilities(): void {
     registerAbility('super_spies_moon_zero_three', 'special', superSpiesMoonZeroThreeSpecial);
     registerAbility('super_spies_moon_zero_three', 'talent', superSpiesMoonZeroThreeTalent);
     registerTitanSpecialValidator('super_spies_moon_zero_three', ({ state, playerId, baseIndex, titan }) => {
-        if (titan.location.zone !== 'setaside') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄧ墝搴撴梺';
+        if (titan.location.zone !== 'setaside') return '该泰坦当前不在牌库旁';
         return getMoonZeroThreeEligibleBases(state, playerId).some(candidate => candidate.baseIndex === baseIndex)
             ? null
             : 'You can only play Moon Zero Three on a base with none of other players minions';
     });
     registerTitanTalentValidator('super_spies_moon_zero_three', ({ state, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getMoonZeroThreeInspectablePlayers(state).length > 0
             ? null
-            : '娌℃湁鍙煡鐪嬬殑鐗屽簱';
+            : '没有可查看的牌库';
     });
     registerTrigger('super_spies_moon_zero_three', 'onDeckInspected', superSpiesMoonZeroThreeOnDeckInspected);
 
     registerTitanSpecialValidator('penguins_emperor_penguin', () =>
-        '浼侀箙甯濈殗鍙兘鍦ㄤ綘鐨勫洖鍚堝紑濮嬫椂閫氳繃鐗规畩鑳藉姏杩涘満');
+        '帝企鹅只能在你的回合开始时通过特殊能力进场');
     registerAbility('penguins_emperor_penguin', 'ongoingActivation', penguinsEmperorPenguinOngoingActivation);
     registerAbility('penguins_emperor_penguin', 'talent', penguinsEmperorPenguinTalent);
     registerTitanOngoingActivationValidator('penguins_emperor_penguin', ({ titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return null;
     });
     registerTitanTalentValidator('penguins_emperor_penguin', ({ state, playerId, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getEmperorPenguinTalentCandidates(state, playerId).length > 0
             ? null
-            : '浣犵殑鎵嬬墝涓庡純鐗屽爢涓病鏈夋垬鍔?3 鎴栨洿浣庣殑闅忎粠';
+            : '你的手牌与弃牌堆中没有战斗力 3 或更低的随从';
     });
     registerTrigger('penguins_emperor_penguin', 'onTurnStart', penguinsEmperorPenguinOnTurnStart, { global: true });
 
     registerTitanSpecialValidator('changerbots_mergacon', () =>
-        '鍚堜綋鏈哄櫒浜哄彧鑳藉湪浣犵殑鍥炲悎寮€濮嬫椂閫氳繃鐗规畩鑳藉姏杩涘満');
+        '合体机器人只能在你的回合开始时通过特殊能力进场');
     registerAbility('changerbots_mergacon', 'talent', changerbotsMergaconTalent);
     registerTitanTalentValidator('changerbots_mergacon', ({ state, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getOtherBaseOptions(state, titan.location.baseIndex).length > 0
             ? null
             : 'There is no other base to move to';
@@ -3394,13 +3394,13 @@ export function registerTitanAbilities(): void {
         (state.titanOngoingSuppressedUntilTurnEnd ?? []).includes(titan.uid) ? 0 : 3);
 
     registerTitanSpecialValidator('itty_critters_rainboroc', () =>
-        '褰╄櫣楦熷彧鑳藉湪鍩哄湴璁″垎鍚庨€氳繃鐗规畩鑳藉姏杩涘満');
+        '彩虹鸟只能在基地计分后通过特殊能力进场');
     registerAbility('itty_critters_rainboroc', 'talent', ittyCrittersRainborocTalent);
     registerTitanTalentValidator('itty_critters_rainboroc', ({ state, playerId, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getRainborocLowPowerDiscardCards(state, playerId).length > 0
             ? null
-            : '浣犵殑寮冪墝鍫嗕腑娌℃湁鎴樺姏 2 鎴栨洿浣庣殑闅忎粠';
+            : '你的弃牌堆中没有战力 2 或更低的随从';
     });
     registerTrigger('itty_critters_rainboroc', 'afterScoring', (ctx) => ittyCrittersRainborocAfterScoring({
         state: ctx.state,
@@ -3422,12 +3422,12 @@ export function registerTitanAbilities(): void {
     registerAbility('explorers_very_large_boulder', 'special', explorersVeryLargeBoulderSpecial);
     registerTitanSpecialValidator('explorers_very_large_boulder', ({ state, baseIndex, titan }) => {
         const base = state.bases[baseIndex];
-        if (titan.location.zone !== 'setaside') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄧ墝搴撴梺';
+        if (titan.location.zone !== 'setaside') return '该泰坦当前不在牌库旁';
         if (titan.location.zone !== 'setaside') return 'This titan is not set aside';
         if (!base) return 'Invalid base index';
         return base.minions.length === 0
             ? null
-            : '浣犲彧鑳藉皢纭曞ぇ鍦嗙煶鎵撳嚭鍒版病鏈夌帺瀹堕殢浠庣殑鍩哄湴';
+            : '你只能将硕大圆石打出到没有玩家随从的基地';
     });
     registerTrigger('explorers_very_large_boulder', 'onMinionMoved', explorersVeryLargeBoulderOnMinionMoved, {
         playerContext: 'sourceController',
@@ -3439,9 +3439,9 @@ export function registerTitanAbilities(): void {
     registerTitanSpecialValidator('ignobles_the_hill_that_strolls', ({ state, playerId }) =>
         getHillOwnedMinionsControlledByOthers(state, playerId).length >= 2
             ? null
-            : '鍙湁鑷冲皯 2 涓綘鎷ユ湁鐨勯殢浠庢琚叾浠栫帺瀹舵帶鍒舵椂锛屼綘鎵嶈兘鎵撳嚭婕父灞卞箔宸ㄤ汉');
+            : '只有至少 2 个你拥有的随从正被其他玩家控制时，你才能打出漫游山丘巨人');
     registerTitanTalentValidator('ignobles_the_hill_that_strolls', ({ state, playerId, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         const canGive = getHillGiveControlTargets(state, playerId).length > 0;
         const canReclaim = getHillOwnedMinionsControlledByOthers(state, playerId, titan.location.baseIndex).length > 0;
         return (canGive || canReclaim)
@@ -3457,9 +3457,9 @@ export function registerTitanAbilities(): void {
     registerAbility('time_travelers_time_box', 'special', timeTravelersTimeBoxSpecial);
     registerAbility('time_travelers_time_box', 'talent', timeTravelersTimeBoxTalent);
     registerTitanSpecialValidator('time_travelers_time_box', ({ titan }) =>
-        getTimeBoxCounter(titan) >= 5 ? null : '鏃堕棿鐩掑瓙鐨勮鏁拌繕鏈揪鍒?5');
+        getTimeBoxCounter(titan) >= 5 ? null : '时间盒子的计数还未达到 5');
     registerTitanTalentValidator('time_travelers_time_box', ({ titan }) =>
-        titan.location.zone === 'base' ? null : '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満');
+        titan.location.zone === 'base' ? null : '该泰坦当前不在场');
     registerTrigger('time_travelers_time_box', 'onTurnStart', timeTravelersTimeBoxOnTurnStart, { global: true, optional: true });
     registerTrigger('time_travelers_time_box', 'onCardReturnedToHand', timeTravelersTimeBoxOnCardReturnedToHand, { global: true, optional: true });
 
@@ -3469,7 +3469,7 @@ export function registerTitanAbilities(): void {
 
     registerAbility('sphinx', 'talent', sphinxTalent);
     registerTitanTalentValidator('sphinx', ({ state, playerId, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return (state.players[playerId]?.hand.length ?? 0) > 0
             ? null
             : 'You have no card in hand to bury';
@@ -3484,14 +3484,14 @@ export function registerTitanAbilities(): void {
 
     registerAbility('magical_girls_walking_castle', 'special', magicalGirlsWalkingCastleSpecial);
     registerTitanSpecialValidator('magical_girls_walking_castle', ({ state, playerId, baseIndex, titan }) => {
-        if (titan.location.zone !== 'setaside') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄧ墝搴撴梺';
+        if (titan.location.zone !== 'setaside') return '该泰坦当前不在牌库旁';
         return getOwnMinionCountOnBase(state, baseIndex, playerId) >= 2
             ? null
-            : '浣犲彧鑳藉皢绉诲姩鍩庡牎鎵撳嚭鍒版湁浣犺嚦灏?2 涓殢浠庣殑鍩哄湴';
+            : '你只能将移动城堡打出到有你至少 2 个随从的基地';
     });
     registerAbility('magical_girls_walking_castle', 'talent', magicalGirlsWalkingCastleTalent);
     registerTitanTalentValidator('magical_girls_walking_castle', ({ state, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getOtherBaseOptions(state, titan.location.baseIndex).length > 0
             ? null
             : 'There is no other base to move to';
@@ -3502,7 +3502,7 @@ export function registerTitanAbilities(): void {
     registerTitanSpecialValidator('mega_troopers_megabot', ({ state, playerId, baseIndex }) =>
         getOwnMinionCountOnBase(state, baseIndex, playerId) >= 3
             ? null
-            : '浣犲彧鑳藉皢瓒呯骇浣愬痉鎵撳嚭鍒版湁浣犺嚦灏?3 涓殢浠庣殑鍩哄湴');
+            : '你只能将超级佐德打出到有你至少 3 个随从的基地');
     registerTrigger('mega_troopers_megabot', 'beforeScoring', megaTroopersMegabotBeforeScoring);
     registerTitanPowerModifier('mega_troopers_megabot', ({ state, baseIndex, playerId }) =>
         getOwnMinionCountOnBase(state, baseIndex, playerId));
@@ -3519,7 +3519,7 @@ export function registerTitanAbilities(): void {
             playerId,
             effectiveHandSize: player.hand.length,
         }).length > 0;
-        return hasPlayableAction ? null : '寮冪墝鍚庝篃娌℃湁鍙澶栨墦鍑虹殑鏍囧噯鎴樻湳';
+        return hasPlayableAction ? null : '弃牌后也没有可额外打出的标准战术';
     });
     registerTitanPowerModifier('ghosts_creampuff_man', ({ state, playerId }) => {
         const handSize = state.players[playerId]?.hand.length ?? 0;
@@ -3531,7 +3531,7 @@ export function registerTitanAbilities(): void {
     registerTitanSpecialValidator('innsmouth_dagon', ({ state, playerId, baseIndex }) =>
         getDagonMatchingMinionCount(state, baseIndex, playerId) >= 2
             ? null
-            : '浣犲彧鑳藉皢澶ц‘鎵撳嚭鍒版湁浣犺嚦灏戜袱涓悓鍚嶉殢浠庣殑鍩哄湴');
+            : '你只能将大衮打出到有你至少两个同名随从的基地');
     registerTitanTalentValidator('innsmouth_dagon', ({ state, playerId }) => {
         const player = state.players[playerId];
         const hasMinionInHand = player?.hand.some(card => card.type === 'minion') ?? false;
@@ -3543,7 +3543,7 @@ export function registerTitanAbilities(): void {
     registerAbility('wizards_arcane_protector', 'special', wizardArcaneProtectorSpecial);
     registerAbility('wizards_arcane_protector', 'talent', wizardArcaneProtectorTalent);
     registerTitanSpecialValidator('wizards_arcane_protector', ({ state }) =>
-        (state.cardsPlayedThisTurn ?? 0) >= 5 ? null : '浣犳湰鍥炲悎杩樻病鏈夋墦鍑?5 寮犵墝');
+        (state.cardsPlayedThisTurn ?? 0) >= 5 ? null : '你本回合还没有打出 5 张牌');
 
     registerTitanPowerModifier('wizards_arcane_protector', ({ state, playerId }) => {
         const handSize = state.players[playerId]?.hand.length ?? 0;
@@ -3563,7 +3563,7 @@ export function registerTitanAbilities(): void {
         const canTransferMadness = buildCthulhuTitanTransferOptions(state, playerId).length > 0;
         return (canDrawMadness || canTransferMadness)
             ? null
-            : '浣犳棦涓嶈兘鎶界柉鐙傚崱锛屼篃娌℃湁鍙浆浜ょ粰鍏朵粬鐜╁鐨勭柉鐙傚崱';
+            : '你既不能抽疯狂卡，也没有可转交给其他玩家的疯狂卡';
     });
     registerInterceptor('cthulhu_cthulhu_titan', (state, event) => buildCthulhuTitanCounterEvents(state, event));
 
@@ -3594,10 +3594,10 @@ export function registerTitanAbilities(): void {
             : 'You can only play Major Ursa on a base where you have a minion';
     });
     registerTitanTalentValidator('bear_cavalry_major_ursa', ({ state, titan }) => {
-        if (titan.location.zone !== 'base') return '鐠囥儲鍢查崸锕€缍嬮崜宥勭瑝閸︺劌婧€';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getOtherBaseOptions(state, titan.location.baseIndex).length > 0
             ? null
-            : '濞屸剝婀侀崣顖欎簰缁夎濮╅崚鎵畱閸忔湹绮崺鍝勬勾';
+            : '没有其他可移动到的基地';
     });
     registerTrigger('bear_cavalry_major_ursa', 'onTitanMoved', bearCavalryMajorUrsaOnTitanMoved, { optional: true });
     registerTitanSpecialValidator('bear_cavalry_major_ursa', ({ state, titan, baseIndex }) => {
@@ -3607,7 +3607,7 @@ export function registerTitanAbilities(): void {
             : 'Invalid base index';
     });
     registerTitanTalentValidator('bear_cavalry_major_ursa', ({ state, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         const base = state.bases[titan.location.baseIndex];
         const hasMinionHere = !!base && base.minions.length > 0;
         const canMoveTitan = getOtherBaseOptions(state, titan.location.baseIndex).length > 0;
@@ -3623,7 +3623,7 @@ export function registerTitanAbilities(): void {
     registerAbility('vampires_ancient_lord', 'special', vampireAncientLordSpecial);
     registerAbility('vampires_ancient_lord', 'talent', vampireAncientLordTalent);
     registerTitanSpecialValidator('vampires_ancient_lord', ({ state }) =>
-        (state.powerCountersPlacedOnMinionsThisTurn ?? 0) >= 2 ? null : '浣犳湰鍥炲悎杩樻病鏈変负闅忎粠鏀剧疆 2 鏋?+1 鍔涢噺鏍囪');
+        (state.powerCountersPlacedOnMinionsThisTurn ?? 0) >= 2 ? null : '你本回合还没有为随从放置 2 枚 +1 力量标记');
     registerTitanTalentValidator('vampires_ancient_lord', ({ state, playerId, baseIndex }) => {
         const base = state.bases[baseIndex];
         if (!base) return 'Invalid base index';
@@ -3634,12 +3634,12 @@ export function registerTitanAbilities(): void {
     });
     registerInterceptor('vampires_ancient_lord', (state, event) => buildAncientLordBonusCounterEvents(state, event));
     registerTitanSpecialValidator('vampires_ancient_lord', () =>
-        '姝ゆ嘲鍧﹂€氳繃鍏剁壒娈婅Е鍙戣繘鍦猴紝涓嶈兘鎵嬪姩鍙戝姩');
+        '此泰坦通过其特殊触发进场，不能手动发动');
     registerTitanTalentValidator('vampires_ancient_lord', ({ state, playerId }) => {
         const hasTarget = state.bases.some(base =>
             base.minions.some(minion => minion.controller === playerId && (minion.powerCounters ?? 0) > 0),
         );
-        return hasTarget ? null : '浣犳病鏈夊凡鏈?+1 鎴樻枟鍔涙爣璁扮殑宸辨柟闅忎粠';
+        return hasTarget ? null : '你没有已有 +1 战力标记的己方随从';
     });
     registerTrigger('vampires_ancient_lord', 'onPowerCounterChanged', vampireAncientLordOnPowerCounterChanged, {
         global: true,
@@ -3649,7 +3649,7 @@ export function registerTitanAbilities(): void {
 
     registerAbility('werewolves_great_wolf_spirit', 'special', werewolvesGreatWolfSpiritSpecial);
     registerTitanSpecialValidator('werewolves_great_wolf_spirit', ({ state, playerId, baseIndex, titan }) => {
-        if (titan.location.zone !== 'setaside') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄧ墝搴撴梺';
+        if (titan.location.zone !== 'setaside') return '该泰坦当前不在牌库旁';
         const eligibleBases = getGreatWolfSpiritEligibleBases(state, playerId);
         if (eligibleBases.length < 2) return 'You must be tied for highest power on at least 2 bases';
         return eligibleBases.some(option => option.baseIndex === baseIndex)
@@ -3658,15 +3658,15 @@ export function registerTitanAbilities(): void {
     });
     registerAbility('werewolves_great_wolf_spirit', 'talent', werewolvesGreatWolfSpiritTalent);
     registerTitanTalentValidator('werewolves_great_wolf_spirit', ({ state, titan, playerId }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getGreatWolfSpiritTalentTargets(state, playerId).length > 0
             ? null
-            : '娌℃湁鍙幏寰楀姏閲忕殑宸辨柟闅忎粠';
+            : '没有可获得力量的己方随从';
     });
 
     registerAbility('tricksters_big_funny_giant', 'special', trickstersBigFunnyGiantSpecial);
     registerTitanSpecialValidator('tricksters_big_funny_giant', ({ state, titan, baseIndex }) => {
-        if (titan.location.zone !== 'setaside') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄧ墝搴撴梺';
+        if (titan.location.zone !== 'setaside') return '该泰坦当前不在牌库旁';
         return state.bases[baseIndex] ? null : 'Invalid base index';
     });
     registerTrigger('tricksters_big_funny_giant', 'onTurnEnd', trickstersBigFunnyGiantOnTurnEnd);
@@ -3680,7 +3680,7 @@ export function registerTitanAbilities(): void {
 
     registerAbility('pirates_the_kraken', 'talent', piratesTheKrakenTalent);
     registerTitanTalentValidator('pirates_the_kraken', ({ state, titan }) => {
-        if (titan.location.zone !== 'base') return '璇ユ嘲鍧﹀綋鍓嶄笉鍦ㄥ満';
+        if (titan.location.zone !== 'base') return '该泰坦当前不在场';
         return getOtherBaseOptions(state, titan.location.baseIndex).length > 0
             ? null
             : 'There is no other base to move to';
@@ -4043,7 +4043,7 @@ export function registerTitanInteractionHandlers(): void {
         const interaction = createSimpleChoice(
             `titan_frankenstein_the_bride_start_choose_target_${timestamp}`,
             playerId,
-            'The Bride锛氶€夋嫨鏁堟灉鐩爣',
+            'The Bride：选择效果目标',
             options,
             { sourceId: 'titan_frankenstein_the_bride_start_choose_target', targetType: 'generic' },
         );
@@ -4110,7 +4110,7 @@ export function registerTitanInteractionHandlers(): void {
         const interaction = createSimpleChoice(
             `titan_frankenstein_the_bride_start_choose_base_${timestamp}`,
             playerId,
-            'The Bride锛氶€夋嫨瑕佹墦鍑虹殑鍩哄湴',
+            'The Bride：选择要打出的基地',
             getAllBaseOptions(state.core),
             { sourceId: 'titan_frankenstein_the_bride_start_choose_base', targetType: 'base' },
         );
@@ -4164,7 +4164,7 @@ export function registerTitanInteractionHandlers(): void {
         const interaction = createSimpleChoice(
             `titan_frankenstein_the_bride_talent_extra_action_${timestamp}`,
             playerId,
-            'The Bride锛氶€夋嫨瑕佺Щ闄ょ殑鏍囪缁勫悎',
+            'The Bride：选择要移除的标记组合',
             buildTheBrideExtraActionOptions(state.core, playerId),
             { sourceId: 'titan_frankenstein_the_bride_talent_extra_action', targetType: 'generic' },
         );
@@ -4571,7 +4571,7 @@ export function registerTitanInteractionHandlers(): void {
         const interaction = createSimpleChoice(
             `titan_explorers_very_large_boulder_destroy_${timestamp}`,
             playerId,
-            '纭曞ぇ鍦嗙煶锛氶€夋嫨瑕佹秷鐏殑闅忎粠',
+            '硕大圆石：选择要消灭的随从',
             buildMinionTargetOptions(destroyTargets, { state: state.core, sourcePlayerId: playerId, effectType: 'destroy' }),
             { sourceId: 'titan_explorers_very_large_boulder_destroy', targetType: 'minion' },
         );
@@ -4664,7 +4664,7 @@ export function registerTitanInteractionHandlers(): void {
             next.controllerId,
             `Megabot: move to ${getBaseDef(continuation.scoringBaseDefId)?.name ?? `Base ${continuation.scoringBaseIndex + 1}`} before it scores?`,
             [
-                { id: 'move', label: '绉诲姩鍒拌鍩哄湴', value: { move: true }, displayMode: 'button' as const },
+                { id: 'move', label: '移动到该基地', value: { move: true }, displayMode: 'button' as const },
                 { id: 'stay', label: '鐣欏湪鍘熷湴', value: { move: false }, displayMode: 'button' as const },
             ],
             { sourceId: 'titan_mega_troopers_megabot_move', targetType: 'button' },
@@ -5267,7 +5267,7 @@ export function registerTitanInteractionHandlers(): void {
             const interaction = createSimpleChoice(
                 `titan_bear_cavalry_major_ursa_choose_counter_target_${timestamp}`,
                 playerId,
-                'Major Ursa锛氶€夋嫨姝ゅ涓€涓殢浠庢斁缃?+1 鎴樺姏鏍囪',
+                'Major Ursa：选择此处一个随从放置 +1 战力标记',
                 buildMinionTargetOptions(
                     base.minions.map(minion => ({
                         uid: minion.uid,
@@ -5337,7 +5337,7 @@ export function registerTitanInteractionHandlers(): void {
         const interaction = createSimpleChoice(
             `titan_bear_cavalry_major_ursa_choose_base_${timestamp}`,
             playerId,
-            '婢堆呭敽鎼囱嶇窗闁瀚ㄧ憰浣哥殺鐠囥儵娈㈡禒搴Ｐ╅崝銊ュ煂閻ㄥ嫬鐔€閸?',
+            'Major Ursa：选择要将该随从移动到的基地',
             buildBaseTargetOptions(baseOptions, state.core),
             { sourceId: 'titan_bear_cavalry_major_ursa_choose_base', targetType: 'base' },
         );
@@ -5404,7 +5404,7 @@ export function registerTitanInteractionHandlers(): void {
         const interaction = createSimpleChoice(
             `titan_ghosts_creampuff_man_play_${timestamp}`,
             playerId,
-            '濂舵补娉¤姍缇庝汉锛氶€夋嫨瑕佷粠寮冪墝鍫嗛澶栨墦鍑虹殑鏍囧噯鎴樻湳',
+            '奶油泡芙美人：选择要从弃牌堆额外打出的标准战术',
             actionOptions,
             { sourceId: 'titan_ghosts_creampuff_man_play', targetType: 'generic' },
         );

--- a/src/games/smashup/data/cards.ts
+++ b/src/games/smashup/data/cards.ts
@@ -1266,7 +1266,7 @@ function getBaseDefIdsForFactionsLegacy(factionIds: string[]): string[] {
 
 
 /** 查找卡牌定义 */
-/** 鏍规嵁鎵€閫夋淳绯昏幏鍙栧熀鍦板畾涔?ID锛堝悓鍙樹綋琛ュ厖锛欿OD 鍙ˉ POD锛屽熀纭€鍙ˉ鍩虹锛?*/
+/** 根据所选派系获取基地定义 ID（同变体补充：POD 只补 POD，基础只补基础） */
 export function getBaseDefIdsForFactions(factionIds: string[]): string[] {
     const selectedFactionIds = [...new Set(factionIds)];
     const selectedOriginalFactions = new Set(

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -1,7 +1,7 @@
 /**
- * 澶ф潃鍥涙柟 (Smash Up) - 棰嗗煙鍐呮牳缁勮
+ * 大杀四方 (Smash Up) - 领域内核组装
  *
- * 鑱岃矗锛歴etup 鍒濆鍖栥€丗lowSystem 閽╁瓙銆乸layerView銆乮sGameOver
+
  */
 
 import type { DomainCore, GameEvent, GameOverResult, PlayerId, RandomFn, MatchState } from '../../../engine/types';
@@ -78,7 +78,7 @@ import {
 } from './scoringSession';
 
 // ============================================================================
-// 鍩哄湴璁板垎杈呭姪鍑芥暟锛堜緵 FlowHooks 鍜?Prompt 缁х画鍑芥暟鍏辩敤锛?
+
 // ============================================================================
 
 function collectQualifiedPlayerPowers(
@@ -433,9 +433,9 @@ function finalizeCurrentScoringBase(
 }
 
 /**
- * 瀵规寚瀹氬熀鍦版墽琛岃鍒嗛€昏緫锛岃繑鍥炴墍鏈夌浉鍏充簨浠?
+
  * 
- * 鍖呭惈锛歜eforeScoring 鍩哄湴鑳藉姏 鈫?鎺掑悕璁＄畻 鈫?BASE_SCORED 鈫?afterScoring 鍩哄湴鑳藉姏 鈫?BASE_REPLACED
+
  */
 export function scoreOneBase(
     core: SmashUpCore,
@@ -452,7 +452,6 @@ export function scoreOneBase(
         core = matchState.core;
     }
 
-    // 榛樿 random锛堢‘瀹氭€у洖閫€锛岃鍒嗕腑澶у鏁?trigger 涓嶉渶瑕侀殢鏈猴級
     const rng: RandomFn = random ?? {
         random: () => 0.5,
         d: () => 1,
@@ -475,15 +474,10 @@ export function scoreOneBase(
             : session,
         );
     }
-    
-    // 銆愪慨澶嶃€憂ewBaseDeck 蹇呴』鍦ㄥ嚱鏁伴《閮ㄥ０鏄庯紝閬垮厤 TDZ 閿欒
-    // 闂锛氫箣鍓嶅湪涓や釜涓嶅悓鐨勪綔鐢ㄥ煙涓０鏄庝簡 newBaseDeck锛坙ine 454 鍜?line 476锛?
-    // 褰撳嚱鏁板湪 afterScoring 绐楀彛鎵撳紑鍚庢彁鍓嶈繑鍥烇紝鍐嶆璋冪敤鏃朵細璁块棶鏈垵濮嬪寲鐨勫灞?newBaseDeck
     let newBaseDeck = baseDeck;
-    // 瑙﹀彂 ongoing beforeScoring锛堝 pirate_king 绉诲姩鍒拌鍩哄湴銆乧thulhu_chosen +2鍔涢噺锛?
-    // 鍏堜簬鍩哄湴鑳藉姏鎵ц锛岀‘淇濆熀鍦拌兘鍔涜兘鐪嬪埌 ongoing 鏁堟灉鐨勭粨鏋?
+
     
-    // 妫€鏌ユ槸鍚﹀凡缁忚Е鍙戣繃 beforeScoring锛堥槻姝氦浜掕В鍐冲悗閲嶅瑙﹀彂锛?
+
     const alreadyTriggeredBeforeScoring = core.beforeScoringTriggeredBases?.includes(baseIndex) ?? false;
     
     
@@ -509,7 +503,7 @@ export function scoreOneBase(
             core = rq0.state.core;
         }
         
-        // 鍙戝皠浜嬩欢鏍囪姝ゅ熀鍦板凡瑙﹀彂杩?beforeScoring
+
         const markEvent = {
             type: SU_EVENT_TYPES.BEFORE_SCORING_TRIGGERED,
             payload: { baseIndex },
@@ -517,36 +511,29 @@ export function scoreOneBase(
         };
         events.push(markEvent as unknown as SmashUpEvent);
         
-        // 鉁?鍏抽敭淇锛氱珛鍗冲皢鏍囪浜嬩欢 reduce 鍒版湰鍦?core 鍓湰
+
         // 
-        // 闂锛氫簨浠堕┍鍔ㄦ灦鏋勪腑锛屼簨浠剁殑鍙戝皠锛坋mit锛夊拰褰掔害锛坮educe锛夋槸鍒嗙鐨勶細
-        // 1. scoreOneBase 鍙戝皠浜嬩欢鍚庣珛鍗宠繑鍥?
+
         // 2. 杩欎簺浜嬩欢瑕佺瓑鍒版暣涓?onPhaseExit 杩斿洖鍚庯紝鎵嶄細琚?pipeline 閫愪釜 reduce
-        // 3. 浣?FlowSystem 鍦ㄤ氦浜掕В鍐冲悗浼氶噸鏂拌繘鍏?onPhaseExit锛屾鏃朵娇鐢ㄧ殑 core 杩樻病鏈夊寘鍚涓€娆″彂灏勭殑鏍囪浜嬩欢
+
         // 
-        // 瑙ｅ喅鏂规锛氬彂灏勬爣璁颁簨浠跺悗绔嬪嵆 reduce 鍒版湰鍦?core 鍓湰锛岀‘淇濆悗缁皟鐢?scoreOneBase 鏃惰兘鐪嬪埌"宸茶Е鍙?鏍囪
+
         // 
-        // 绀轰緥鍦烘櫙锛堟捣鐩楃帇绉诲姩 bug锛夛細
+
         // - 绗竴娆¤皟鐢細妫€鏌?beforeScoringTriggeredBases 鈫?undefined 鈫?瑙﹀彂 beforeScoring 鈫?鍒涘缓娴风洍鐜嬩氦浜?鈫?halt
-        // - 鐢ㄦ埛鐐瑰嚮"绉诲姩鍒拌鍩哄湴" 鈫?浜や簰瑙ｅ喅
-        // - 绗簩娆¤皟鐢細濡傛灉娌℃湁绔嬪嵆 reduce锛宐eforeScoringTriggeredBases 浠嶆槸 undefined 鈫?鍙堝垱寤虹浉鍚?ID 鐨勪氦浜?鈫?UI 鍗′綇
+
         core = reduce(core, markEvent as unknown as SmashUpEvent);
 
-        // beforeScoring 鍙兘鍒涘缓浜嗕氦浜掞紙濡傛捣鐩楃帇绉诲姩纭锛?
-        // 蹇呴』鍏?halt 绛変氦浜掕В鍐炽€佷簨浠?reduce 鍒?core 鍚庯紝鍐嶇户缁?
         if (ms?.sys?.interaction?.current) {
             return { events, newBaseDeck: baseDeck, matchState: ms };
         }
     }
 
-    // 灏?ongoing beforeScoring 浜х敓鐨勪簨浠讹紙濡?TEMP_POWER_ADDED銆丮INION_MOVED锛塺educe 鍒?core锛?
-    // 纭繚鍚庣画鍩哄湴鑳藉姏鍜屾帓鍚嶈绠椾娇鐢ㄦ渶鏂扮姸鎬?
     let updatedCore = core;
     for (const evt of events) {
         updatedCore = reduce(updatedCore, evt as SmashUpEvent);
     }
 
-    // 瑙﹀彂 beforeScoring 鍩哄湴鑳藉姏锛堝叆闃燂紝鎸?Wiki 鍚屾椂瑙﹀彂鎺掑簭瑙ｅ喅锛?
     const queuedBeforeBase = collectBaseAbilityTriggers({
         core: updatedCore,
         timing: 'beforeScoring',
@@ -569,7 +556,6 @@ export function scoreOneBase(
         }
     }
 
-    // 璁＄畻鎺掑悕锛堜娇鐢?reduce 鍚庣殑 core锛屽寘鍚?beforeScoring 鐨勪复鏃跺姏閲忎慨姝?+ ongoing 鍗″姏閲忚础鐚級
     const updatedBaseAfterBefore = updatedCore.bases[baseIndex];
     // beforeScoring 处理后，如果该基地已不再达标，则本次计分直接跳过
     // （例如 pirate_king 移走随从导致基地力量降到 breakpoint 以下）
@@ -628,7 +614,6 @@ export function scoreOneBase(
     const finalPlayerPowers = collectQualifiedPlayerPowers(updatedCore, scoringBase, baseIndex);
     const rankings = buildBaseRankings(baseDef, finalPlayerPowers);
 
-    // 鏀堕泦姣忎綅鐜╁鐨勯殢浠庡姏閲?breakdown锛堢敤浜?ActionLog 灞曠ず锛?
     const minionBreakdowns: Record<PlayerId, MinionPowerBreakdown[]> = {};
     for (const m of scoringBase.minions) {
         const bd = getEffectivePowerBreakdown(updatedCore, m, baseIndex);
@@ -652,8 +637,6 @@ export function scoreOneBase(
     };
     events.push(scoreEvt);
 
-    // 瑙﹀彂 onMinionDiscardedFromBase锛堝熀鍦扮粨绠楀純缃紝闈炴秷鐏級
-    // 鍦?BASE_SCORED 鍚庛€乤fterScoring 鍓嶈Е鍙戯紝姝ゆ椂闅忎粠浠嶅湪 core 涓紙reducer 灏氭湭鎵ц锛?
     for (const m of scoringBase.minions) {
         const queued = collectTriggers(core, 'onMinionDiscardedFromBase', {
             state: core,
@@ -684,7 +667,6 @@ export function scoreOneBase(
     const interactionBeforeAfterScoring = ms?.sys?.interaction?.current?.id ?? null;
     const queueLenBeforeAfterScoring = ms?.sys?.interaction?.queue?.length ?? 0;
 
-    // 妫€鏌ユ槸鍚﹀凡缁忚Е鍙戣繃 afterScoring锛堥槻姝氦浜掕В鍐冲悗閲嶅瑙﹀彂锛?
     const alreadyTriggeredAfterScoring = updatedCore.afterScoringTriggeredBases?.includes(baseIndex) ?? false;
 
     if (!alreadyTriggeredAfterScoring) {
@@ -783,14 +765,6 @@ export function scoreOneBase(
         (interactionAfter !== null && interactionAfter !== interactionBeforeAfterScoring) ||
         (queueLenAfter > queueLenBeforeAfterScoring);
 
-    // 銆愭柊澧炪€戞鏌ユ槸鍚﹂渶瑕佹墦寮€ afterScoring 鍝嶅簲绐楀彛
-    // 娉ㄦ剰锛歛fterScoring 鍝嶅簲绐楀彛鍦?BASE_SCORED 涔嬪悗銆丅ASE_CLEARED 涔嬪墠鎵撳紑
-    // 杩欐牱鐜╁鎵撳嚭鐨?afterScoring 鍗＄墝鍙互褰卞搷璇ュ熀鍦扮殑鍔涢噺锛屽苟鍙兘瀵艰嚧閲嶆柊璁″垎
-    // 
-    // 鈿狅笍 銆愬叧閿慨澶嶃€戞棤璁哄熀鍦拌兘鍔涙槸鍚﹀垱寤轰簡浜や簰锛岄兘瑕佹鏌ユ槸鍚︽湁 afterScoring 鍗＄墝
-    // 鍘熷洜锛氬熀鍦拌兘鍔涘垱寤轰氦浜掞紙濡傛捣鐩楁咕绉诲姩闅忎粠锛夊拰鍝嶅簲绐楀彛锛堣鐜╁鎵撳嚭 afterScoring 鍗＄墝锛?
-    // 鏄袱涓嫭绔嬬殑鏈哄埗锛屽簲璇ュ悓鏃跺瓨鍦?
-    // 妫€鏌ユ槸鍚︽湁鐜╁鎵嬬墝涓湁 afterScoring 鍗＄墝
     const playersWithAfterScoringCards = ms
         ? getPlayersWithPlayableAfterScoringResponses({ ...ms, core: afterScoringCore }, now)
         : [];
@@ -894,7 +868,6 @@ export function scoreOneBase(
     return { events, newBaseDeck, matchState: ms };
 }
 
-/** 娉ㄥ唽澶氬熀鍦拌鍒嗙殑浜や簰瑙ｅ喅澶勭悊鍑芥暟 */
 export function registerMultiBaseScoringInteractionHandler(): void {
     registerInteractionHandler('multi_base_scoring', (state, _playerId, value) => {
         const { baseIndex } = value as { baseIndex?: number };
@@ -1153,7 +1126,7 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
     getNextPhase({ from }): string {
         const idx = PHASE_ORDER.indexOf(from as GamePhase);
         if (idx === -1 || idx >= PHASE_ORDER.length - 1) {
-            // endTurn 鍚庡洖鍒?startTurn锛堣烦杩?factionSelect锛屽畠鍙湪娓告垙寮€濮嬫椂浣跨敤涓€娆★級
+
             return 'startTurn';
         }
         return PHASE_ORDER[idx + 1];
@@ -1171,7 +1144,6 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
         if (from === 'endTurn') {
             const events: SmashUpEvent[] = [];
 
-            // 瑙﹀彂 ongoing 鏁堟灉 onTurnEnd锛堟敼涓哄叆闃燂紝鎸?Wiki 鍚屾椂瑙﹀彂鎺掑簭瑙ｅ喅锛?
             const queuedTurnEnd = collectTriggers(core, 'onTurnEnd', {
                 state: core,
                 matchState: state,
@@ -1186,7 +1158,7 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
                 const msForQueue = { ...state, core: coreForQueue };
                 const rq = maybeResolveReactionQueue(msForQueue, random, now);
                 if (rq) {
-                    // 鍏抽敭锛歰nTurnEnd 瑙﹀彂鍣ㄥ彲鑳戒骇鐢?MINION_DESTROYED 绛夛紝闇€瑕佺粡杩?destroy鈫抦ove 寰幆鍚庡鐞?
+
                     const afterDestroyMove = processDestroyMoveCycle(rq.events, rq.state, pid, random, now);
                     events.push(...afterDestroyMove.events);
                 }
@@ -1348,7 +1320,7 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
         const pid = getCurrentPlayerId(core);
         const now = typeof command.timestamp === 'number' ? command.timestamp : 0;
         const events: GameEvent[] = [];
-        // 杩借釜 sys 鍙樻洿锛堝熀鍦拌兘鍔?ongoing 鍙兘鍒涘缓 Interaction锛?
+
         let currentMatchState: MatchState<SmashUpCore> = state;
         let hasSysUpdate = false;
 
@@ -1394,7 +1366,6 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
 
             const startTurnTriggeredEvents: SmashUpEvent[] = [];
 
-            // 瑙﹀彂鍩哄湴 onTurnStart 鑳藉姏锛堟敼涓哄叆闃燂紝鎸?Wiki 鍚屾椂瑙﹀彂鎺掑簭瑙ｅ喅锛?
             const baseResult = triggerAllBaseAbilities('onTurnStart', startTurnCore, nextPlayerId, now, undefined, currentMatchState, random);
             startTurnTriggeredEvents.push(...baseResult.events);
             if (baseResult.matchState) {
@@ -1402,7 +1373,6 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
                 currentMatchState = { ...baseResult.matchState, core: startTurnCore };
             }
 
-            // 瑙﹀彂 ongoing 鏁堟灉 onTurnStart锛堟敼涓哄叆闃燂紝鎸?Wiki 鍚屾椂瑙﹀彂鎺掑簭瑙ｅ喅锛?
             const onTurnStartEvents = fireTriggers(startTurnCore, 'onTurnStart', {
                 state: startTurnCore,
                 matchState: currentMatchState,
@@ -1443,7 +1413,6 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
                 events.push(...immediateStartTurn.events);
             }
 
-            // Wiki: Start Turn 鏃跺彲鍏嶈垂鎻紑涓€寮犺嚜宸辨帶鍒剁殑鍩嬭懍鍗★紙鍙€夛紝涓旀瘡鍥炲悎浠呬竴娆★級
             const coreForUncover = currentMatchState.core;
             const buriedChoices: { cardUid: string; baseIndex: number; label: string }[] = [];
             for (let bi = 0; bi < coreForUncover.bases.length; bi++) {
@@ -1477,7 +1446,6 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
                 hasSysUpdate = true;
             }
 
-            // 鏈?sys 鍙樻洿鏃惰繑鍥?PhaseEnterResult锛屽惁鍒欒繑鍥炵函浜嬩欢鏁扮粍
             if (hasSysUpdate) {
                 return { events, updatedState: currentMatchState } as PhaseEnterResult;
             }
@@ -1592,15 +1560,13 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
             return { autoContinue: true, playerId: pid };
         }
 
-        // 閫氱敤瀹堝崼锛氫换浣曢樁娈垫湁寰呭鐞嗙殑 Interaction 鏃堕兘涓嶈嚜鍔ㄦ帹杩?
-        // 锛堝熀鍦拌兘鍔涘鎷夎幈鑰?onTurnStart銆佹墭灏斿浘鍔?afterScoring 绛夊彲鑳藉湪浠绘剰闃舵鍒涘缓 Interaction锛?
         if (state.sys.interaction?.current) {
             return undefined;
         }
 
         // factionSelect 鑷姩鎺ㄨ繘 check
         if (phase === 'factionSelect') {
-            // 濡傛灉鎵€鏈変汉閮介€夊畬浜嗭紙reducer鎶妔election缃┖浜嗭級锛屽垯鑷姩杩涘叆涓嬩竴闃舵
+
             if (!core.factionSelection) {
                 return { autoContinue: true, playerId: pid };
             }
@@ -1614,15 +1580,6 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
             return { autoContinue: true, playerId: pid };
         }
 
-        // scoreBases 闃舵锛氭潯浠舵€ц嚜鍔ㄦ帹杩?
-        // 
-        // 銆愪慨澶嶉€昏緫銆?
-        // 1. 濡傛灉 flowHalted=true 涓斾氦浜掑凡瑙ｅ喅 鈫?鑷姩鎺ㄨ繘锛堟竻鐞?halt 鐘舵€侊級
-        // 2. 濡傛灉娌℃湁 eligible 鍩哄湴 鈫?鑷姩鎺ㄨ繘锛堟棤闇€璁″垎锛?
-        // 3. 濡傛灉鏈?eligible 鍩哄湴涓斿搷搴旂獥鍙ｅ凡鍏抽棴 鈫?鑷姩鎺ㄨ繘锛堣Е鍙戣鍒嗭級
-        // 4. 鍏朵粬鎯呭喌锛堝搷搴旂獥鍙ｄ粛鎵撳紑锛夆啋 涓嶈嚜鍔ㄦ帹杩涳紙绛夊緟鍝嶅簲锛?
-        // 
-        // 杩欐牱鍙互閬垮厤鏃犻檺寰幆锛屽悓鏃跺湪鍝嶅簲绐楀彛鍏抽棴鍚庤嚜鍔ㄦ帹杩涜Е鍙戣鍒嗐€?
         if (phase === 'scoreBases') {
             if (state.sys.responseWindow?.current) {
                 return undefined;
@@ -1668,7 +1625,6 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
             }
         }
 
-        // endTurn 鑷姩鎺ㄨ繘鍒?startTurn锛堝垏鎹㈢帺瀹跺悗锛?
         if (phase === 'endTurn') {
             return { autoContinue: true, playerId: pid };
         }
@@ -1676,12 +1632,11 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
 };
 
 // ============================================================================
-// playerView锛氫笉鍐嶉殣钘忔墜鐗?鐗屽簱锛岀洿鎺ュ彂閫佸畬鏁存暟鎹紙涓嶉渶瑕侀槻浣滃紛锛?
+
 // ============================================================================
 
 function playerView(state: SmashUpCore, playerId: PlayerId): Partial<SmashUpCore> {
-    // 榛樿涓嶉殣钘忎换浣曚俊鎭紙椤圭洰鍐呬笉闃蹭綔寮婏級锛屼絾鍩嬭懍鍗￠渶瑕侀伒寰?Wiki锛氫粠鎵嬬墝鍩嬭懍榛樿涓嶅叕寮€銆?
-    // 鍥犳瀵归潪鎺у埗鑰呴殣钘?buriedCards 鐨?defId 绛変俊鎭紝浠呬繚鐣欌€滄湁澶氬皯寮犮€佺敱璋佹帶鍒躲€佸湪鍝釜鍩哄湴鈥濈殑鍙鎬с€?
+
     const maskedBases = state.bases.map(b => {
         if (!b.buriedCards || b.buriedCards.length === 0) return b;
         return {
@@ -1701,7 +1656,6 @@ function playerView(state: SmashUpCore, playerId: PlayerId): Partial<SmashUpCore
     return { bases: maskedBases };
 }
 
-
 // ============================================================================
 // isGameOver
 // ============================================================================
@@ -1709,7 +1663,6 @@ function playerView(state: SmashUpCore, playerId: PlayerId): Partial<SmashUpCore
 function isGameOver(state: SmashUpCore): GameOverResult | undefined {
     if (state.gameResult) return state.gameResult;
 
-    // 鍥炲悎缁撴潫鏃舵鏌ワ細鏈夌帺瀹?>= 15 VP锛堝師濮?VP锛屾儵缃氬湪鏈€缁堝垎鏁颁腑浣撶幇锛?
     const winners = state.turnOrder.filter(pid => state.players[pid]?.vp >= VP_TO_WIN);
     if (winners.length === 0) return undefined;
 
@@ -1719,12 +1672,12 @@ function isGameOver(state: SmashUpCore): GameOverResult | undefined {
     if (winners.length === 1) {
         return { winner: winners[0], scores };
     }
-    // 澶氫汉杈炬爣锛氭渶缁堝垎鏁版渶楂樿€呰儨
+
     const sorted = winners.sort((a, b) => scores[b] - scores[a]);
     if (scores[sorted[0]] > scores[sorted[1]]) {
         return { winner: sorted[0], scores };
     }
-    // 骞冲眬锛氱柉鐙傚崱杈冨皯鑰呰儨锛堝厠鑻忛瞾鎵╁睍瑙勫垯锛?
+
     if (state.madnessDeck !== undefined) {
         const madnessA = countMadnessCardsForPlayer(state, sorted[0]);
         const madnessB = countMadnessCardsForPlayer(state, sorted[1]);
@@ -1732,7 +1685,7 @@ function isGameOver(state: SmashUpCore): GameOverResult | undefined {
             return { winner: madnessA < madnessB ? sorted[0] : sorted[1], scores };
         }
     }
-    // 浠嶇劧骞冲眬锛氱户缁父鎴?
+
     return undefined;
 }
 
@@ -1742,7 +1695,7 @@ export function getScores(state: SmashUpCore): Record<PlayerId, number> {
         const player = state.players[pid];
         if (!player) continue;
         let vp = player.vp;
-        // P19: 鐤媯鍗?VP 鎯╃綒锛堟瘡 2 寮犳墸 1 VP锛?
+
         if (state.madnessDeck !== undefined) {
             vp -= madnessVpPenalty(countMadnessCardsForPlayer(state, pid));
         }
@@ -1752,17 +1705,16 @@ export function getScores(state: SmashUpCore): Record<PlayerId, number> {
 }
 
 // ============================================================================
-// 浜嬩欢鎷︽埅锛氭浛浠ｆ晥鏋滐紙Replacement Effects锛?
+
 // ============================================================================
 
-/** 灏嗛鍩熷眰鎷︽埅鍣ㄦ敞鍐岃〃濮旀墭缁欏紩鎿?interceptEvent 閽╁瓙 */
 function domainInterceptEvent(
     state: SmashUpCore,
     event: SmashUpEvent
 ): SmashUpEvent | SmashUpEvent[] | null {
     const result = ongoingInterceptEvent(state, event);
     if (result !== undefined) return result;
-    return event; // 鏃犳嫤鎴櫒鍖归厤锛岃繑鍥炲師浜嬩欢
+    return event;
 }
 
 function resolveTitanClashEventsOnBase(
@@ -1876,7 +1828,7 @@ function resolveDeferredPecosBillClashEvents(
 }
 
 // ============================================================================
-// 绯荤粺浜嬩欢鍚庡鐞嗭細Prompt bridge 绛夌郴缁熶骇鐢熺殑棰嗗煙浜嬩欢闇€瑕佽Е鍙?ongoing trigger
+
 // ============================================================================
 
 function postProcessSystemEvents(
@@ -1886,11 +1838,11 @@ function postProcessSystemEvents(
     matchState?: MatchState<SmashUpCore>,
     options?: { skipImmediateStartTurnMinionTriggers?: boolean },
 ): { events: SmashUpEvent[]; matchState?: MatchState<SmashUpCore> } {
-    // 鎻愬彇鏃堕棿鎴筹紙鍙栫涓€涓簨浠剁殑 timestamp锛?
+
     const now = events.length > 0 && typeof events[0].timestamp === 'number' ? events[0].timestamp : 0;
-    // 褰撳墠鐜╁浣滀负 trigger 鐨?sourcePlayerId
+    // 当前玩家作为 trigger 的 sourcePlayerId
     const pid = getCurrentPlayerId(state);
-    // 浣跨敤 pipeline 浼犲叆鐨?matchState锛堝寘鍚湡瀹?sys锛夛紝鎴栨瀯閫犳渶灏忓寘瑁?
+
     let ms = matchState ?? { core: state, sys: { interaction: { current: undefined, queue: [] } } } as unknown as MatchState<SmashUpCore>;
     const inputEventsAlreadyReduced = !!(ms.sys as any)?._ppseInputEventsReduced;
     if (inputEventsAlreadyReduced) {
@@ -1903,39 +1855,24 @@ function postProcessSystemEvents(
         };
     }
 
-    // 渚濇鎵ц淇濇姢杩囨护 + trigger 鍚庡鐞嗭紙閾惧紡浼犻€?matchState锛?
-    // destroy 鈫?move 寰幆鐩村埌绋冲畾锛坢ove 瑙﹀彂鍣ㄥ彲鑳戒骇鐢熸柊鐨?MINION_DESTROYED锛?
     const afterDestroyMove = processDestroyMoveCycle(events, ms, pid, random, now);
     if (afterDestroyMove.matchState) ms = afterDestroyMove.matchState;
-    // 杩斿洖鎵嬬墝/鏀剧墝搴撳簳淇濇姢杩囨护锛堜笌 execute() 鍚庡鐞嗗榻愶級
+
     const afterProtectedAffect = filterProtectedAffectEvents(afterDestroyMove.events, ms.core, pid);
     const afterAffect = processAffectTriggers(afterProtectedAffect, ms, pid, random, now);
     if (afterAffect.matchState) ms = afterAffect.matchState;
     const afterDeckInspection = processDeckInspectionTriggers(afterAffect.events, ms, pid, random, now);
     if (afterDeckInspection.matchState) ms = afterDeckInspection.matchState;
 
-    // 妫€娴?MINION_PLAYED 浜嬩欢锛岃嚜鍔ㄨ拷鍔犺Е鍙戦摼锛坥nPlay + 鍩哄湴鑳藉姏 + ongoing锛?
-    // 鍏抽敭锛氬繀椤诲厛鎶?MINION_PLAYED 涔嬪墠鐨勪簨浠?reduce 鍒?core 涓紝
-    // 鍚﹀垯 onPlay 澶╄祴璇诲彇鐨勭墝搴?鎵嬬墝绛夌姸鎬佹槸鏃х殑锛堝缁寸撼鏂崟椋熻€呬粠鐗屽簱鎼滅储鎵撳嚭琛屽案锛?
-    // 琛屽案 onPlay 璇诲彇 deck[0] 鏃?CARDS_DRAWN 杩樻病 reduce锛岀墝搴撴湭鏇存柊锛夈€?
-    //
-    // 淇绛栫暐锛氬湪閬囧埌 MINION_PLAYED 鏃讹紝鍏堟妸瀹冧箣鍓嶇殑闈?MINION_PLAYED 浜嬩欢
-    // reduce 鍒颁复鏃?core 涓紝璁?fireMinionPlayedTriggers 鎷垮埌鏈€鏂扮殑鐗屽簱/鎵嬬墝鐘舵€併€?
-    // 涓?reduce MINION_PLAYED 鏈韩锛屽洜涓哄湪 execute 璺緞锛堟楠?4.5锛変腑 state 宸茬粡
-    // 鍖呭惈浜嗘墍鏈変簨浠剁殑 reduce 缁撴灉锛屽啀 reduce 浼氬鑷?minionsPlayed 绛夊瓧娈甸噸澶嶈绠椼€?
-    //
-    // 鍘婚噸閫昏緫锛圖45 缁村害锛夛細postProcessSystemEvents 鍦?pipeline 涓璋冪敤涓ゆ锛堟楠?4.5 鍜屾楠?5锛夛紝
-    // 蹇呴』闃叉鍚屼竴涓?MINION_PLAYED 浜嬩欢琚噸澶嶅鐞嗐€傚幓閲嶇瓥鐣ワ細
-    // 1. 浼樺厛妫€鏌?sourceCommandType锛氭潵鑷懡浠ょ殑浜嬩欢锛堟湁 sourceCommandType锛夊彧鍦ㄦ楠?4.5 澶勭悊
-    // 2. 瀵逛簬娲剧敓浜嬩欢锛堟棤 sourceCommandType锛夛紝閫氳繃 cardUid+baseIndex 鍘婚噸锛岄伩鍏嶉噸澶嶅鐞?
-    // 3. 浣跨敤 matchState.sys._processedMinionPlayed 闆嗗悎璁板綍宸插鐞嗙殑浜嬩欢锛堟牸寮忥細`${cardUid}@${baseIndex}`锛?
+    // 先 reduce 到临时 core 中，让 fireMinionPlayedTriggers 拿到最新的牌库/手牌状态。
+    // 必须防止同一 MINION_PLAYED 事件被重复处理。去重策略：
+
     const derivedEvents: SmashUpEvent[] = [];
-    // 鏀堕泦 MINION_PLAYED 涔嬪墠鐨勯潪 MINION_PLAYED 浜嬩欢锛岀敤浜庝复鏃?reduce
+
     const prePlayEvents: SmashUpEvent[] = [];
     
-    // 鍒濆鍖栧凡澶勭悊浜嬩欢闆嗗悎锛堝鏋滀笉瀛樺湪锛?
-    // 浣跨敤 any 绫诲瀷鏂█缁曡繃 SystemState 绫诲瀷闄愬埗锛堣繖鏄父鎴忕壒瀹氱殑涓存椂鐘舵€侊級
-    // 銆怐45 淇銆戠粺涓€澶勭悊 MINION_PLAYED 鍜?ACTION_PLAYED 鐨勫幓閲?
+
+    // 【D45 修复】统一处理 MINION_PLAYED 和 ACTION_PLAYED 的去重
     const sysAny = ms.sys as any;
     if (!sysAny._processedPlayedEvents || !(sysAny._processedPlayedEvents instanceof Set)) {
         sysAny._processedPlayedEvents = new Set<string>();
@@ -1975,27 +1912,25 @@ function postProcessSystemEvents(
         } else if (event.type === SU_EVENTS.MINION_PLAYED) {
             const playedEvt = event as MinionPlayedEvent;
             
-            // 鍘婚噸妫€鏌ワ細鏋勯€犱簨浠跺敮涓€鏍囪瘑锛圡INION: + cardUid + baseIndex锛?
+
             const eventKey = `MINION:${playedEvt.payload.cardUid}@${playedEvt.payload.baseIndex}`;
             
-            // 濡傛灉宸插鐞嗚繃锛岃烦杩囷紙闃叉姝ラ 4.5 鍜屾楠?5 閲嶅澶勭悊锛?
+
             if (processedSet.has(eventKey)) {
                 prePlayEvents.push(event);
                 continue;
             }
             
-            // 鏍囪涓哄凡澶勭悊
+            // 标记为已处理
             processedSet.add(eventKey);
             
-            // 灏嗕箣鍓嶇Н绱殑浜嬩欢 reduce 鍒颁复鏃?core
-            // 纭繚 onPlay 瑙﹀彂鏃剁湅鍒扮殑鏄渶鏂扮姸鎬侊紙闅忎粠宸插湪鍦轰笂锛岀墝搴?鎵嬬墝宸叉洿鏂帮級
+            // 将之前积累的事件 reduce 到临时 core
+
             let tempCore = state;
             for (const preEvt of prePlayEvents) {
                 tempCore = reduce(tempCore, preEvt);
             }
-            // 銆愰噸瑕併€戝浜庝粠闈炴墜鐗屾潵婧愨€滈澶栨墦鍑衡€濈殑闅忎粠锛坒romDeck / fromDiscard / fromBuried锛夛紝
-            // 蹇呴』鍦ㄨ繖閲?reduce 褰撳墠 MINION_PLAYED 浜嬩欢锛岀‘淇?onPlay 瑙﹀彂鍣ㄨ兘鍦?core 涓壘鍒拌闅忎粠锛?
-            // 骞惰鍒版纭殑 metadata.playedFrom锛堜緥濡傜炕鍑哄煁钁墝鏃讹級銆?
+
             const payload = event.payload;
             if (payload.fromDeck || payload.fromDiscard || payload.fromBuried) {
                 tempCore = reduce(tempCore, event);
@@ -2016,36 +1951,33 @@ function postProcessSystemEvents(
             derivedEvents.push(...triggers.events);
             if (triggers.matchState) ms = triggers.matchState;
         } else if (event.type === SU_EVENTS.ACTION_PLAYED) {
-            // 銆怐45 淇銆慉CTION_PLAYED 浜嬩欢涔熼渶瑕佸幓閲嶏紝闃叉琛屽姩鍗?onPlay 鑳藉姏琚Е鍙戜袱娆?
-            // 鍏稿瀷鍦烘櫙锛氫紶閫侀棬鍒涘缓浜や簰锛屼氦浜掕В鍐冲悗 pipeline 閲嶆柊杩涘叆 postProcessSystemEvents
+
             const playedEvt = event as { type: string; payload: { playerId: string; cardUid: string; defId: string }; timestamp: number };
             
-            // 鍘婚噸妫€鏌ワ細鏋勯€犱簨浠跺敮涓€鏍囪瘑锛圓CTION: + cardUid + playerId锛?
+
             const eventKey = `ACTION:${playedEvt.payload.cardUid}@${playedEvt.payload.playerId}`;
             
-            // 濡傛灉宸插鐞嗚繃锛岃烦杩囷紙闃叉姝ラ 4.5 鍜屾楠?5 閲嶅澶勭悊锛?
+
             if (processedSet.has(eventKey)) {
                 prePlayEvents.push(event);
                 continue;
             }
             
-            // 鏍囪涓哄凡澶勭悊
+            // 标记为已处理
             processedSet.add(eventKey);
             
-            // ACTION_PLAYED 鐨?onPlay 瑙﹀彂宸插湪 execute() 涓鐞嗭紝杩欓噷鍙渶瑕佹爣璁板幓閲?
-            // 涓嶉渶瑕侀澶栬Е鍙戦€昏緫锛堜笌 MINION_PLAYED 涓嶅悓锛?
+
             prePlayEvents.push(event);
         } else {
             prePlayEvents.push(event);
         }
     }
 
-    // 瀵?derived events 閫掑綊鎵ц trigger 鍚庡鐞嗭紙onPlay 浜х敓鐨?MINION_DESTROYED 绛夐渶瑕佽Е鍙?onDestroy 閾撅級
     let finalDerived = derivedEvents;
     if (derivedEvents.length > 0) {
         const afterDerivedDestroyMove = processDestroyMoveCycle(derivedEvents, ms, pid, random, now);
         if (afterDerivedDestroyMove.matchState) ms = afterDerivedDestroyMove.matchState;
-        // 杩斿洖鎵嬬墝/鏀剧墝搴撳簳淇濇姢杩囨护锛堜笌 execute() 鍚庡鐞嗗榻愶級
+
         const afterDerivedProtectedAffect = filterProtectedAffectEvents(afterDerivedDestroyMove.events, ms.core, pid);
         const afterDerivedAffect = processAffectTriggers(afterDerivedProtectedAffect, ms, pid, random, now);
         if (afterDerivedAffect.matchState) ms = afterDerivedAffect.matchState;

--- a/src/games/smashup/domain/ongoingEffects.ts
+++ b/src/games/smashup/domain/ongoingEffects.ts
@@ -1,13 +1,9 @@
 /**
- * 婵犮垹鐖㈤崟顒傜シ闂佹悶鍎茬粙鎺楀蓟?- 闂佸綊鏅查懗鍫曟偨婵犳艾鏋侀柛顐ゅ枔娴滎垶鏌熼崙銈夋闁糕晛鎳庨々濂稿幢濡棿妗?
+
  *
- * 婵炴垶鎸搁ˇ閬嶏綖閹烘绠柨鏃囨閻掑鏌涢敐鍐ㄥ閻炴凹鍋婂畷鍦偓锝呭缁?
- * 1. protection - 婵烇絽娲︾换鍐╂叏閵忋倖鈷曢煫鍥ф捣閻倕鈽夐幘宕囆㈢憸鏉跨墦閹囨偡閹殿喗姣庨悷婊勬緲瀹曨剟骞栭悜鑺ユ櫖闁割偅绻嶅ú銈呪槈閹惧磭孝鐟滄媽灏欓幃顕€顢曢敐鍥嗐儵鏌ｈ箛锝呭箲闁逞屽厸濡炴帞绮径鎰煑婵°倐鍋撴い鏇ㄥ櫍楠炲秶鈧綆鍙庨弨浠嬫煕閺傝濡煎┑鍌涚墵瀹曨偄顓艰箛鏇狀槴
- * 2. restriction - 闂傚倸瀚崝鏇㈠春濡ゅ懎绠肩€广儱瀚粙濠囨煥濞戞澧曟い鈹懐鐭夊ù锝堫嚃閸撻箖鏌熼崹顐ｅ碍闁搞値鍙冨鎹愮疀鎼达絿鐓犻梺鍛婂笧婢ф鎮￠崶顒€鏄ラ柛婵嗗閸曢箖鏌曢崱鏇″厡妞も晪绠戦～銏ゅ閳ユ枼鍙洪柣鐐寸☉閼活垱鎱ㄩ埡鍛闁宠棄鎳愮粈?
- * 3. trigger - 婵炲瓨绮岄鍕枎閵忋垺鍠嗛柨鏇楀亾鐟滄澘鍊垮畷鍫曟倷閸撲焦顔嶉梺鎸庣☉閻楀棝銆呰濮婃崘绠涙惔锝囩厾闂佺绻堥崕鍗炩攦閳ь剟鏌￠崘顓炵厫缂佸鍏橀幃姗€顢樺┃鎯т壕濞达絽鎲＄粈鈧梺鍛婅壘閻楀繒鍒掗妸鈺佺骇闁绘柨鎲￠ˇ褔鏌熼崜浣规珪濠⒀勭箞閺?
+
  *
- * 闂佺懓鍤栭梽鍕春閸涙潙闂柕濠忕畱閻?defId 濠电偛顦崝宀勫船娴犲鏅€光偓閸愵亞顓奸柣鐐寸☉閺堫剙顪冮崒鐐插唨閻熸瑥瀚粊锕傛煕閿曚焦銆冪紒?ongoing 闁荤偞绋戦懟顖涙叏閳哄懎纭€闁炽儴娅曠€氭煡姊婚崨顓犵缂侇喚濞€閹虫鎸婃径濠庢綕闂佸搫琚崕鎾敋濡ゅ懎违?
- * 缂備胶铏庨崹浼村吹闁秴鏋侀柟宄扮焾閸熷酣鎮规担鍙夘潐缂佸彉鍗冲濠氬Ψ椤垵娈戦梺鍝勫暞濠€鍦閸洖绀傞柕澶堝劤缁夊ジ鏌涢幘宕囆ゅ┑顔芥倐楠炩偓濞撴艾锕︾粈澶娾槈閹惧磭校閻庡灚妫冨鍨緞婵犲倽顔夐梺鍛婄懄椤洦鎱ㄩ幖浣哥畱濞达絿顣介崑?
+
  */
 
 import type { PlayerId, RandomFn, MatchState } from '../../../engine/types';
@@ -27,91 +23,76 @@ import { getBaseDef, getTitanDef } from '../data/cards';
 import { matchesDefId, mustUseBaseLimitedMinionQuota } from './utils';
 
 // ============================================================================
-// 缂備緡鍋夐褔鎮楁搴樺亾鐟欏嫮鐓紒?
-// ============================================================================
 
-/** 婵烇絽娲︾换鍐╂叏閵忋垻灏甸悹鍥皺閳?*/
 export type ProtectionType =
-    | 'destroy'       // 婵炴垶鎸哥粔纾嬨亹閼碱剚鍋栨い鎰剁悼鍟搁梺?
-    | 'move'          // 婵炴垶鎸哥粔纾嬨亹閼碱剚鍋栨い鎰╀紗閳哄懎绀?
-    | 'affect'        // 婵炴垶鎸哥粔纾嬨亹閸懇鍋撴担鍐炬綈濠⒀勭矒瀹曪繝鏁嶉崟顐澓閻熸粍婢樺畷顒勫箹閻戣姤鏅柛顐ｇ箘閻ｎ厼鈽夐弬娆炬Х缂佺粯宀搁獮搴ㄥΧ韫囨洜顦?
-    | 'action';       // 婵炴垶鎸哥粔纾嬨亹閸懇鍋撴担鍐炬綈濠⒀勭矌閹壆浠﹂挊澹鏌涘鐑╁亾閸愬樊娈梺?
+    | 'destroy'
+    | 'move'
+    | 'affect'
+    | 'action';
 
-/** 闂佺硶鏅涢幖顐耿閹绢喗鍤勯柦妯侯槸椤棃鏌涘Ο渚剰闁糕晜顨呰灋闁逞屽墴瀵濡烽妷銉︾槪闂佽桨绀佹惔婊呮閻楀牊浜ら柡鍌涘缁€鈧?true 闁荤偞绋忛崝搴ㄥΦ濮樿鲸瀚氶柕澶堝劤閸炪劑鏌涢敂钘夘€滈柛蹇旓耿瀹曟繂鈽夊搴㈣晧闂佸憡锚椤戝懘宕?*/
 export type BaseAbilitySuppressionChecker = (state: SmashUpCore, baseIndex: number) => boolean;
 
-/** 婵烇絽娲︾换鍐╂叏閵忕姈娑㈠焵椤掑嫬钃熼柕澶堝€楅悷鎰槈閹炬剚鍎愰柡?*/
 export interface ProtectionCheckContext {
     state: SmashUpCore;
-    /** 闁荤偞鍑归崑鍌滄崲濮樿泛绠柕鍫濇处閻ｉ亶姊婚崨顓犵缂?*/
+
     targetMinion: MinionOnBase;
-    /** 闂傚倸鎳庣换瀣垝閻樿绠ラ柍褜鍓熷畷鐑藉Ω閵壯冩暏闂侀潻闄勬竟鍡涘磼閵娿儺鍤?*/
+
     targetBaseIndex: number;
-    /** 闂佸憡鐟﹂崹濂稿箲閿濆牄浜归柛妤冨仦閹瑩鏌ｉ妸銉ヮ伀閻㈩垵娅ｉ埀顒傤攰椤旀劗妲愬▎鎾崇哗閻犲洦褰冨В濠囨煠閺夋寧瀚呯紒?*/
+
     sourcePlayerId: PlayerId;
-    /** 婵烇絽娲︾换鍐╂叏閵忋垻灏甸悹鍥皺閳?*/
+
     protectionType: ProtectionType;
 }
 
-/** 婵烇絽娲︾换鍐╂叏閵忕姈娑㈠焵椤掑嫬钃熼柕澶堝劚濮ｆ劙鏌℃担绋跨盎缂佽京澧楀濠氬棘閹稿海顦?true 闁荤偞绋忛崝搴ㄥΦ濮樿鲸瀚氶柕澶嗘櫆椤撶懓霉閻樻煡顎楃憸鏉跨墛缁屽崬鈹戦崶顬?*/
 export type ProtectionChecker = (ctx: ProtectionCheckContext) => boolean;
 
-/** 闂傚倸瀚崝鏇㈠春濡ゅ啰灏甸悹鍥皺閳?*/
 export type RestrictionType =
-    | 'play_minion'   // 缂備礁鍊烽悞锕傤敆濞戙垹绠ラ柟鎯у暱濮ｅ姊婚崨顓犵缂侇喚濞€瀹曟岸鎮ч崼銏犲福闂佺硶鏅涢幖顐耿?
-    | 'play_action';  // 缂備礁鍊烽悞锕傤敆濞戙垹绠ラ柟鎯у暱濮ｅ鎮跺☉妯垮濠殿喒鏅犲畷锟犲灳閸愯尙鍘掗梺鍝勬湰閸旀洟鎮㈤埀顒勬煕?
+    | 'play_minion'
+    | 'play_action';
 
-/** 闂傚倸瀚崝鏇㈠春濡も偓铻為柍褜鍓熷濠氬Ψ閵堝洨鎲繛鎴炴尭椤戝棝寮?*/
 export interface RestrictionCheckContext {
     state: SmashUpCore;
-    /** 闁荤偞鍑归崑濠傤瀶濞差亜绀嗛柛鎾茬劍閻ｉ亶鏌涢埡浣规儓婵犫偓鐎靛憡顫曢柕蹇曞Х缁?*/
+
     baseIndex: number;
-    /** 闁诲繐绻戠换鍡涙儊椤栫偛绠肩€广儱瀚粙濠囨煟閵娿儱顏悽顖濇閳?*/
     playerId: PlayerId;
-    /** 闂傚倸瀚崝鏇㈠春濡ゅ啰灏甸悹鍥皺閳?*/
+
     restrictionType: RestrictionType;
-    /** 婵☆偆澧楃换鍌炈囨繝姘瀬闁绘鐗嗙粊锕傛煥濞戞澧曟い鈹洤纭€闁挎稑瀚·?defId闂侀潧妫旈悞锕€菐瀹曞洤瀵查柤濮愬€楅幖濂告煥?*/
+
     extra?: Record<string, unknown>;
 }
 
-/** 闂傚倸瀚崝鏇㈠春濡も偓铻為柍褜鍓熷濠氬Ψ閵夈儲鐦ｉ梺杞扮鎼存粎妲愰悧鍫熶氦闁哄倹瀵х粈鈧?true 闁荤偞绋忛崝搴ㄥΦ濮樿泛绠肩€广儱瀚粙濠囨偠濮樼厧浜版俊鐐そ瀹?*/
 export type RestrictionChecker = (ctx: RestrictionCheckContext) => boolean;
 
 /**
- * 婵炲瓨绮岄鍕枎閵忋倕绠柨鏃囨閻掑鏌涢敐搴ｅ帨缂佸彉鍗冲瀛樺緞缁嬫寧鏆曢梺杞扮閻楀﹪鎮樻径鎰櫖闁革富婀痯lacement Effects闂?
+
  *
- * 闁哄鏅滈弻銊ッ洪弽顓炵９闁煎綊鍋婇崵鏂库槈閺傛妲风紒妤€鑻锝夊即閻斿憡鍎?interceptEvent 婵炴垶鎸撮崑鎾绘煠閻ゎ垱褰х紒?
- * - undefined 闂?婵炴垶鎸哥粔鐢碘偓姘ュ€濋獮瀣敂鎼达絿顦╃紓鍌欑秬閸涱垱鏆板┑鈽嗗亐閸嬫捇鏌＄仦璇插姍缂佹鎳忕粙澶愬焵椤掍胶鈻旀い蹇撴噹椤忥繝鏌熼幖顓濈盎婵炲懏甯￠弫?
- * - SmashUpEvent / SmashUpEvent[] 闂?闂佸搫娲︾€笛冪暦?
- * - null 闂?闂佸憡姘ㄩ崑娑樷枍?
+
  */
 export type EventInterceptor = (
     state: SmashUpCore,
     event: SmashUpEvent
 ) => SmashUpEvent | SmashUpEvent[] | null | undefined;
 
-/** 闁荤喐鐟辩粻鎴ｃ亹閸岀偛绫嶉柤绋跨仛缁?*/
 export type TriggerTiming =
     | 'onDuelStarted'
     | 'onDuelResolved'
-    | 'onMinionPlayed'     // 闂傚倸鎳庣换瀣垝閻樿绀傞柕澶堝劜缁ㄦ岸鏌?
-    | 'onActionPlayed'     // 闁荤偞绋戦懟顖涙叏閳哄懎纭€闁斥晛鍟埅鐢告煕閹寸姴鍔嬫俊鐐插€块弫宥夊醇閵忊剝娈㈡繛瀛樼矊妤犳悂鎮㈤埀顒勬煕閿旇棄顎滈柛蹇旓耿瀹曟繂鈽夐姀鈱掓洟鏌涢幒鎿冩當閻庡灚鐓￠弫?
-    | 'onCardsDiscarded'   // 闂佸綊娼ч鍥ㄦ櫠濠靛棭鍤曢柛鎰典簽閺嬪倿鏌?
-    | 'onCardBuried'       // 闂佸憡顨愮槐鏇熸櫠濠靛牊鍋栨い鎰╁灮閸樻垿鏌︽笟鍥у婵?
-    | 'onBuriedCardUncovered' // 闂佺硶鏅涢鍫ュ箠瀹ュ鍋嬬€光偓閸愮偓钑夌紓鍌氱墣椤曆呮閹达箑绫?
-    | 'onBaseRevealed'     // 闂佺硶鏅涢幖顐耿鐎靛摜绀勯悹鍥ㄥ絻濮?闂佸搫娲︾€笛冪暦閺屻儱瑙﹂幖绮光偓鍐叉辈闂侀潻濡囩亸銊ф濞嗘挸绠ラ柍杞拌兌濞兼棃鏌涢埡浣规儓婵犫偓鐎靛憡鍠嗛柨鏇楀亾鐟滄澘鍊块弫?
-    | 'onMinionDestroyed'  // 闂傚倸鎳庣换瀣垝閻樺灚鍋栨い鎰剁悼鍟搁梺璇叉禋閸樿棄顪?
-    | 'onMinionMoved'      // 闂傚倸鎳庣换瀣垝閻樺灚鍋栨い鎰╀紗閳哄懎绀夐柕濠忛檮椤?
-    | 'onCardReturnedToHand' // 闂佸憡顨愮槐鏇熸櫠濠靛洨顩烽幖绮瑰墲缁ㄦ艾鈽夐幘绛规敾闁搞劊鍔岄锝夊礃椤忓嫷鏉洪梺鍓插亜濡粎鎹㈠鈧畷妤呭Ψ閿曗偓椤や線鏌ｅΔ鈧張顒€顪?
-    | 'onDeckInspected'    // 闂佺粯顨呴懟顖滆姳鏉堚晜鍋栨い鎰剁悼閸欌偓闂?/ 闁诲繒鍋炲ú婊堝Φ?/ 濠碘槅鍋€閸嬫挾绱掓笟鍨仾婵?
-    | 'onMinionAffected'   // 闂傚倸鎳庣换瀣垝閻樺灚鍋栨い鎰╁焺閸ょ娀鏌熼棃娑卞剱闁哄懌鍎靛绋款煥閸愵煈娈梺鍛婄箓缁夐潧顪冮崒鐐存櫖闁割偓绲肩划鐢告煕濮橆剛澧涙俊鐐插€垮鐢告偖鐎靛摜鐛ュ┑鐐村灥閻楀繑瀵?缂備礁顦抽褎鎱?闂佸憡姊归惄顖炲闯閻戞鈹嶆い鏃囧Г閺?闂傚倸瀚€氼喖顭?闂佺鐭囬崘銊у幀闂佸搫顦崯顐ャ亹婢舵劕鍗抽弶鍫濆⒔缁€?
-    | 'onMinionDiscardedFromBase' // 闂佺硶鏅涢幖顐耿鐎靛摜纾奸柟鎯у閺嗩剟鏌￠崘銊у煟婵炲牄鍨虹粋鎺撴償閵堝孩钑夐悗娈垮枛閸熶即鎮块崱娑欐櫖闁割偁鍎叉慨婊勭箾閹存繄澧㈠ù鐓庡暣閺?
-    | 'onTurnEnd'          // 闂佹悶鍎抽崑娑㈠箖鎼达絿纾奸柟鎯х摠鐏忓棝鏌?
-    | 'onTurnStart'        // 闂佹悶鍎抽崑娑㈠箖鎼粹槅鍤曢柍褜鍓氶幈銊р偓锝庡亝椤?
-    | 'beforeScoring'      // 闂佺硶鏅涢幖顐耿鐎靛憡濯奸柍銉ュ暱閻庡鏌?
-    | 'afterScoring';      // 闂佺硶鏅涢幖顐耿鐎靛憡濯奸柍銉ュ暱閻庡鏌?
+    | 'onMinionPlayed'
+    | 'onActionPlayed'
+    | 'onCardsDiscarded'
+    | 'onCardBuried'
+    | 'onBuriedCardUncovered'
+    | 'onBaseRevealed'
+    | 'onMinionDestroyed'
+    | 'onMinionMoved'
+    | 'onCardReturnedToHand'
+    | 'onDeckInspected'
+    | 'onMinionAffected'
+    | 'onMinionDiscardedFromBase'
+    | 'onTurnEnd'
+    | 'onTurnStart'
+    | 'beforeScoring'
+    | 'afterScoring';
 
-/** 閻熸粍婢樺畷顒勫箹妞嬪海灏甸悹鍥皺閳ь剛鍏橀弫宥夊醇濠婂懐鐓?onMinionAffected 闂佸搫鍟抽崺鏍э耿娓氣偓瀹曟劗娑垫搴ｎ槴 */
 export type TitanAwareTriggerTiming = TriggerTiming | 'whenScoring' | 'onTitanMoved';
 
 export type AffectType =
@@ -124,7 +105,6 @@ export type AffectType =
     | 'cancel_ability'
     | 'shuffle_into_deck';
 
-/** 闁荤喐鐟辩粻鎴ｃ亹閸屾稓鈻斿┑鐘辫兌閻熸捇鏌?*/
 export interface TriggerContext {
     state: SmashUpCore;
     /** 完整的 match 状态，用于触发器创建交互 */
@@ -195,26 +175,24 @@ export interface TriggerContext {
     now: number;
 }
 
-/** 闁荤喐鐟辩粻鎴ｃ亹閸岀偛鐐婇柣鎰濞堝爼鏌涢幋锝呅撻柡鍡欏枑濞煎寮幐搴ｎ槬闂?*/
 export interface TriggerResult {
     events: SmashUpEvent[];
-    /** 婵犵鈧啿鈧綊鎮樻径灞惧枂闁挎洍鍋撶憸鏉垮€垮畷鎶藉Ω閳哄倷绮柣鐔告磻缁€渚€宕归崡鐑嗗殘閺夌偟澧楅崬澶娒瑰鍕嚋缂佽鲸鐟︽穱濠囧磼濠婂啳绀嬮柣搴ｆ嚀閻栧ジ鍩€椤掆偓椤︽壆鈧哎鍔戦弫宥嗗緞濞戞氨顦柡澶嗘櫆閺屻劌煤閺嶎厼鍗抽悗娑櫳戦悡鈧梺鍛婅壘濞村嘲鈻?matchState */
+
     matchState?: MatchState<SmashUpCore>;
 }
 
-/** 闁荤喐鐟辩粻鎴ｃ亹閸岀偛鐐婇柣鎰濞堝爼鏌涢幋锝呅撻柡鍡欏枛閺佸秴顫濆畷鍥╊唹闂佹悶鍎抽崑妯活殽閸ヮ剚鍋ㄩ柣鏃傚劋閻ｅ崬霉濠婂喚鍎庢繛鍡愬灲閺佸秹宕煎┑鍥ь伅闂佸憡鐟崹鍫曞焵椤掆偓椤﹀崬鈻?matchState闂?*/
 export type TriggerCallback = (ctx: TriggerContext) => SmashUpEvent[] | TriggerResult;
 
 // ============================================================================
-// 闂佺懓鍤栭梽鍕春閸涙潙闂柕濠忛檮閺嗗牓鏌涢幇顒佹拱婵炵⒈鍨堕幆?
+
 // ============================================================================
 
 interface ProtectionEntry {
-    /** 闂佸湱绮崝鎺旀閸偆鈹嶆繝闈涙搐琚橀梺?ongoing 闂佸憡顨愮槐鏇熸櫠濠靛绠ｉ柡宥庡幗椤撶懓霉?defId */
+
     sourceDefId: string;
     protectionType: ProtectionType;
     checker: ProtectionChecker;
-    /** 濠电偞鍨甸悧鎰板焵椤掍緡娈旈柣搴ㄦ敱缁屽崬鈹戦崶顬垿鏌ㄥ☉娆庝孩鐞氭繈鏌涘▎鎰仴闁诡喗顨婂Λ渚€鍩€椤掑倹鍟哄ù锝呮贡鍟搁梺璇叉禋閸樿棄顭囬棃娑掓敠闁归偊鍓欓獮銏ゆ煟濡も偓閻妲愬▎鎰箚?trickster_hideout闂?*/
+
     consumable?: boolean;
 }
 
@@ -232,16 +210,16 @@ interface TriggerEntry {
     phase?: 'replacement' | 'reaction';
     playerContext?: 'eventPlayer' | 'sourceController';
     baseScoped?: boolean;
-    /** true 闂佸搫鍟抽崺鏍偓鍨矒瀹曢攱娼幍顔炬啰濠殿噯绲界换瀣煂濠婂牆绾ч柕澶涘閻栭亶鎮楅崷顓炰粧缂佽翰鍎靛畷锟犲即閻樺樊浠鹃梺绋跨箞閸庨潧危?闂佸湱鐟抽崱鈺傛杸闂佹寧绋戦惌渚€鍩€椤掆偓婵傛梻绮径鎰強妞ゆ牗绋戦惁?defId 闂佽壈椴搁懝楣冨箖鎼淬垻鈻旈柍褜鍓欓埢?*/
+
     perInstance?: boolean;
-    /** true 闂佸搫鍟崕濂搞€呴敃鈧晥闁稿本绋掗梽宥嗙節瑜庨崝鏇犳崲閳ь剙顪冮妶鍫敽缂傚秴鎳忕粋宥嗘償閿涘嫮歇闂佸憡鎸哥粔鐤杺闂佸憡鐟﹂崹鐢割敋椤旇姤鍎熼柡鍐ㄥ€归悾閬嶆煕閳轰焦鎯堟繝鈧幘顔芥櫖闁割偅绮庢导鎰攽閳ュ啿鈧粙顢橀幖浣哥闁糕剝顨堥崬銊╂煕閿曞偆鏆掔紒妤€鍊块幆鍐礋椤栨侗鍚傛繛瀵稿Т閸戠晫妲?*/
+
     sourceScope?: 'any' | 'triggerBase';
     /**
      * Global triggers bypass the "source must be in play" witness check.
      * Use for Special cards that can be played from hand/discard when a condition happens.
      */
     global?: boolean;
-    /** global 闁荤喐鐟辩粻鎴ｃ亹閸岀偛闂柕濞垮劚鐢帡鎮规担鍦憙妞ゎ偄妫涢幏鐘虫媴閻戞鏆犻梺鍝勵槶閸庤尙鑺遍鈧畷鐘诲传閸曨厼骞嶉梺鎸庣⊕閻╊垳鍒掗婊勫?hand + discard */
+
     globalZones?: Array<'hand' | 'discard' | 'deck'>;
 }
 
@@ -258,7 +236,7 @@ interface InterceptorEntry {
 }
 
 // ============================================================================
-// 濠电偛顦崝宀勫船閻ｅ本鍋?
+
 // ============================================================================
 
 const protectionRegistry: ProtectionEntry[] = [];
@@ -267,30 +245,27 @@ const triggerRegistry: TriggerEntry[] = [];
 const interceptorRegistry: InterceptorEntry[] = [];
 const baseAbilitySuppressionRegistry: { sourceDefId: string; checker: BaseAbilitySuppressionChecker }[] = [];
 
-/** 濠电偛顦崝宀勫船閼恒儳鈹嶆繝闈涙搐琚橀梺鐟板殩闂勫嫰宕洪崨鏉戦棷?*/
 export function registerProtection(
     sourceDefId: string,
     protectionType: ProtectionType,
     checker: ProtectionChecker,
     options?: { consumable?: boolean }
 ): void {
-    // 闂佸憡锚椤兘宕抽崨濠勨攳婵犻潧娲よ闂佹寧绋掗懝楣冨箖閹惧鈻旈柍?sourceDefId + protectionType 闂佸憡鐟禍婵嬪极閻愬搫绀冮悘鐐跺亹椤忚鲸绻涢崱蹇旑潐缂佽鲸鐟╁濂稿矗婢舵ê澹?HMR 闂備焦褰冪粔鎾囬幓鎺嗘灃闁靛鍎遍弬鈧梺?
+
     if (protectionRegistry.some(e => e.sourceDefId === sourceDefId && e.protectionType === protectionType)) return;
     protectionRegistry.push({ sourceDefId, protectionType, checker, consumable: options?.consumable });
 }
 
-/** 濠电偛顦崝宀勫船娴犲鈷旈柟閭﹀墮閻撴垿鏌熼崙銈夋闁糕晛鎳樺畷?*/
 export function registerRestriction(
     sourceDefId: string,
     restrictionType: RestrictionType,
     checker: RestrictionChecker
 ): void {
-    // 闂佸憡锚椤兘宕抽崨濠勨攳婵犻潧娲よ闂佹寧绋掗懝楣冨箖閹惧鈻旈柍?sourceDefId + restrictionType 闂佸憡鐟禍婵嬪极閻愬搫绀冮悘鐐跺亹椤忚鲸绻涢崱蹇旑潐缂佽鲸鐟╁濂稿矗婢舵ê澹?HMR 闂備焦褰冪粔鎾囬幓鎺嗘灃闁靛鍎遍弬鈧梺?
+
     if (restrictionRegistry.some(e => e.sourceDefId === sourceDefId && e.restrictionType === restrictionType)) return;
     restrictionRegistry.push({ sourceDefId, restrictionType, checker });
 }
 
-/** 濠电偛顦崝宀勫船閻ｅ本鍠嗛柨鏇楀亾鐟滄澘鍊块獮蹇涙晜閽樺鍔甸梺?*/
 export function registerTrigger(
     sourceDefId: string,
     timing: TitanAwareTriggerTiming,
@@ -306,7 +281,7 @@ export function registerTrigger(
         sourceScope?: 'any' | 'triggerBase';
     }
 ): void {
-    // 闂佸憡锚椤兘宕抽崨濠勨攳婵犻潧娲よ闂佹寧绋掗懝楣冨箖閹惧鈻旈柍?sourceDefId + timing 闂佸憡鐟禍婵嬪极閻愬搫绀冮悘鐐跺亹椤忚鲸绻涢崱蹇旑潐缂佽鲸鐟╁濂稿矗婢舵ê澹?HMR 闂備焦褰冪粔鎾囬幓鎺嗘灃闁靛鍎遍弬鈧梺?
+
     if (triggerRegistry.some(e => e.sourceDefId === sourceDefId && e.timing === timing)) return;
     triggerRegistry.push({
         sourceDefId,
@@ -527,27 +502,24 @@ export function collectTriggers(
     } as TriggerQueuedEvent;
 }
 
-/** 濠电偛顦崝宀勫船閼恒儳顩查悗锝傛櫆椤愪粙鏌熼崙銈夋闁糕晛鎳樺畷鎶解€﹂幒鏃傤槱闂佸搫娲ら妵姗€宕鍕瀬闁割偆鍠撴禍顖炴煥?*/
 export function registerInterceptor(
     sourceDefId: string,
     interceptor: EventInterceptor
 ): void {
-    // 闂佸憡锚椤兘宕抽崨濠勨攳婵犻潧娲よ闂佹寧绋掗懝楣冨箖閹惧鈻旈柍?sourceDefId 闂佸憡鐟禍婵嬪极閻愬搫绀冮悘鐐跺亹椤忚鲸绻涢崱蹇旑潐缂佽鲸鐟╁濂稿矗婢舵ê澹?HMR 闂備焦褰冪粔鎾囬幓鎺嗘灃闁靛鍎遍弬鈧梺?
+
     if (interceptorRegistry.some(e => e.sourceDefId === sourceDefId)) return;
     interceptorRegistry.push({ sourceDefId, interceptor });
 }
 
-/** 濠电偛顦崝宀勫船娴犲鏄ラ柛婵嗗閸曢箖鏌ょ€圭姵顥夊┑顔肩箻瀹曘垻鈧綆浜滈悡鎴︽煥濞戞澧曟い?alien_jammed_signal闂佹寧绋掔喊宥嗘櫠瀹ュ瀚夊璺鸿嫰鐠愮喖鎮楃涵鍛厫婵☆偁鍊楅幉鎾幢濮楀棗濡伴梺绯曟櫅閹碱偄锕㈤幘顔藉殑闁芥ê顦～鏃堟煥?*/
 export function registerBaseAbilitySuppression(
     sourceDefId: string,
     checker: BaseAbilitySuppressionChecker
 ): void {
-    // 闂佸憡锚椤兘宕抽崨濠勨攳婵犻潧娲よ闂佹寧绋掗懝楣冨箖閹惧鈻旈柍?sourceDefId 闂佸憡鐟禍婵嬪极閻愬搫绀冮悘鐐跺亹椤忚鲸绻涢崱蹇旑潐缂佽鲸鐟╁濂稿矗婢舵ê澹?HMR 闂備焦褰冪粔鎾囬幓鎺嗘灃闁靛鍎遍弬鈧梺?
+
     if (baseAbilitySuppressionRegistry.some(e => e.sourceDefId === sourceDefId)) return;
     baseAbilitySuppressionRegistry.push({ sourceDefId, checker });
 }
 
-/** 濠电偞鎸搁幊鎰板煘閺嶎厼绠ラ柍褜鍓熷鍨緞鐎ｎ偅娈橀梺鍛婂姇閻線濡撮崘顔芥櫖闁割偆鍠撻妶鎾偣閸ャ劍绀堥柡浣靛€濋弫?*/
 export function clearOngoingEffectRegistry(): void {
     protectionRegistry.length = 0;
     restrictionRegistry.length = 0;
@@ -561,35 +533,33 @@ export function hasRegisteredTrigger(sourceDefId: string, timing: TriggerTiming)
 }
 
 /**
- * 婵炴垶鎸鹃崕銈嗘櫠瀹ュ瀚?POD 闂佺粯顨呴悧濠傦耿娴煎瓨鍎嶉柛鏇ㄥ亜楠炪垽鏌ｅΔ鈧張顒佺珶閹烘鐓傞煫鍥ㄦ⒐閺嗗牓鏌?trigger/restriction/protection 闂佸憡甯╅崑鍕箖?
+
  * 
- * POD 闂?defId 闂佸搫绉堕崢褏妲愰埄鍐枖?闂佸憡顭囬崰鎾存櫠濮婃攨fId + _pod"闂佹寧绋戦悧鍡涖€?alien_scout_pod闂佹寧绋戦ˇ顓㈠焵?
- * 濠殿喗绺块崐鏇㈠吹闁秴鏋佸ù鑲╃節閹查箖鏌涘Ο鐑橆棞闁告垟鈧枼鏋栭柕濞垮劚閺傗偓闁荤偞渚楅悡澶屾濠靛牅鐒婇柛鈩冪懐閸庡﹪鏌涘顒傚閻㈩垼鍋呴幈銊р偓锝庝海閸╁瞼鈧鍠栫换鎺戔枔?defId 闂佹眹鍔岀€氼厽鏅跺澶婂珘?trigger/restriction/protection 婵犮垼娉涚粔鎾春濡ゅ啰纾兼繛鍡楁禋閸ょ娀骞栫€涙ɑ鈷掓繛?_pod 闂佺粯顨呴悧濠傦耿娴兼潙违?
- * 闁哄鏅滈悷锕傛偋闁秴绫嶉柣妯肩帛娴犳ê鈽夐幘璺哄妺闁伙腹鍓濈粙?POD 闂佸憡銇涢埀顒€鍟跨粈瀣煟濞嗘ê澧扮紒槌栦邯瀹?trigger 婵炲濯寸徊鍧楁偉濠婂牊鏅悘鐐跺Г閻ㄦ垿鏌ら崘娴嬪亾閻曚礁鏁ら梺绋跨箲閸庡ジ宕靛鍫濈闁靛ě鍕厱闂佸綊娼ч悘婵嬫偄閳ь剛鐥娑樹壕闂佺粯顨呴悧蹇撯枔閹达箑绀傞柕濞垮労濞堢増绻涢幘铏暈闁搞劍鐟╅弻鍛村及韫囨洖绔奸梺?
+
  * 
- * 闂婎偄娲ら幊姗€濡磋箛娑樻嵍闁靛绠戦。鏌ユ煛閸繍妲规繛锝呯－閸栨牜绱掑Ο缁樻畼闂佸憡鍔曢懟顖炴偩椤掆偓琚欓柡鍥╁仦閸婄敻鎮圭€ｎ亜鏆熼柡浣靛€曢～銏ゅΧ閸涱厽鐦ｉ梺杞版祰閸╁洭鍩€?
+
  */
 export function registerPodOngoingAliases(): void {
     let mappedCount = 0;
     
-    // 1. 闂佸搫瀚慨鎾儍?Trigger
+
     const triggersToAdd: TriggerEntry[] = [];
     for (const entry of triggerRegistry) {
         const { sourceDefId, timing, callback } = entry;
         
-        // 闁荤姴鎼悿鍥╂崲閸愵煈鍟呴柤纰卞墰閻ュ懘鏌?_pod 闂?
+
         if (sourceDefId.endsWith('_pod')) continue;
         if (getTitanDef(sourceDefId)) continue;
         
         const podDefId = `${sourceDefId}_pod`;
         
-        // 婵犵鈧啿鈧綊鎮?POD 闂佺粯顨呴悧濠傦耿閺夋鍟呴柤纰卞墰閻ュ懏绻涙径鍫濆闁哥偘绮欓弫宥呯暆閸愵亜鍔滈柡澶嗘櫅濞村嫮妲愬▎鎰枖鐎广儱鐗滃ú顒勬煟閳哄倻澧俊顖氼槸椤曪綀绠涢弮鈧弳鍫ユ煕閹邦剛鐒跨紒?
+
         const alreadyRegistered = triggerRegistry.some(
             e => e.sourceDefId === podDefId && e.timing === timing
         );
         if (alreadyRegistered) continue;
         
-        // 濠电儑缍€椤曆勬叏閻愬搫绀嗛柡澶庢硶缁愨剝绻涙径鍫濆闁哥偘绮欏畷姘旈崟鈹惧亾?
+
         triggersToAdd.push({
             sourceDefId: podDefId,
             timing,
@@ -604,7 +574,7 @@ export function registerPodOngoingAliases(): void {
         mappedCount++;
     }
     
-    // 闂佸綊娼х紞濠囧闯閸濆媱搴ｆ嫚閹绘帩娼遍梺鎸庣☉閻楁挻瀵奸埡鍛鐎广儱鎳忛煬顒勬⒑椤掆偓缁夋潙顔忔繝姘睄闁哄牆鐏氶崣蹇涙煛閳ь剛鎲撮崟顒侇啀缂傚倷绀佺€氬摜妲?
+
     for (const entry of triggersToAdd) {
         registerTrigger(entry.sourceDefId, entry.timing, entry.callback, {
             optional: entry.optional,
@@ -616,7 +586,7 @@ export function registerPodOngoingAliases(): void {
         });
     }
     
-    // 2. 闂佸搫瀚慨鎾儍?Restriction
+
     const restrictionsToAdd: RestrictionEntry[] = [];
     for (const entry of restrictionRegistry) {
         const { sourceDefId, restrictionType, checker } = entry;
@@ -637,7 +607,7 @@ export function registerPodOngoingAliases(): void {
     
     restrictionRegistry.push(...restrictionsToAdd);
     
-    // 3. 闂佸搫瀚慨鎾儍?Protection
+
     const protectionsToAdd: ProtectionEntry[] = [];
     for (const entry of protectionRegistry) {
         const { sourceDefId, protectionType, checker } = entry;
@@ -658,7 +628,7 @@ export function registerPodOngoingAliases(): void {
     
     protectionRegistry.push(...protectionsToAdd);
     
-    // 4. 闂佸搫瀚慨鎾儍?BaseAbilitySuppression
+
     const suppressionsToAdd: { sourceDefId: string; checker: BaseAbilitySuppressionChecker }[] = [];
     for (const entry of baseAbilitySuppressionRegistry) {
         const { sourceDefId, checker } = entry;
@@ -679,10 +649,9 @@ export function registerPodOngoingAliases(): void {
     
     baseAbilitySuppressionRegistry.push(...suppressionsToAdd);
     
-    // 闂佸搫瀚慨鎾儍閻樼鍋撻悷鐗堟拱闁搞劍宀搁弫宥夊醇濠靛棗娈ラ梺鐓庮殠娴滄粍鎱ㄩ埡鍛強闁绘灏欏▓?POD 闂佺粯顨呴悧濠傦耿娴煎瓨鍎?trigger/restriction/protection闂?
+
 }
 
-/** 闂佸吋鍎抽崲鑼躲亹閸パ€鏋栭柕濞垮劚閺傗偓闁荤偞绋忛崝宀勫Φ閸モ晙鐒婇煫鍥ュ劤缁€鍕偣鐎ｎ亜鏆㈤柣锔诲灦閹粙鈥﹂幒鏃傤槴 */
 export function getOngoingEffectRegistrySize(): {
     protection: number;
     restriction: number;
@@ -697,7 +666,6 @@ export function getOngoingEffectRegistrySize(): {
     };
 }
 
-/** 闂佸吋鍎抽崲鑼躲亹閸ヮ剙绠ラ柍褜鍓熷鍨緞婵犲倸娈ュ┑鐐差槶閸斿矂宕禒瀣剭?sourceDefId闂佹寧绋戦悧蹇涘极閵堝棛顩查幖娣€曢崢鎾煕閺冣偓缁嬫牠銆侀幋鐐碘枖闁告繂瀚烽崥鈧柣鐘辫濡插嫮妲?*/
 export function getRegisteredOngoingEffectIds(): {
     protectionIds: Set<string>;
     restrictionIds: Set<string>;
@@ -710,7 +678,6 @@ export function getRegisteredOngoingEffectIds(): {
     const interceptorIds = new Set(interceptorRegistry.map(e => e.sourceDefId));
     const baseAbilitySuppressionIds = new Set(baseAbilitySuppressionRegistry.map(e => e.sourceDefId));
 
-    // trigger 闂傚倸娲犻崑鎾绘偡閺囨碍顦风紒缁樺哺閹?timing 婵烇絽娲犻崜婵囧閸涘瓨鏅€光偓閳ь剟寮妶鍡欘洸閹兼番鍨虹痪顖滅磼椤旂厧鈷旈柍銉︼耿閹啴宕熼顐㈡倎闁?
     const triggerIds = new Map<string, TriggerTiming[]>();
     for (const entry of triggerRegistry) {
         const existing = triggerIds.get(entry.sourceDefId) ?? [];
@@ -721,27 +688,24 @@ export function getRegisteredOngoingEffectIds(): {
     return { protectionIds, restrictionIds, triggerIds, interceptorIds, baseAbilitySuppressionIds };
 }
 
-
 // ============================================================================
-// 闂佸搫琚崕鎾敋?API
+
 // ============================================================================
 
 /**
- * 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撻梺闈╅檮婵粙宕楀鈧畷婵嗏槈濞嗘剫锕傛煕濮樺墽鐣虫い顐畵瀹曘垻鈧綆浜滈悡?
+
  *
- * 闂備緡鍓欑粔鏉戭啅婵犳艾绠ラ柍褜鍓熷鍨緞婵犲嫬鏁ら梺闈╅檮婵粙宕楀鈧畷婵嗏槈濡櫣顏婚梺鍛婂笩閸╂牠寮悙鍝勭閻忕偠濮ら悵銈夋煥濞戞瀚扮憸鎶婂懏鍟哄ù锝堫潐缁犳帒鈽夐幘顖氫壕婵炴垶鎼╂禍锝囨崲閹达箑鐐?true 闁诲繐绻楃划楣冨Υ閸愵亞鐭嗗Δ锔筋儥濞煎爼鏌涘Ο渚剰闁糕晜顨婃俊?
- * 闂佹椿娼块崝瀣姳?alien_jammed_signal 缂?闂佸搫鍟版慨楣冿綖鐎ｎ喖鏄ラ柛婵嗗閸曢箖鏌ょ€圭姵顥夊┑?闂佽桨绀侀悧濠囨倶婢舵劕违?
+
  */
 export function isBaseAbilitySuppressed(
     state: SmashUpCore,
     baseIndex: number
 ): boolean {
-    // 1. 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撴繛瀛樼矊濞撮攱鎱ㄩ幖浣哥畱濞达絿鍎ら悾鍗炩槈閹惧磭鎽犳俊鐐插€垮畷銏⑩偓锝庝簻閻撴垿鏌ㄥ☉妯煎缂佽翰鍎叉穱濠囧磼閿斿墽鐛ラ梺杞扮閻楀﹪鎮樻径濠庡晠闁肩⒈鍓涘▔銏㈢磼?闂佸憡銇涢埀顒€鍟块崵鎺旂磼閸屾繍鍤欐繝褉鍋撻梺鎸庣☉婵傛梻寰婃ィ鍐ㄥ偍閻庯綆浜滈悡鎴︽煙闂€鎰厡闁汇垹顭峰畷姘紣娴ｈ櫣鎲繛鎴炴惄娴滄粌煤閺嶎厼瑙﹂柛顐ｇ箘绾捐鈹戦纰卞劀缂?
+
     if (state.suppressedBasesUntilTurnStart?.some(s => s.baseIndex === baseIndex)) {
         return true;
     }
 
-    // 2. 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撴繛瀛樼矊妤犵鈹冮埀顒€鈽夐幘绛瑰伐鐎规洟浜堕幃褍鐣濋埀顒€鈻撻幋锕€绠板ù锝堟閺侀箖鏌涘Ο渚剰闁?
     if (baseAbilitySuppressionRegistry.length === 0) return false;
     for (const entry of baseAbilitySuppressionRegistry) {
         const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
@@ -751,7 +715,6 @@ export function isBaseAbilitySuppressed(
     return false;
 }
 
-/** 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎鐎规洟浜堕幃褍鐣濋崘銊ュ箣闂佸憡姊圭粙鎺懳ｉ幖浣歌Е闁挎洍鍋撴い锔规櫆缁傚秵鎯旈垾宕囶伝闂佸憡甯楀﹢褰掓嚈?*/
 export function isCardSuppressed(
     state: SmashUpCore,
     cardUid: string,
@@ -821,10 +784,9 @@ export function getSuppressionFilteredStateForSource(
 }
 
 /**
- * 濠碘槅鍋€閸嬫捇鏌＄仦璇插姦婵炲牄鍨虹粋鎺撴償閵忊寬锕傛煕濮樺墽鐣辩憸鏉跨墛缁屽崬鈹戦崶顬?
+
  *
- * 闂備緡鍓欑粔鏉戭啅婵犳艾绠ラ柍褜鍓熷鍨緞婢跺瞼顔旈梺纭呯堪閸婃牜鈧哎鍊濋獮瀣敂閸曨剛褰滈梺鎸庣☉閼活垵銇愯閹茬増鎷呯憴鍕暢婵炴垶鎸撮崑鎾斥槈閹垮啩娴风紒缁樺灴瀹?true 闁诲繐绻楃划楣冨Υ閸愵亞鐭嗛柛婵嗗缂嶁偓婵烇絽娲︾换鍐╂叏閵忋倕违?
- * 闂佸憡鐟禍婵嗭耿娴ｅ浜归柟鎹愭珪缁ㄦ艾鈽夐幘绛瑰伐闁宦板姂瀹曠兘濡搁敃鈧徊鐟般€掑顓犫棩缂佺粯宀搁獮搴ㄥΧ閸ャ劎鏆?ongoing 闂佸憡顨愮槐鏇熸櫠濠靛绠ｉ柡宥庡幗椤撶懓霉閻樻彃顒㈡俊鐐插€块弫宥囦沪缁涘娈搁柟鐓庣摠濮婂湱鈧哎鍊濋獮瀣敂閸曨剛褰滈梺褰掓涧缁夊爼寮幘璇叉瀬闁割偅绋堥崑?
+
  */
 export function isMinionProtected(
     state: SmashUpCore,
@@ -846,7 +808,7 @@ export function isMinionProtected(
 
     for (const entry of protectionRegistry) {
         if (entry.protectionType !== protectionType) continue;
-        // 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎婵犙€鍋撴繛鎴炴尭閿曘儱危閹间礁瑙﹂柨鏃囧Г缁犳帡鏌熺紒妯哄缂佽泛鐏氱粚鍗炩攽閸ヮ灝鎴︽煟閵娿儱顏繛濂告涧閳瑰啴骞囬崜浣侯槱ongoing 闂佸憡銇涢崜婵嬪垂閵娾晜鈷曢煫鍥ф捣閻倝鏌?
+
         const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
         if (!isSourceActive(filteredState, entry.sourceDefId)) continue;
         if (entry.checker({ ...ctx, state: filteredState })) return true;
@@ -855,10 +817,9 @@ export function isMinionProtected(
 }
 
 /**
- * 濠碘槅鍋€閸嬫捇鏌＄仦璇插姦婵炲牄鍨虹粋鎺撴償閵忊寬锕傛煕濮樺墽鐣辩憸鏉跨墦瀹曟碍瀵肩€涙ê顫″┑鐐村灥閻楁劙鍩€椤掍緡娈旈柣搴ㄦ敱缁屽崬鈹戦崶顬垿鏌ㄥ☉妯煎ⅱ闁轰降鍊栫粋宥嗘償閿濆棛鐛ラ梺鍝勭Т濞差參鍩€椤掆偓椤︽壆鈧哎鍔嶅濠氬炊閵婏箑袘闂?
+
  *
- * 濠电偞鍨甸悧鎰板焵椤掍緡娈旈柣搴ㄦ敱缁屽崬鈹戦崶顬垿鏌ㄥ☉妯煎妞?tooth_and_claw闂佹寧绋戦ˇ顔剧箔婢跺鍎熼柡鍌涘闊剟鏌ｉ埡濠傛灍闁绘牭缍侀弻鍛緞鐎ｎ亶浠撮梻鍌氬暢閸╂牠顢欑仦鐐氦闁搞儯鍔嶆慨銏ゆ煥?
- * 闂佸吋婢橀懟顖滆姳閺屻儱鎹堕柕濞垮€楅惃鎴澝归悩铏瀯濡ょ姴娲幃浠嬫偄闁垮鈧敻姊洪锝勪孩缂?filterProtectedDestroyEvents 濠电偞鍨甸悧鎰板焵椤掍緡娈旀い锔规櫊閹爼宕遍幇銊ヤ壕?
+
  */
 export function isMinionProtectedNonConsumable(
     state: SmashUpCore,
@@ -880,7 +841,7 @@ export function isMinionProtectedNonConsumable(
 
     for (const entry of protectionRegistry) {
         if (entry.protectionType !== protectionType) continue;
-        if (entry.consumable) continue; // 闁荤姴鎼悿鍥╂崲閸愩劉妲堥柛顐岛閸嬫挸螖閳ь剟鎮楅柨瀣攳婵犻潧娲よ
+        if (entry.consumable) continue;
         const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
         if (!isSourceActive(filteredState, entry.sourceDefId)) continue;
         if (entry.checker({ ...ctx, state: filteredState })) return true;
@@ -941,27 +902,20 @@ export function getConsumableProtectionSource(
         const filteredState = getSuppressionFilteredStateForSource(state, entry.sourceDefId);
         if (!isSourceActive(filteredState, entry.sourceDefId)) continue;
         if (!entry.checker({ ...ctx, state: filteredState })) continue;
-        // 闂佺懓鐏氶崕鎶藉春鐏炶В妲堥柛顐岛閸嬫挸螖閳ь剟鎮楅柨瀣攳婵犻潧娲よ闂佸搫顦崕鑼姳椤曗偓閺佸秶浠﹂崜褍寮ㄩ梺鐟扮仛閸庢娊宕ｉ幐搴㈠闁规崘鍩栭悾?ongoing 闂佸憡顨愮槐鏇熸櫠濠靛牃鍋撻崷顓炰粧缂?
+
         const base = filteredState.bases[targetBaseIndex];
         if (!base) continue;
-        // 闂佺绻愰悧濠囁夐崨鏉戣摕闁靛鏅滈鐟懊归悩鏌ュ弰婵＄虎鍣ｉ幆鍫ュ焵?
+
         const filteredTargetMinion = base.minions.find(minion => minion.uid === targetMinion.uid) ?? targetMinion;
         const attached = filteredTargetMinion.attachedActions.find(a => a.defId === entry.sourceDefId);
         if (attached) return { uid: attached.uid, defId: attached.defId, ownerId: attached.ownerId };
-        // 闂佸憡鍔曠粔鐢杆夐崨鏉戣摕闁靛鍎抽崬銊╂煕?ongoing
+
         const ongoing = base.ongoingActions.find(o => o.defId === entry.sourceDefId);
         if (ongoing) return { uid: ongoing.uid, defId: ongoing.defId, ownerId: ongoing.ownerId };
     }
     return undefined;
 }
 
-/**
- * 濠碘槅鍋€閸嬫捇鏌＄仦璇插姕闁瑰ジ鏀遍幏鍛煥閸曨儷锕傛煕濮樺墽鐣虫い顐畵濮婁粙骞囬鈧悡?
- *
- * 婵炴垶鎸堕崐鏇㈡儑閺夎娑㈠焵椤掑嫬钃熼柕澶樺灣缁?
- * 1. 闂佺硶鏅涢幖顐耿鐎电硶鍋撶憴鍕叝缂佺姷鍠愮粙澶嬬節閸曨剛鏆?restrictions闂佹寧绋戦悧濠囧汲閻旂厧绠叉い鏇楀亾闁崇懓绉瑰畷婵嬧€﹂幒鏃傤槷闂佺厧顨庢禍婊勬叏閳哄啯鍠嗛柨婵嗘閳ь兛绮欓弫?
- * 2. ongoing 闂佽桨绀侀悧濠囨倶婢跺ň鏋栭柕濞垮劚閺傗偓闁荤偞渚楅悡澶屾濞嗘垶鍋橀悘鐐舵琚熼梺?闂傚倸鎳庣换瀣垝閻樼粯鍎嶉柛鏇ㄥ墮椤忥繝鏌熼幖顓濈盎婵炲懏甯￠弫?
- */
 export function isOperationRestricted(
     state: SmashUpCore,
     baseIndex: number,
@@ -972,20 +926,17 @@ export function isOperationRestricted(
     const base = state.bases[baseIndex];
     if (!base) return false;
 
-    // 1. 闂佺硶鏅涢幖顐耿鐎电硶鍋撶憴鍕叝缂佺姷鍠愮粙澶嬬節閸曨剛鏆犻梻鍌氬閸旀洟宕哄Δ鍐╁枂闁告洦鍋勯悘鐔兼煥濞戞澧涢柡鍡欏枛楠炴垿顢氶埀顒勫煘瀹ュ绀夋い顓熷笧缁€?
     const baseDef = getBaseDef(base.defId);
     if (baseDef?.restrictions) {
         for (const r of baseDef.restrictions) {
             if (r.type !== restrictionType) continue;
-            // 闂佸搫鍟版慨闈涱焽椤栨稓顩烽柛顐ｆ礃椤庢瑩鏌?
+
             if (!r.condition) return true;
-            // 闂佸搫顦埀顒€寮堕浠嬫⒒閸曨剙濮囬柛鈺傤殜閺佸秴顫㈤悽顣濸ower闂佹寧绋戦悧鍡樻叏韫囨稒鐓?<= maxPower 闂佹眹鍔岀€氭澘鈻撻姀锛勵浄閹兼番鍊ゅ鍓佺磼閸屾瑧鍔嶆い鎺撶洴閺?
+
             if (r.condition.maxPower !== undefined && restrictionType === 'play_minion') {
                 const basePower = extra?.basePower as number | undefined;
                 if (basePower !== undefined && basePower <= r.condition.maxPower) {
-                    // Tsar's Palace + Infiltrate FAQ闂?
-                    // 闂佸吋鐪归崕鎾敋濮樿埖鍋濋柍杞扮贰閸熲偓闂侀潻璐熼崝蹇涱敋濮樿泛鏄ラ柛婵嗗閸曟儳鈽夐幘绛规敾婵犫偓娓氣偓閹虫盯顢旈崟顓犵暢闂佺鐭囬崘銊у幀闂?Infiltrate闂佹寧绋戝绌昦y-on-base 闁荤偞绋戦懟顖涙叏閳哄懏鏅鑸电〒缁€?
-                    // 闂佸憡甯楅悷銉ㄣ亹閸欏顩烽柕澶涢檮閿熴儵鎮峰▎蹇旑棏闁逞屽墯缁楊摰wer闂? 婵炴垶鎸哥粔纾嬨亹閺屻儱绠ラ柟鎯у暱濮ｅ鏌嶉妷锔剧畼婵炲牊鍨垮浠嬪箛椤掆偓閻撴垿鏌?
+
                     if (baseDef.id === 'base_tsars_palace') {
                         const hasBaseInfiltrate = base.ongoingActions.some(o =>
                             o.ownerId === playerId && o.defId.startsWith('ninja_infiltrate'),
@@ -997,7 +948,7 @@ export function isOperationRestricted(
                     return true;
                 }
             }
-            // 闂佸搫顦埀顒€寮堕浠嬫⒒閸曨剙濮囬柛鈺傤殜閺佸秴顫㈤悞鐜箁aPlayMinionPowerMax闂佹寧绋戦悧鎾宦烽崒娑樼窞闁哄诞鍐╃様闂佺粯顨呴張顒€顪冮崒鐐茬婵炴垯鍨瑰▍?> limit 闂佹眹鍔岀€氭澘鈻撻姀锛勵浄閹兼番鍊ゅ鍓佺磼閸屾瑧鍔嶆い鎺撶洴閺?
+
             if (r.condition.extraPlayMinionPowerMax !== undefined && restrictionType === 'play_minion') {
                 const basePower = extra?.basePower as number | undefined;
                 const isExtraMinionPlay = extra?.isExtraMinionPlayAttempt as boolean | undefined;
@@ -1013,13 +964,12 @@ export function isOperationRestricted(
                     return true;
                 }
             }
-            // 闂佸搫顦埀顒€寮堕浠嬫⒒閸曨剙濮囬柛鈺傤殜閺佸秴顫㈤悽绉恑onPlayLimitPerTurn闂佹寧绋戦悧濠囨儊閿熺姴鐐婇柣鎰级閸娿倖鎱ㄩ敐鍛缂傚秴鎳橀幃鎶藉煛娓氬洤鏅欓梺闈╄礋閸斿秹顢楀┑瀣槬闁告繂瀚崟楣冩煙閸偅灏柛銈庡弮濮婃崘绠涙惔锝囩厾婵炴垶鎸搁敃顏勵瀶濞差亝鏅?
+
             if (r.condition.minionPlayLimitPerTurn !== undefined && restrictionType === 'play_minion') {
                 const player = state.players[playerId];
                 const playedAtBase = player?.minionsPlayedPerBase?.[baseIndex] ?? 0;
                 if (playedAtBase >= r.condition.minionPlayLimitPerTurn) {
-                    // Antarctic Base + Infiltrate FAQ闂?
-                    // 闂佸吋鐪归崕鎵礊濮椻偓瀹曠兘濡搁…鎴濇畽闂佺硶鏅涢幖顐耿鐎涙鈻斿┑鐘插暞缁犳帡鏌ゆ總澶夌盎缂佽绶氶獮鎺曨槻闁糕晜顨婇幆?Infiltrate闂佹寧绋戝绌昦y-on-base 闁荤偞绋戦懟顖涙叏閳哄懏鏅鑸电〒缁€澶愭煕閹烘挾鎳佺紓宥嗭耿瀹曪綁顢涘▎搴ｉ瀺闂婎偄娲ㄩ弲顐﹀汲閹邦喗瀚氶柕澶嗘櫆椤庢瑩鏌涢幒鏇犲牚闁?
+
                     if (baseDef.id === 'base_antarctic_base') {
                         const hasBaseInfiltrate = base.ongoingActions.some(o =>
                             o.ownerId === playerId && o.defId.startsWith('ninja_infiltrate'),
@@ -1034,7 +984,6 @@ export function isOperationRestricted(
         }
     }
 
-    // 2. ongoing 闂佽桨绀侀悧濠囨倶婢跺ň鏋栭柕濞垮劚閺傗偓闁荤偞渚楅悡澶屾濞嗘垶鍋橀悘鐐舵琚熼梺?闂傚倸鎳庣换瀣垝閻樼粯鍎嶉柛鏇ㄥ墮椤忥繝鏌熼幖顓濈盎婵炲懏甯￠弫?
     if (restrictionRegistry.length > 0) {
         const ctx: RestrictionCheckContext = {
             state,
@@ -1054,7 +1003,6 @@ export function isOperationRestricted(
     return false;
 }
 
-/** 濠碘槅鍋€閸嬫捇鏌＄仦璇插姢閻㈩垵娅ｉ埀顒傤攰閸╂牕危閹间礁瑙﹂柨鏇楀亾妞わ腹鏅滅粋宥嗘償閵忕姷妲风紓鍌欑贰閸樻椽鎳欓幋锔藉剭闁告洦鍋勫鍧楁倶閻愨晛浜鹃梻鍌氬閸旀洟宕哄Δ鍛櫖闁割偅绻嶅ú銈夋煟椤愵剛纾挎繝鈧姀銈呯闁瑰嘲鐭堥崬?POD闂?*/
 export function hasPlayerTurnRestriction(
     state: SmashUpCore,
     playerId: PlayerId,
@@ -1066,12 +1014,10 @@ export function hasPlayerTurnRestriction(
 }
 
 /**
- * 闂佸湱鐟抽崱鈺傛杸婵炲瓨绮岄鍕枎閵忋倕绠柨鏃囨閻掑鏌ㄥ☉娆忓摵濞存粌鐖煎畷銏ゅ幢濡粯娈橀梺鍛婂姇閻厧鈻撻幋锕€绠柨鏃囨閻掑鏌涢敐搴ｅ帨缂佽鲸绻勭划顓㈩敄鐠侯煈浼囨繛鎴炴惄娴滐絿鎹㈤幋锕€鐐婇柣鎰劋婵?undefined 闂佹眹鍔岀€氼喚鍒掗妸鈺佸嚑婵犲﹤鎳忛弲鎼佹煛?
+
  *
  * 闁哄鏅滈弻銊ッ洪弽顓炵９缁绢參顥撶粣?
- * - undefined 闂?闂佸搫鍟版慨鐢碘偓姘ュ€濋獮瀣敂閸曨剛褰滈梺鍛婄墪缂嶅﹪宕?
- * - SmashUpEvent / SmashUpEvent[] 闂?闂佸搫娲︾€笛冪暦?
- * - null 闂?闂佸憡姘ㄩ崑娑樷枍?
+
  */
 export function interceptEvent(
     state: SmashUpCore,
@@ -1088,11 +1034,6 @@ export function interceptEvent(
     return undefined;
 }
 
-/**
- * 闁荤喐鐟辩粻鎴ｃ亹閸岀偛绠伴柛銉戝懏姣庨梺鍝勫暢閸╂牕鈹冮埀顒勬煟閵娿儱顏褍绉瑰鍨緞鐎ｎ亶浠梺瑙勬儗娴滄粌鈻?
- *
- * 闁哄鏅滈弻銊ッ洪弽顓炵闁逞屽墴瀵灚寰勯獮顔芥礋瀹曪綁骞嬪┑鍥╁綔婵炲瓨绫傞崨顔芥闂佹眹鍔岀€氼亞鑺遍妸锔绢浄閻犺櫣鍎ょ€氭煡鏌涘▎妯虹仸闁逞屽墮椤﹀崬鈻?matchState闂?
- */
 export function fireTriggers(
     state: SmashUpCore,
     timing: TitanAwareTriggerTiming,
@@ -1190,10 +1131,9 @@ function selectSpecificSourceLocation(
 }
 
 /**
- * 婵炲濮撮幊鎾诡杺闂佸憡鐟﹂崹鍓佲偓鍨皑閳ь剝顫夌喊宥咁焽闂堟稈鏀?defId 闂佹眹鍔岀€氼垵顤傞梺鍛婄懄閸ㄩ潧鈻嶉幒妤€违?
+
  *
- * 闂佹椿娼块崝瀣姳椤掑嫬鐏虫繝濠傚暞閸婂崬鈽夐幘顖氫壕 Start Turn 缂備焦鍔栭〃鍛般亹濞戞瑧鈻旀い鎾跺枑閻撯偓闁哄鏅滅粙鎴濃攦閳ь剟鏌ｉ妸銉ヮ仼鐎规洟浜堕幃褍鐣濋崟顑跨帛闁荤喐娲戦懗鍫曟偟濞戙垹绀嗛柡鍕潧婢跺本鍠嗛柨鏇楀亾鐟滄澘鍊块崹鎯р攽婵犲嫮顔愮紓渚囧亯椤曆冣攦閳ь剟鏌￠崪浣哥伈缂?
- * 闂備緡鍓欓悘婵嬪储閵堝鐓傜€广儱妫欓悡鈧梺瑙勵問閸嬪懎顕ｉ崸妤€绀傞柕濞炬櫅閸?onTurnStart 闂佸搫顦崕鑼姳椤曗偓婵?
+
  */
 export function fireTriggerForSource(
     state: SmashUpCore,
@@ -1296,36 +1236,29 @@ function isSourceInZones(
 }
 
 // ============================================================================
-// 闂佸憡鍔曢幊姗€宕曠€涙ɑ缍囬柛娑卞幖琚?
+
 // ============================================================================
 
 /**
- * 濠碘槅鍋€閸嬫捇鏌＄仦璇插姕閻庢哎鍊濋獮瀣敂閸曨剛褰滈梺鍝勵槶閸庤尙鑺遍鈧浼搭敍濮橆厼鍓ㄩ梺闈╄礋閸斿苯鈹冮埀顒€鈽夐幘绛规敾婵＄偠娉曢幑?
+
  *
- * 闂佸搫顦崕鑼姳椤曗偓瀹曪綁顢涘▎搴ｉ瀺闂佸搫瀚烽崹鐣屾?
- * 1. 闂佺硶鏅涢幖顐耿閹绢喖瀚夋い鎺戝暣閻撯晠鏌ㄥ☉妯荤秳ase.defId闂?
- * 2. 闂佺硶鏅涢幖顐耿鐎涙鈻斿┑鐘插閻?ongoing 闁荤偞绋戦懟顖涙叏閳哄懎纭€闁宠棄鎳愮粈鍒糿goingActions 婵炴垶鎼╅崢鎯р枔?defId闂?
- * 3. 闂佺硶鏅涢幖顐耿鐎涙鈻斿┑鐘插閻ｉ亶姊婚崨顓犵缂侇喚濞€閺佸秹宕搁。寮塱ons 婵炴垶鎼╅崢鎯р枔?defId闂佹寧绋戞總鏃傜箔閺嶎厼瀚?ongoing 闂佺厧鐤囧Λ鍕叏韫囨稑鍐€闁搞儮鏅╅崝顕€鏌?
- * 4. 闂傚倸鎳庣换瀣垝閻樺磭鈻斿┑鐘叉处椤庡秹鏌ｉ鐔蜂壕闂?ongoing 闁荤偞绋戦懟顖涙叏閳哄懎纭€闁宠棄鎳愮粈鍒焧tachedActions 婵炴垶鎼╅崢鎯р枔?defId闂?
+
  */
 function isSourceActive(state: SmashUpCore, sourceDefId: string): boolean {
     if (state.pendingAfterScoringSpecials?.some(s => s.sourceDefId === sourceDefId)) {
         return true;
     }
     for (const base of state.bases) {
-        // 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撻梺闈╁婢ф锕㈡导瀵稿彆?
         if (base.defId === sourceDefId) {
             return true;
         }
-        // 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撻梺闈╃畵椤ｏ妇绮崒鐐村剭?ongoing 闁荤偞绋戦懟顖涙叏閳哄懎纭€?
         if (base.ongoingActions.some(o => o.defId === sourceDefId)) {
             return true;
         }
-        // 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撻梺闈╃畵椤ｏ妇绮崒鐐村剭闁告洦鍨遍鐟懊?
         if (base.minions.some(m => m.defId === sourceDefId)) {
             return true;
         }
-        // 濠碘槅鍋€閸嬫捇鏌＄仦璇插姦婵炲牄鍨虹粋鎺撴償濠靛牏鎲梻鍌氬鐎氼喖顭囬崘顔藉剭闁告洦鍣弨浠嬫煕閺傝濡肩€?
+
         for (const m of base.minions) {
             if (m.attachedActions?.some(a => a.defId === sourceDefId)) {
                 return true;
@@ -1341,17 +1274,13 @@ function isSourceActive(state: SmashUpCore, sourceDefId: string): boolean {
 }
 
 /**
- * 濠碘槅鍋€閸嬫捇鏌＄仦璇插姕閻庢哎鍊濋獮瀣敂閸曨剛褰滈梺鍝勵槶閸庤尙鑺遍鈧浼搭敍濮橆厼鍓ㄩ梺闈╄礋閸斿秶鈧灚姘ㄩ埀顒冾潐閼归箖鎮㈤埀顒勬煕閿曞偆鏆掔紒妤€鍊哥叅闁哄嫬绻掗埞?
- * 闂佹椿娼块崝瀣姳椤掑嫬鏄ラ柛婵嗗閸曢箖鏌ゆ總澶夋捣闂傚ň鏅犻幆鍐礋椤栨侗鈧瑩鏌涢幒鏇炵厫闁哄懌鍎靛?
+
  */
 export function isSourceActiveOnBase(state: SmashUpCore, sourceDefId: string, baseIndex: number): boolean {
     const base = state.bases[baseIndex];
     if (!base) return false;
-    // 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撻梺闈╁婢ф锕㈡导瀵稿彆?
     if (base.defId === sourceDefId) return true;
-    // 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撻梺闈╃畵椤ｏ妇绮崒鐐村剭?ongoing 闁荤偞绋戦懟顖涙叏閳哄懎纭€?
     if (base.ongoingActions.some(o => o.defId === sourceDefId)) return true;
-    // 濠碘槅鍋€閸嬫捇鏌＄仦璇插姎闁绘柡鍋撻梺闈╃畵椤ｏ妇绮崒鐐村剭闁告洦鍨遍鐟懊?
     if (base.minions.some(m => m.defId === sourceDefId)) return true;
     for (const minion of base.minions) {
         if (minion.attachedActions?.some(action => action.defId === sourceDefId)) {
@@ -1369,25 +1298,22 @@ export function isSourceActiveOnBase(state: SmashUpCore, sourceDefId: string, ba
 }
 
 // ============================================================================
-// 闂佺硶鏅涢幖顐耿閹绢喗鈷旈柟閭﹀墮閻撴垵菐閸ワ絽澧插ù鐓庢嚇瀵濡烽…鎴濇畱闂佹寧绋戝﹢绂?闁诲繒鍋涢崐閿嬬箾閸ヮ剚鍋ㄦい顓熷笧缁€?
+
 // ============================================================================
 
-/** 闂佺硶鏅涢幖顐耿閹绢喗鈷旈柟閭﹀墮閻撴垵菐閸ワ絽澧插ù鐓庢嚇閺佸秹宕奸姀鈩冩婵?UI 闂佸搫瀚晶浠嬪Φ濮樿埖鏅?*/
 export interface BaseRestrictionInfo {
-    /** 闂傚倸瀚崝鏇㈠春濡ゅ啰灏甸悹鍥皺閳?*/
+
     type: 'blocked_faction' | 'blocked_action';
-    /** 闂佸搫瀚晶浠嬪Φ濮樿泛妫橀柛銉ｅ妽閹烽亶鏌ㄥ☉妯煎妞も敪鍏犳椽宕滆閸忓洭鏌涘顒傂ょ悮銊╂煥?*/
+
     displayText: string;
-    /** 闂佸搫顦崕鑼姳椤曗偓瀹曪繝鏁嶉崟顐澓 defId */
+
     sourceDefId: string;
 }
 
 /**
- * 闂佸吋鍎抽崲鑼躲亹閸ヮ剙鏄ラ柛婵嗗閸曟儳鈽夐幘绛瑰姛婵炲牊鍨块獮宥夊焵椤掑嫬瀚夊鑸靛姈椤庢瑩鏌涢幒鎾存瀯濞ｅ洤锕獮渚€顢涢妶鍥╊槱闂佹椿娼块崝瀣姳?UI 闂佸搫瀚晶浠嬪Φ濮樿埖鏅?
+
  *
- * @param state 閻熸粎澧楅幐鍛婃櫠閻樺眰鈧帡宕ㄦ繝鍌滀簽闂佺粯顭堥崺鏍焵?
- * @param baseIndex 闂佺硶鏅涢幖顐耿鐎靛憡顫曢柕蹇曞Х缁?
- * @returns 闂傚倸瀚崝鏇㈠春濡や胶鈹嶉柍鈺佸暕缁辨牠鏌℃担鐟邦棆缂?
+
  */
 export function getBaseRestrictions(state: SmashUpCore, baseIndex: number): BaseRestrictionInfo[] {
     const base = state.bases[baseIndex];
@@ -1395,13 +1321,11 @@ export function getBaseRestrictions(state: SmashUpCore, baseIndex: number): Base
 
     const restrictions: BaseRestrictionInfo[] = [];
 
-    // 濠碘槅鍋€閸嬫捇鏌?Block the Path闂佹寧绋戦悧鍡涙儍濠靛牊宕夋い鏍ュ€楃粈?
     const blockAction = base.ongoingActions.find(o => matchesDefId(o.defId, 'trickster_block_the_path'));
     if (blockAction) {
         const blockedFaction = blockAction.metadata?.blockedFaction as string | undefined;
         if (blockedFaction) {
-            // 闁诲海鏁搁崢褔宕?FACTION_DISPLAY_NAMES 婵炴潙鍚嬪畝鎼佸焵椤掑倸校闁搞劍鑹鹃銉╊敂閸℃鐣炬繛鎾寸缁诲棛绮嬮崱娑欐櫖閻忕偞鍎抽。鎻捗归悩顔煎姤缂佺粯鐗犻弻灞界暆閳ь剙煤閸ф绠抽柕澶堝€曢埢蹇涙煟?factionId
-            // UI 闁诲繒鍋涢崐椋庢娴煎瓨鐒绘慨妯虹－缁?i18n 闂?FACTION_DISPLAY_NAMES 闁哄鍎愰崜姘暦閺屻儱鍙婇柛鎾椾椒绮甸梺鍛婅壘缁夋儼鈪?
+
             restrictions.push({
                 type: 'blocked_faction',
                 displayText: blockedFaction,
@@ -1410,7 +1334,6 @@ export function getBaseRestrictions(state: SmashUpCore, baseIndex: number): Base
         }
     }
 
-    // 闂佸搫鐗滄禍婵嗩焽閻㈢鐭楁い鏍ㄧ懁缁ㄤ即鏌涢敂鍝勫缂佺粯鐗犻弻宀€浠﹂幆褎缍夐梺鍛婃⒒婵挳宕ｉ悙顒傤浄闁哄稁鍘介娆撴煕閹烘垵顣抽悶姘煎亰瀹曞湱鈧絽澧庣粈鍕攽?Ornate Dome 缂備礁鍊烽悞锕傤敆濞戙垹绠ラ柟鎹愵嚃閺€浠嬫煕閺傝濡肩€规洟浜堕弫?
     // const domeAction = base.ongoingActions.find(o => o.defId === 'steampunk_ornate_dome');
     // if (domeAction) {
     //     restrictions.push({


### PR DESCRIPTION
## 说明
- 修复 Smash Up 泰坦相关乱码显示文本
- 清理同批合并带入的 smoke test 与共享领域注释乱码
- 不包含其他功能改动

## 范围
- `src/games/smashup/abilities/titans.ts`
- `src/games/smashup/__tests__/smashup.smoke.test.ts`
- `src/games/smashup/data/cards.ts`
- `src/games/smashup/domain/index.ts`
- `src/games/smashup/domain/ongoingEffects.ts`
- `src/games/smashup/abilities/ongoing_modifiers.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation strings, comments, and user-facing prompts across game ability modules and domain handlers for improved clarity.

* **Tests**
  * Enhanced smoke test descriptions with clearer, more descriptive naming conventions for better test readability.

* **Chores**
  * Removed commented-out code blocks and unused test stubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->