### PR TITLE
修正大杀四方多基地计分重检

### DIFF
--- a/src/games/smashup/__tests__/scoreBases-auto-continue.test.ts
+++ b/src/games/smashup/__tests__/scoreBases-auto-continue.test.ts
@@ -2352,15 +2352,14 @@ describe('scoreBases 阶段自动推进', () => {
         const core = makeMinimalCore({
             bases: [
                 makeBase('base_pirate_cove', [
-                    makeMinion('0', 'robot_warbot', 4),
+                    makeMinion('0', 'robot_warbot', 20),
                     makeMinion('1', 'pirate_first_mate', 2),
                 ]),
                 makeBase('base_egg_chamber', [
-                    makeMinion('0', 'robot_microbot_alpha', 1),
-                    makeMinion('1', 'pirate_king', 5),
+                    makeMinion('0', 'robot_microbot_alpha', 9),
+                    makeMinion('1', 'pirate_king', 8),
                 ]),
             ],
-            scoringEligibleBaseIndices: [0, 1],
         });
 
         const state: MatchState<SmashUpCore> = {

--- a/src/games/smashup/__tests__/scoringEligibleLock.test.ts
+++ b/src/games/smashup/__tests__/scoringEligibleLock.test.ts
@@ -1,14 +1,14 @@
 /**
  * 计分阶段 eligible 基地锁定测试
  *
- * 规则（Wiki Phase 3 Step 4）：一旦基地在进入 scoreBases 阶段时达到 breakpoint，
- * 即使 Me First! 响应窗口中力量被降低到 breakpoint 以下，该基地仍然必定计分。
+ * 规则（Wiki Phase 3 Step 4）：每次只选择一个达标基地开始计分；只有已经开始
+ * 结算的当前基地，即使 beforeScoring 链路中力量被降低到 breakpoint 以下，仍然计分。
  *
  * 验证：
- * 1. getScoringEligibleBaseIndices 优先返回锁定列表
- * 2. 锁定列表不存在时回退到实时计算
- * 3. 进入 scoreBases 阶段时锁定事件被正确发射和 reduce
- * 4. 力量降低后锁定列表不变
+ * 1. 旧锁定字段仍兼容旧快照/夹具
+ * 2. 正常计分链使用实时 eligible 查询
+ * 3. 只有当前已选择基地会写入锁定事件
+ * 4. 已完成一个基地后，会重新检查桌面并丢弃不再达标的旧候选
  */
 
 import { describe, expect, it, beforeAll } from 'vitest';
@@ -17,8 +17,10 @@ import { createInitialSystemState } from '../../../engine/pipeline';
 import type { MatchState, RandomFn } from '../../../engine/types';
 import { smashUpSystemsForTest } from '../game';
 import { SmashUpDomain } from '../domain';
-import { getScoringEligibleBaseIndices, getTotalEffectivePowerOnBase, getEffectiveBreakpoint } from '../domain/ongoingModifiers';
+import { smashUpFlowHooks } from '../domain/index';
+import { getRealtimeScoringEligibleBaseIndices, getScoringEligibleBaseIndices, getTotalEffectivePowerOnBase, getEffectiveBreakpoint } from '../domain/ongoingModifiers';
 import { reduce } from '../domain/reduce';
+import { createScoringBaseRef, createScoringSession, getScoringSession, setScoringSession } from '../domain/scoringSession';
 import type { SmashUpCore, BaseInPlay, PlayerState, MinionOnBase, SmashUpCommand, SmashUpEvent } from '../domain/types';
 import { SU_COMMANDS, SU_EVENTS } from '../domain/types';
 import { SU_EVENT_TYPES } from '../domain/events';
@@ -177,6 +179,21 @@ describe('计分阶段 eligible 基地锁定', () => {
             expect(result).toEqual([0]);
         });
 
+        it('实时查询不会返回旧锁定列表里不再达标的未选择基地', () => {
+            const core = makeMinimalCore({
+                bases: [
+                    makeBase(BASE_JUNGLE, [
+                        makeMinion('m1', '0', 5),
+                        makeMinion('m2', '1', 5),
+                    ]),
+                ],
+                scoringEligibleBaseIndices: [0],
+            });
+
+            expect(getScoringEligibleBaseIndices(core)).toEqual([0]);
+            expect(getRealtimeScoringEligibleBaseIndices(core)).toEqual([]);
+        });
+
         it('锁定列表包含重复索引时应保序去重，避免重复计分/重复交互选项', () => {
             const core = makeMinimalCore({
                 bases: [
@@ -189,6 +206,75 @@ describe('计分阶段 eligible 基地锁定', () => {
 
             const result = getScoringEligibleBaseIndices(core);
             expect(result).toEqual([2, 0]);
+        });
+    });
+
+    describe('正常 scoreBases session 重新检查', () => {
+        it('进入 scoreBases 时只建立候选 session，不写阶段级锁定事件', () => {
+            const core = makeMinimalCore({
+                bases: [
+                    makeBase(BASE_JUNGLE, [
+                        makeMinion('j0', '0', 6),
+                        makeMinion('j1', '1', 8),
+                    ]),
+                    makeBase(BASE_TAR_PITS, [
+                        makeMinion('t0', '0', 9),
+                        makeMinion('t1', '1', 8),
+                    ]),
+                ],
+            });
+            const sys = createInitialSystemState([...TEST_PLAYER_IDS], smashUpSystemsForTest, undefined);
+            sys.phase = 'playCards';
+            const state: MatchState<SmashUpCore> = { core, sys };
+
+            const phaseEnter = smashUpFlowHooks.onPhaseEnter?.({
+                state,
+                from: 'playCards',
+                to: 'scoreBases',
+                command: { type: 'ADVANCE_PHASE', playerId: '0', payload: undefined, timestamp: 1 } as any,
+                random: testRandom,
+            }) as { events: SmashUpEvent[]; updatedState: MatchState<SmashUpCore> };
+
+            expect(phaseEnter.events.map(event => event.type)).not.toContain(SU_EVENTS.SCORING_ELIGIBLE_BASES_LOCKED);
+            expect(phaseEnter.updatedState.core.scoringEligibleBaseIndices).toBeUndefined();
+            expect(getScoringSession(phaseEnter.updatedState)?.lockedBaseRefs.map(ref => ref.slotIndex)).toEqual([0, 1]);
+        });
+
+        it('已完成一个基地后，会重新检查并丢弃不再达标的旧候选基地', () => {
+            const core = makeMinimalCore({
+                bases: [
+                    makeBase(BASE_JUNGLE, [
+                        makeMinion('j0', '0', 6),
+                        makeMinion('j1', '1', 8),
+                    ]),
+                    makeBase(BASE_TAR_PITS, [
+                        makeMinion('t0', '0', 4),
+                        makeMinion('t1', '1', 4),
+                    ]),
+                ],
+            });
+            const sys = createInitialSystemState([...TEST_PLAYER_IDS], smashUpSystemsForTest, undefined);
+            sys.phase = 'scoreBases';
+            let state: MatchState<SmashUpCore> = { core, sys };
+            const completedRef = createScoringBaseRef(core, 0);
+            const staleRef = createScoringBaseRef(core, 1);
+            expect(completedRef).toBeDefined();
+            expect(staleRef).toBeDefined();
+            state = setScoringSession(state, {
+                ...createScoringSession(core, [0, 1]),
+                lockedBaseRefs: [completedRef!, staleRef!],
+                completedBaseRefs: [completedRef!],
+            });
+
+            const phaseExit = smashUpFlowHooks.onPhaseExit?.({
+                state,
+                from: 'scoreBases',
+                command: { type: 'ADVANCE_PHASE', playerId: '0', payload: undefined, timestamp: 2 } as any,
+                random: testRandom,
+            }) as { events: SmashUpEvent[]; updatedState: MatchState<SmashUpCore> };
+
+            expect(phaseExit.events.map(event => event.type)).not.toContain(SU_EVENTS.BASE_SCORED);
+            expect(getScoringSession(phaseExit.updatedState)).toBeUndefined();
         });
     });
 

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -53,7 +53,7 @@ import {
     VP_TO_WIN,
     getCurrentPlayerId,
 } from './types';
-import { getEffectivePower, getTotalEffectivePowerOnBase, getEffectiveBreakpoint, getEffectivePowerBreakdown, getPlayerEffectivePowerOnBase, getScoringEligibleBaseIndices } from './ongoingModifiers';
+import { getEffectivePower, getTotalEffectivePowerOnBase, getEffectiveBreakpoint, getEffectivePowerBreakdown, getPlayerEffectivePowerOnBase, getRealtimeScoringEligibleBaseIndices, getScoringEligibleBaseIndices } from './ongoingModifiers';
 import { collectTriggers, fireTriggerForSource, getModifiedBaseVp, hasRegisteredTrigger, interceptEvent as ongoingInterceptEvent, isBaseScoringSuppressed } from './ongoingEffects';
 import { maybeResolveReactionQueue } from './reactionQueue';
 import {
@@ -384,7 +384,7 @@ function buildBaseRankings(
 }
 
 function getLockedScoringBaseIndices(core: SmashUpCore): number[] {
-    return getScoringEligibleBaseIndices(core);
+    return getRealtimeScoringEligibleBaseIndices(core);
 }
 
 function ensureScoreBasesSession(state: MatchState<SmashUpCore>): MatchState<SmashUpCore> {
@@ -396,6 +396,24 @@ function ensureScoreBasesSession(state: MatchState<SmashUpCore>): MatchState<Sma
         return state;
     }
     return setScoringSession(state, createScoringSession(state.core, lockedIndices));
+}
+
+function refreshPendingScoringBaseRefs(state: MatchState<SmashUpCore>): MatchState<SmashUpCore> {
+    const session = getScoringSession(state);
+    if (!session || session.currentBaseRef) {
+        return state;
+    }
+    const liveRefs = getRealtimeScoringEligibleBaseIndices(state.core)
+        .map((baseIndex) => createScoringBaseRef(state.core, baseIndex))
+        .filter((baseRef): baseRef is SmashUpScoringBaseRef => !!baseRef)
+        .filter((baseRef) => !session.completedBaseRefs.some((completedRef) => isSameScoringBaseRef(completedRef, baseRef)));
+
+    return updateScoringSession(state, (currentSession) => currentSession
+        ? {
+            ...currentSession,
+            lockedBaseRefs: liveRefs,
+        }
+        : currentSession);
 }
 
 function buildMultiBaseScoringInteraction(
@@ -497,35 +515,17 @@ function finalizeCurrentScoringBase(
     );
     const completedSession = getScoringSession(completedState);
     if (completedSession) {
-        const discoveredEligibleRefs = getScoringEligibleBaseIndices(postDeferredCore)
+        const liveEligibleRefs = getRealtimeScoringEligibleBaseIndices(postDeferredCore)
             .map((baseIndex) => createScoringBaseRef({ ...postDeferredCore }, baseIndex))
             .filter((baseRef): baseRef is SmashUpScoringBaseRef => !!baseRef)
-            .filter((baseRef) => !completedSession.completedBaseRefs.some((completedRef) => isSameScoringBaseRef(completedRef, baseRef)))
-            .filter((baseRef) => !completedSession.lockedBaseRefs.some((lockedRef) => isSameScoringBaseRef(lockedRef, baseRef)));
+            .filter((baseRef) => !completedSession.completedBaseRefs.some((completedRef) => isSameScoringBaseRef(completedRef, baseRef)));
 
-        if (discoveredEligibleRefs.length > 0) {
-            completedState = updateScoringSession(completedState, (currentSession) => currentSession
-                ? {
-                    ...currentSession,
-                    lockedBaseRefs: [...currentSession.lockedBaseRefs, ...discoveredEligibleRefs],
-                }
-                : currentSession);
-
-            const futureState = { ...completedState, core: postDeferredCore };
-            const futureSession = getScoringSession(futureState);
-            const remainingLockedIndices = futureSession
-                ? futureSession.lockedBaseRefs
-                    .filter((baseRef) => !futureSession.completedBaseRefs.some((completedRef) => isSameScoringBaseRef(completedRef, baseRef)))
-                    .map((baseRef) => resolveScoringBaseRefSlotIndex(futureState, baseRef))
-                    .filter((baseIndex): baseIndex is number => baseIndex !== undefined)
-                : [];
-
-            events.push({
-                type: SU_EVENTS.SCORING_ELIGIBLE_BASES_LOCKED,
-                payload: { baseIndices: remainingLockedIndices },
-                timestamp: now,
-            } as SmashUpEvent);
-        }
+        completedState = updateScoringSession(completedState, (currentSession) => currentSession
+            ? {
+                ...currentSession,
+                lockedBaseRefs: liveEligibleRefs,
+            }
+            : currentSession);
     }
     const awaitingReduceState = {
         ...completedState,
@@ -626,6 +626,28 @@ export function scoreOneBase(
             }
             : session,
         );
+    }
+    const currentBaseSelectedForScoring = !!(
+        ms
+        && currentBaseRef
+        && isSameScoringBaseRef(getScoringSession(ms)?.currentBaseRef, currentBaseRef)
+    );
+    if (
+        currentBaseSelectedForScoring
+        && (
+            !Array.isArray(core.scoringEligibleBaseIndices)
+            || core.scoringEligibleBaseIndices.length !== 1
+            || core.scoringEligibleBaseIndices[0] !== baseIndex
+        )
+    ) {
+        const currentBaseLockEvent = {
+            type: SU_EVENTS.SCORING_ELIGIBLE_BASES_LOCKED,
+            payload: { baseIndices: [baseIndex] },
+            timestamp: now,
+        } as unknown as SmashUpEvent;
+        events.push(currentBaseLockEvent);
+        core = reduce(core, currentBaseLockEvent);
+        ms = { ...ms, core };
     }
     let newBaseDeck = baseDeck;
 
@@ -739,10 +761,11 @@ export function scoreOneBase(
     }
     const effectiveBreakpointAfterBefore = getEffectiveBreakpoint(updatedCore, baseIndex);
     const totalPowerAfterBefore = getTotalEffectivePowerOnBase(updatedCore, updatedBaseAfterBefore, baseIndex);
-    const lockedAtScoreBasesEnter = updatedCore.scoringEligibleBaseIndices?.includes(baseIndex) ?? false;
-    // 规则（Wiki Phase 3 Step 4）：进入 scoreBases 阶段时达到 breakpoint 的基地会被锁定，
-    // 即便在 Me First! / beforeScoring 链路中力量被压到 breakpoint 以下，仍应继续计分。
-    if (!lockedAtScoreBasesEnter && totalPowerAfterBefore < effectiveBreakpointAfterBefore) {
+    const selectedBaseLocked = currentBaseSelectedForScoring
+        || (updatedCore.scoringEligibleBaseIndices?.includes(baseIndex) ?? false);
+    // 规则：只有已经被选择并开始结算的当前基地，即使 beforeScoring 链路中力量
+    // 被压到 breakpoint 以下，也会继续完成本次计分。
+    if (!selectedBaseLocked && totalPowerAfterBefore < effectiveBreakpointAfterBefore) {
         if (ms) ms = { ...ms, core: updatedCore };
         return { events, newBaseDeck: baseDeck, matchState: ms };
     }
@@ -1695,6 +1718,7 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
             }
 
             if (!currentSession.currentBaseRef) {
+                currentState = refreshPendingScoringBaseRefs(currentState);
                 const remainingBaseRefs = getRemainingScoringBaseRefs(currentState);
 
                 if (remainingBaseRefs.length === 0) {
@@ -1996,19 +2020,11 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
                 timestamp: now,
             } as GameEvent);
 
-            const eligibleIndices = getScoringEligibleBaseIndices(core);
+            const eligibleIndices = getRealtimeScoringEligibleBaseIndices(core);
             currentMatchState = eligibleIndices.length > 0
                 ? setScoringSession(currentMatchState, createScoringSession(core, eligibleIndices))
                 : clearScoringSession(currentMatchState);
             hasSysUpdate = true;
-
-            if (eligibleIndices.length > 0) {
-                events.push({
-                    type: SU_EVENTS.SCORING_ELIGIBLE_BASES_LOCKED,
-                    payload: { baseIndices: eligibleIndices },
-                    timestamp: now,
-                } as GameEvent);
-            }
 
             return { events, updatedState: currentMatchState } as PhaseEnterResult;
         }

--- a/src/games/smashup/domain/ongoingModifiers.ts
+++ b/src/games/smashup/domain/ongoingModifiers.ts
@@ -1360,20 +1360,7 @@ export function getEffectiveBreakpoint(
     return Math.max(0, baseDef.breakpoint + total + tempDelta);
 }
 
-/**
- * 获取当前计分阶段中 eligible 的基地索引列表（单一查询入口）。
- *
- * 规则（Wiki Phase 3 Step 4）：一旦基地在进入 scoreBases 阶段时达到 breakpoint，
- * 即使 Me First! 响应窗口中力量被降低到 breakpoint 以下，该基地仍然必定计分。
- *
- * - 如果 `core.scoringEligibleBaseIndices` 存在（进入阶段时锁定），直接返回。
- * - 否则实时计算（正常流程不应走到这里，仅作为安全回退）。
- */
-export function getScoringEligibleBaseIndices(state: SmashUpCore): number[] {
-    if (Array.isArray(state.scoringEligibleBaseIndices)) {
-        return normalizeScoringEligibleBaseIndices(state.scoringEligibleBaseIndices);
-    }
-    // 回退：实时计算
+export function getRealtimeScoringEligibleBaseIndices(state: SmashUpCore): number[] {
     const indices: number[] = [];
     for (let i = 0; i < state.bases.length; i++) {
         const base = state.bases[i];
@@ -1386,6 +1373,19 @@ export function getScoringEligibleBaseIndices(state: SmashUpCore): number[] {
         }
     }
     return normalizeScoringEligibleBaseIndices(indices);
+}
+
+/**
+ * 获取当前可计分基地索引。
+ *
+ * `scoringEligibleBaseIndices` 只用于当前已选择基地/旧快照兼容；正常计分链应使用
+ * getRealtimeScoringEligibleBaseIndices 重新检查桌面，而不是锁定阶段开始时的全部基地。
+ */
+export function getScoringEligibleBaseIndices(state: SmashUpCore): number[] {
+    if (Array.isArray(state.scoringEligibleBaseIndices)) {
+        return normalizeScoringEligibleBaseIndices(state.scoringEligibleBaseIndices);
+    }
+    return getRealtimeScoringEligibleBaseIndices(state);
 }
 
 export function normalizeScoringEligibleBaseIndices(indices: readonly number[]): number[] {


### PR DESCRIPTION
## 修复内容
- scoreBases 阶段进入时只建立候选 session，不再把阶段开始时的所有达标基地写成全局锁定列表。
- 每个基地完成后实时重新检查桌面 eligible 基地，并用实时结果替换后续候选队列。
- 只有当前已选择并开始结算的基地会写入 `SCORING_ELIGIBLE_BASES_LOCKED`，用于支持 beforeScoring 把当前基地压到 breakpoint 以下后仍继续完成本次计分。
- 更新测试，覆盖旧快照兼容、阶段进入不写全局锁、旧候选跌破 breakpoint 后不再继续计分，以及 multi_base_scoring 夹具改用真实达标基地。

## 根因
旧实现把 scoreBases 阶段开始时的所有 eligible 基地都锁进 `scoringEligibleBaseIndices` / scoring session，后续即使未选择的基地已低于 breakpoint，仍会继续被强制计分。

## 验证
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/scoringEligibleLock.test.ts --configLoader native`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/scoreBases-auto-continue.test.ts --configLoader native`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/scoreBases-deferred-finalization.test.ts --configLoader native`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/scoringEligibleLock.test.ts src/games/smashup/__tests__/scoreBases-auto-continue.test.ts src/games/smashup/__tests__/scoreBases-deferred-finalization.test.ts --configLoader native`