### PR TITLE
修正大杀四方玩家视图隐私

### DIFF
--- a/src/engine/ai/__tests__/playerView.test.ts
+++ b/src/engine/ai/__tests__/playerView.test.ts
@@ -3,6 +3,7 @@ import { createInteractionSystem, createSimpleChoice } from '../../systems/Inter
 import { applyPlayerViewToState } from '../playerView';
 import type { GameEngineConfig } from '../../transport/server';
 import type { MatchState } from '../../types';
+import { SmashUpDomain } from '../../../games/smashup/domain';
 import { normalizeSmashUpMatchStateForUi } from '../../../games/smashup/ui/normalizeRuntimeState';
 
 const engineConfig: GameEngineConfig = {
@@ -27,6 +28,12 @@ const smashUpEngineConfig: GameEngineConfig = {
         execute: () => [],
         reduce: (state) => state,
     },
+    systems: [],
+};
+
+const smashUpPrivacyEngineConfig: GameEngineConfig = {
+    gameId: 'smashup',
+    domain: SmashUpDomain as any,
     systems: [],
 };
 
@@ -216,5 +223,70 @@ describe('applyPlayerViewToState', () => {
         expect(spectatorView.core.players['0'].usedDiscardPlayAbilities).toBeUndefined();
         expect(spectatorView.core.bases[0].buriedCards).toEqual([]);
         expect(spectatorView.core.madnessDeck).toEqual(['special_madness', 'special_madness']);
+    });
+
+    it('SmashUp 玩家视图浅合并后不应泄露对手手牌和牌库内容', () => {
+        const authoritativeState: MatchState<unknown> = {
+            core: {
+                activePlayerId: '0',
+                currentPlayerIndex: 0,
+                turnOrder: ['0', '1'],
+                turnNumber: 1,
+                nextUid: 10,
+                players: {
+                    '0': {
+                        id: '0',
+                        hand: [{ uid: 'p0-hand-a', defId: 'pirate_first_mate', type: 'minion', owner: '0' }],
+                        deck: [{ uid: 'p0-deck-a', defId: 'pirate_full_sail', type: 'action', owner: '0' }],
+                        discard: [],
+                        vp: 0,
+                        minionsPlayed: 0,
+                        minionLimit: 1,
+                        actionsPlayed: 0,
+                        actionLimit: 1,
+                        factions: ['pirates', 'aliens'],
+                    },
+                    '1': {
+                        id: '1',
+                        hand: [{ uid: 'p1-secret-hand', defId: 'alien_probe', type: 'action', owner: '1' }],
+                        deck: [{ uid: 'p1-secret-topdeck', defId: 'alien_invader', type: 'minion', owner: '1' }],
+                        discard: [{ uid: 'p1-public-discard', defId: 'alien_scout', type: 'minion', owner: '1' }],
+                        vp: 0,
+                        minionsPlayed: 0,
+                        minionLimit: 1,
+                        actionsPlayed: 0,
+                        actionLimit: 1,
+                        factions: ['pirates', 'aliens'],
+                    },
+                },
+                bases: [{ defId: 'base_tortuga', minions: [], ongoingActions: [] }],
+                baseDeck: [],
+                baseDiscard: [],
+            },
+            sys: {
+                phase: 'playCards',
+                turnNumber: 1,
+                eventStream: { entries: [], nextId: 1 },
+                interaction: { current: undefined, queue: [], isBlocked: false },
+                responseWindow: { current: undefined },
+            },
+        } as MatchState<unknown>;
+
+        const playerView = applyPlayerViewToState(smashUpPrivacyEngineConfig, authoritativeState, '0') as any;
+
+        expect(playerView.core.players['0'].hand[0]).toEqual(expect.objectContaining({
+            uid: 'p0-hand-a',
+            defId: 'pirate_first_mate',
+        }));
+        expect(playerView.core.players['1'].hand).toEqual([
+            expect.objectContaining({ uid: 'hidden_1_hand_0', defId: 'hidden_private_card' }),
+        ]);
+        expect(playerView.core.players['1'].deck).toEqual([
+            expect.objectContaining({ uid: 'hidden_1_deck_0', defId: 'hidden_private_card' }),
+        ]);
+        expect(playerView.core.players['1'].discard[0]).toEqual(expect.objectContaining({
+            uid: 'p1-public-discard',
+            defId: 'alien_scout',
+        }));
     });
 });

--- a/src/games/smashup/__tests__/playerViewBuriedMask.test.ts
+++ b/src/games/smashup/__tests__/playerViewBuriedMask.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { SmashUpDomain } from '../domain';
-import { makeBase, makePlayer, makeState } from './helpers';
+import { makeBase, makeCard, makePlayer, makeState } from './helpers';
 
 describe('playerView buried mask', () => {
     it('非控制者视角查看 borrowed buried card 时，不应把 trueOwnerId 改写成 controllerId', () => {
@@ -32,5 +32,63 @@ describe('playerView buried mask', () => {
             controllerId: '0',
             buriedFrom: 'hand',
         }));
+    });
+
+    it('玩家视角不应暴露对手手牌、牌库和暂存卡内容', () => {
+        const ownHand = [makeCard('p0-hand-a', 'pirate_first_mate', 'minion', '0')];
+        const ownDeck = [makeCard('p0-deck-a', 'pirate_full_sail', 'action', '0')];
+        const opponentHand = [
+            makeCard('p1-hand-a', 'alien_invader', 'minion', '1'),
+            makeCard('p1-hand-b', 'alien_probe', 'action', '1'),
+        ];
+        const opponentDeck = [
+            makeCard('p1-deck-top', 'alien_collector', 'minion', '1'),
+            makeCard('p1-deck-next', 'alien_jammed_signal', 'action', '1'),
+        ];
+        const opponentStored = [{
+            ...makeCard('p1-stored-a', 'time_travelers_time_loop', 'action', '1'),
+            storedByPlayerId: '1',
+            storedUnderUid: 'time-box-a',
+            storedUnderDefId: 'time_travelers_time_box',
+            reason: 'time_travelers_time_box',
+        }];
+        const opponentDiscard = [makeCard('p1-discard-a', 'alien_scout', 'minion', '1')];
+        const core = makeState({
+            players: {
+                '0': makePlayer('0', { hand: ownHand, deck: ownDeck }),
+                '1': makePlayer('1', {
+                    hand: opponentHand,
+                    deck: opponentDeck,
+                    discard: opponentDiscard,
+                    storedCards: opponentStored as any,
+                }),
+            },
+        });
+
+        const view = SmashUpDomain.playerView(core, '0') as any;
+
+        expect(view.players['0'].hand).toEqual(ownHand);
+        expect(view.players['0'].deck).toEqual(ownDeck);
+        expect(view.players['1'].discard).toEqual(opponentDiscard);
+        expect(view.players['1'].hand).toHaveLength(opponentHand.length);
+        expect(view.players['1'].deck).toHaveLength(opponentDeck.length);
+        expect(view.players['1'].storedCards).toHaveLength(opponentStored.length);
+        expect(view.players['1'].hand.map((card: any) => card.defId)).toEqual([
+            'hidden_private_card',
+            'hidden_private_card',
+        ]);
+        expect(view.players['1'].deck.map((card: any) => card.defId)).toEqual([
+            'hidden_private_card',
+            'hidden_private_card',
+        ]);
+        expect(view.players['1'].storedCards[0]).toEqual(expect.objectContaining({
+            uid: 'hidden_1_stored_0',
+            defId: 'hidden_private_card',
+            storedByPlayerId: '1',
+            reason: 'hidden_private_card',
+        }));
+        expect(view.players['1'].hand.map((card: any) => card.uid)).not.toContain('p1-hand-a');
+        expect(view.players['1'].deck.map((card: any) => card.uid)).not.toContain('p1-deck-top');
+        expect(view.players['1'].storedCards[0].storedUnderDefId).toBeUndefined();
     });
 });

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -23,6 +23,8 @@ import type {
     AbilityFeedbackEvent,
     GamePhase,
     PlayerState,
+    CardInstance,
+    StoredCardInstance,
     BaseInPlay,
     TurnStartedEvent,
     TurnEndedEvent,
@@ -2196,6 +2198,35 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
 
 // ============================================================================
 
+const HIDDEN_PRIVATE_CARD_DEF_ID = 'hidden_private_card';
+
+function maskPrivateCard(ownerId: PlayerId, zone: 'hand' | 'deck' | 'stored', index: number): CardInstance {
+    return {
+        uid: `hidden_${ownerId}_${zone}_${index}`,
+        defId: HIDDEN_PRIVATE_CARD_DEF_ID,
+        type: 'action',
+        owner: ownerId,
+    };
+}
+
+function maskStoredCard(ownerId: PlayerId, index: number): StoredCardInstance {
+    return {
+        ...maskPrivateCard(ownerId, 'stored', index),
+        storedByPlayerId: ownerId,
+        reason: HIDDEN_PRIVATE_CARD_DEF_ID,
+    };
+}
+
+function maskPlayerPrivateZones(player: PlayerState, playerId: PlayerId): PlayerState {
+    if (player.id === playerId) return player;
+    return {
+        ...player,
+        hand: player.hand.map((_, index) => maskPrivateCard(player.id, 'hand', index)),
+        deck: player.deck.map((_, index) => maskPrivateCard(player.id, 'deck', index)),
+        storedCards: player.storedCards?.map((_, index) => maskStoredCard(player.id, index)),
+    };
+}
+
 // ============================================================================
 
 function playerView(state: SmashUpCore, playerId: PlayerId): Partial<SmashUpCore> {
@@ -2216,7 +2247,13 @@ function playerView(state: SmashUpCore, playerId: PlayerId): Partial<SmashUpCore
             }),
         };
     });
-    return { bases: maskedBases };
+    const maskedPlayers = Object.fromEntries(
+        Object.entries(state.players).map(([id, player]) => [
+            id,
+            maskPlayerPrivateZones(player, playerId),
+        ]),
+    ) as SmashUpCore['players'];
+    return { bases: maskedBases, players: maskedPlayers };
 }
 
 // ============================================================================


### PR DESCRIPTION
## 修复内容
- 在大杀四方 playerView 中同时覆盖 players，避免引擎浅合并保留完整私有玩家状态
- 非本人视角下将对手手牌、牌库和暂存卡替换为等长隐藏占位卡
- 保留本人手牌/牌库完整可见，并保持弃牌堆公开
- 保留现有埋葬牌脱敏逻辑，继续保留 borrowed buried card 的 trueOwnerId

## 验证
- node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/playerViewBuriedMask.test.ts --configLoader native
- node scripts/infra/vitest-cli-safe.mjs run src/engine/ai/__tests__/playerView.test.ts --configLoader native