### PR TITLE
修正大杀四方疯狂卡终局

### DIFF
--- a/src/games/smashup/__tests__/revealSystem.test.ts
+++ b/src/games/smashup/__tests__/revealSystem.test.ts
@@ -353,14 +353,14 @@ describe('卡牌展示系统', () => {
     });
 
     describe('疯狂卡平局规则', () => {
-        it('VP 相同时疯狂卡较少者胜', () => {
+        it('原始独占领先触发终局后，最终分相同时疯狂卡较少者胜', () => {
             const state: SmashUpCore = {
                 players: {
                     '0': { id: '0', vp: 15, hand: [
                         { uid: 'm1', defId: 'special_madness', type: 'minion', owner: '0' },
                         { uid: 'm2', defId: 'special_madness', type: 'minion', owner: '0' },
                     ], deck: [], discard: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: ['aliens', 'dinosaurs'] as [string, string] },
-                    '1': { id: '1', vp: 15, hand: [
+                    '1': { id: '1', vp: 14, hand: [
                         { uid: 'm3', defId: 'special_madness', type: 'minion', owner: '1' },
                     ], deck: [], discard: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: ['pirates', 'ninjas'] as [string, string] },
                 },
@@ -373,14 +373,69 @@ describe('卡牌展示系统', () => {
                 madnessDeck: [],
             };
 
-            // P0 有 2 张疯狂卡（扣 1 VP → 14），P1 有 1 张（扣 0 VP → 15）
-            // P1 分数更高直接胜出
+            // P0 原始 15 且独占领先，触发终局；P0 扣 1 后与 P1 同为 14，
+            // P1 疯狂卡更少，因此由 P1 获胜。
             const result = SmashUpDomain.isGameOver!(state);
             expect(result).toBeDefined();
             expect(result!.winner).toBe('1');
+            expect(result!.scores).toMatchObject({ '0': 14, '1': 14 });
         });
 
-        it('VP 和疯狂卡都相同时继续游戏', () => {
+        it('原始不足 15 的玩家可在疯狂卡扣分后击败原始领先者', () => {
+            const state: SmashUpCore = {
+                players: {
+                    '0': { id: '0', vp: 15, hand: [
+                        { uid: 'm1', defId: 'special_madness', type: 'minion', owner: '0' },
+                        { uid: 'm2', defId: 'special_madness', type: 'minion', owner: '0' },
+                        { uid: 'm3', defId: 'special_madness', type: 'minion', owner: '0' },
+                        { uid: 'm4', defId: 'special_madness', type: 'minion', owner: '0' },
+                    ], deck: [], discard: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: ['aliens', 'dinosaurs'] as [string, string] },
+                    '1': { id: '1', vp: 14, hand: [], deck: [], discard: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: ['pirates', 'ninjas'] as [string, string] },
+                },
+                turnOrder: ['0', '1'],
+                currentPlayerIndex: 0,
+                bases: [],
+                baseDeck: [],
+                turnNumber: 5,
+                nextUid: 100,
+                madnessDeck: [],
+            };
+
+            const result = SmashUpDomain.isGameOver!(state);
+            expect(result).toBeDefined();
+            expect(result!.winner).toBe('1');
+            expect(result!.scores).toMatchObject({ '0': 13, '1': 14 });
+        });
+
+        it('疯狂卡修正后完全同分且疯狂卡同样少时共享胜利', () => {
+            const state: SmashUpCore = {
+                players: {
+                    '0': { id: '0', vp: 15, hand: [
+                        { uid: 'm1', defId: 'special_madness', type: 'minion', owner: '0' },
+                        { uid: 'm2', defId: 'special_madness', type: 'minion', owner: '0' },
+                        { uid: 'm3', defId: 'special_madness', type: 'minion', owner: '0' },
+                        { uid: 'm4', defId: 'special_madness', type: 'minion', owner: '0' },
+                    ], deck: [], discard: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: ['aliens', 'dinosaurs'] as [string, string] },
+                    '1': { id: '1', vp: 13, hand: [], deck: [], discard: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: ['pirates', 'ninjas'] as [string, string] },
+                    '2': { id: '2', vp: 13, hand: [], deck: [], discard: [], minionsPlayed: 0, minionLimit: 1, actionsPlayed: 0, actionLimit: 1, factions: ['wizards', 'zombies'] as [string, string] },
+                },
+                turnOrder: ['0', '1', '2'],
+                currentPlayerIndex: 0,
+                bases: [],
+                baseDeck: [],
+                turnNumber: 5,
+                nextUid: 100,
+                madnessDeck: [],
+            };
+
+            const result = SmashUpDomain.isGameOver!(state);
+            expect(result).toBeDefined();
+            expect(result!.winner).toBe('1');
+            expect(result!.winners).toEqual(['1', '2']);
+            expect(result!.scores).toMatchObject({ '0': 13, '1': 13, '2': 13 });
+        });
+
+        it('原始最高 VP 没有独占领先时继续游戏', () => {
             const state: SmashUpCore = {
                 players: {
                     '0': { id: '0', vp: 15, hand: [

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -2261,63 +2261,28 @@ function isGameOver(state: SmashUpCore): GameOverResult | undefined {
         return undefined;
     }
 
-    if (isSmashUpTwoVsTwoMode(state)) {
-        const rawTeamTotals = getSmashUpRawTeamVpTotals(state);
-        const candidateTeams = Object.entries(rawTeamTotals)
-            .filter(([, total]) => total >= TEAM_VP_TO_WIN_2V2)
-            .map(([teamId]) => teamId as import('./types').SmashUpTeamId);
-        if (candidateTeams.length === 0) {
-            return undefined;
-        }
+    const rawScores = Object.fromEntries(
+        state.turnOrder.map((pid) => [pid, state.players[pid]?.vp ?? 0]),
+    ) as Record<PlayerId, number>;
+    const highestRawScore = Math.max(...Object.values(rawScores));
+    if (highestRawScore < VP_TO_WIN) return undefined;
+    const rawLeaders = state.turnOrder.filter(pid => rawScores[pid] === highestRawScore);
+    if (rawLeaders.length !== 1) return undefined;
 
-        const scores = getScores(state);
-        const teamScores = getSmashUpTeamScores(state, scores);
-
-        if (candidateTeams.length === 1) {
-            const winners = getSmashUpTeamMembers(state, candidateTeams[0]);
-            return {
-                winner: winners[0],
-                winners,
-                scores,
-            };
-        }
-
-        const sortedTeams = [...candidateTeams].sort((left, right) => teamScores[right] - teamScores[left]);
-        if (teamScores[sortedTeams[0]] > teamScores[sortedTeams[1]]) {
-            const winners = getSmashUpTeamMembers(state, sortedTeams[0]);
-            return {
-                winner: winners[0],
-                winners,
-                scores,
-            };
-        }
-
-        return undefined;
-    }
-    const winners = state.turnOrder.filter(pid => state.players[pid]?.vp >= VP_TO_WIN);
-    if (winners.length === 0) return undefined;
-
-    // 璁＄畻鍚柉鐙傚崱鎯╃綒鐨勬渶缁堝垎鏁?
     const scores = getScores(state);
-
-    if (winners.length === 1) {
-        return { winner: winners[0], scores };
+    if (state.madnessDeck === undefined) {
+        return { winner: rawLeaders[0], scores };
     }
 
-    const sorted = winners.sort((a, b) => scores[b] - scores[a]);
-    if (scores[sorted[0]] > scores[sorted[1]]) {
-        return { winner: sorted[0], scores };
-    }
+    const highestScore = Math.max(...state.turnOrder.map(pid => scores[pid] ?? 0));
+    const finalists = state.turnOrder.filter(pid => scores[pid] === highestScore);
+    if (finalists.length === 1) return { winner: finalists[0], scores };
 
-    if (state.madnessDeck !== undefined) {
-        const madnessA = countMadnessCardsForPlayer(state, sorted[0]);
-        const madnessB = countMadnessCardsForPlayer(state, sorted[1]);
-        if (madnessA !== madnessB) {
-            return { winner: madnessA < madnessB ? sorted[0] : sorted[1], scores };
-        }
-    }
+    const minMadness = Math.min(...finalists.map(pid => countMadnessCardsForPlayer(state, pid)));
+    const winners = finalists.filter(pid => countMadnessCardsForPlayer(state, pid) === minMadness);
+    if (winners.length === 1) return { winner: winners[0], scores };
 
-    return undefined;
+    return { winner: winners[0], winners, scores };
 }
 
 export function getScores(state: SmashUpCore): Record<PlayerId, number> {


### PR DESCRIPTION
## 修复内容
- 重写大杀四方 FFA 终局判断：先确认是否存在原始 VP 达到 15 且独占领先的玩家，再进入终局结算。
- 疯狂卡扩展启用时，终局结算会比较所有玩家扣疯狂卡后的分数，而不是只比较原始 15+ 的玩家。
- 修正疯狂卡同分处理：最终分相同时由疯狂卡更少者胜；若最终分和疯狂卡数量仍同样少，则返回共享胜利 `winners`。
- 删除 `isGameOver()` 中重复且不可达的 2v2 判断块。
- 补充疯狂卡终局回归测试，覆盖原始不足 15 反超、疯狂卡较少者胜、共享胜利、原始最高 VP 未独占时继续游戏。

## 根因
旧实现先过滤原始 VP ≥ 15 的玩家，并在只有一个候选时直接返回胜者，导致疯狂卡扣分后可能获胜的其他玩家永远不会参与比较；同时最终完全同分时返回 `undefined`，无法表达共享胜利。

## 验证
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/revealSystem.test.ts --configLoader native`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/turnCycle.test.ts --configLoader native`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/smashup.smoke.test.ts --configLoader native -t "2v2"`