### PR TITLE
[codex] add first mate scoring-base regression test

### DIFF
--- a/src/games/smashup/__tests__/newOngoingAbilities.test.ts
+++ b/src/games/smashup/__tests__/newOngoingAbilities.test.ts
@@ -842,6 +842,33 @@ describe('pirate_first_mate afterScoring', () => {
         });
         expect(events.filter(e => e.type === SU_EVENTS.MINION_MOVED).length).toBe(0);
     });
+
+    it('只会为当前计分基地上的大副创建触发，不会把其他基地上的大副一起加入队列', () => {
+        const scoringMate = makeMinion('mate-score', 'pirate_first_mate', '0', 2, { powerModifier: 0 });
+        const otherMate = makeMinion('mate-other', 'pirate_first_mate', '0', 2, { powerModifier: 0 });
+        const state = makeState({
+            bases: [
+                makeBase({ defId: 'base_scoring', minions: [scoringMate] }),
+                makeBase({ defId: 'base_other', minions: [otherMate] }),
+                makeBase({ defId: 'base_dest', minions: [] }),
+            ],
+        });
+
+        const queued = collectTriggers(state, 'afterScoring', {
+            state,
+            playerId: '0',
+            baseIndex: 0,
+            rankings: [{ playerId: '0', power: 2, vp: 1 }],
+            random: dummyRandom,
+            now: 100,
+        });
+
+        expect(queued).toBeDefined();
+        const mateTriggers = queued!.payload.triggers.filter(t => t.sourceDefId === 'pirate_first_mate');
+        expect(mateTriggers).toHaveLength(1);
+        expect(mateTriggers[0].sourceCardUid).toBe('mate-score');
+        expect(mateTriggers[0].sourceBaseIndex).toBe(0);
+    });
 });
 
 describe('pirate_first_mate afterScoring - 多实例交互', () => {


### PR DESCRIPTION
## What changed
- add a regression test for `pirate_first_mate` afterScoring
- verify only First Mates on the scoring base are queued
- prevent future regressions where First Mates on other bases also receive the move prompt

## Why
A user-reported Smash Up bug showed that when multiple First Mates were on the table, a First Mate on a non-scoring base could still be prompted to move after another base scored.

The current upstream mainline already scopes the trigger to the scoring base in the ability registration. This PR adds an explicit regression test so that behavior stays locked in.

## Impact
- protects Smash Up afterScoring interaction correctness
- adds automated coverage for a previously unguarded cross-base edge case

## Validation
- `npm run i18n:check`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/newOngoingAbilities.test.ts src/games/smashup/__tests__/temple-firstmate-afterscore.test.ts --configLoader native --pool threads --no-file-parallelism --maxWorkers 1`
- pre-push quality gate also passed on branch push
