### PR TITLE
修正大杀四方起手重抽弃牌流程

### DIFF
--- a/src/games/smashup/__tests__/mulligan.test.ts
+++ b/src/games/smashup/__tests__/mulligan.test.ts
@@ -5,7 +5,7 @@
  * - 起手含随从时不触发重抽
  * - 起手全是行动牌时记录可重抽玩家
  * - 重抽交互入队后流程仍会离开 factionSelect
- * - 重抽后手牌与牌库总数守恒
+ * - 重抽后原手牌进入弃牌堆，手牌/牌库/弃牌堆总数守恒
  * - 最多只允许重抽一次
  */
 
@@ -221,13 +221,25 @@ describe('SmashUp 起手重抽', () => {
 
             const prompt = getSimpleChoicePrompt(started.finalState, STARTING_HAND_MULLIGAN_SOURCE_ID);
             expect(prompt.playerId).toBe('0');
+            const originalHandUids = started.finalState.core.players['0'].hand.map(card => card.uid);
 
             const resolved = respondToPrompt(started.finalState, 'mulligan', '0', random);
+            const player = resolved.finalState.core.players['0'];
+            const eventTypes = resolved.events.map(event => event.type);
 
-            expect(resolved.finalState.core.players['0'].hand.length).toBe(STARTING_HAND_SIZE);
-            expect(resolved.finalState.core.players['0'].deck.length).toBe(40 - STARTING_HAND_SIZE);
-            expect(resolved.finalState.core.players['0'].hand.every(card => typeof card.uid === 'string')).toBe(true);
-            expect(resolved.finalState.core.players['0'].hand.some(card => card.type === 'minion')).toBe(false);
+            expect(player.hand.length).toBe(STARTING_HAND_SIZE);
+            expect(player.deck.length).toBe(40 - STARTING_HAND_SIZE * 2);
+            expect(player.discard.map(card => card.uid)).toEqual(originalHandUids);
+            for (const uid of originalHandUids) {
+                expect(player.hand.map(card => card.uid)).not.toContain(uid);
+                expect(player.deck.map(card => card.uid)).not.toContain(uid);
+            }
+            expect(player.hand.every(card => typeof card.uid === 'string')).toBe(true);
+            expect(player.hand.some(card => card.type === 'minion')).toBe(false);
+            expect(eventTypes).toContain(SU_EVENTS.REVEAL_HAND);
+            expect(eventTypes).toContain(SU_EVENTS.CARDS_DISCARDED);
+            expect(eventTypes).toContain(SU_EVENTS.CARDS_DRAWN);
+            expect(eventTypes).not.toContain(SU_EVENTS.HAND_SHUFFLED_INTO_DECK);
             expect(['startTurn', 'playCards']).toContain(resolved.finalState.sys.phase);
             expectNoPrompt(resolved.finalState);
         });

--- a/src/games/smashup/domain/abilityHelpers.ts
+++ b/src/games/smashup/domain/abilityHelpers.ts
@@ -1145,7 +1145,7 @@ export function shuffleBaseDeck(
 /** 生成展示手牌事件 */
 export function revealHand(
     targetPlayerId: PlayerId | PlayerId[],
-    viewerPlayerId: PlayerId,
+    viewerPlayerId: PlayerId | 'all',
     cards: { uid: string; defId: string }[],
     reason: string,
     now: number,

--- a/src/games/smashup/domain/mulliganHandlers.ts
+++ b/src/games/smashup/domain/mulliganHandlers.ts
@@ -1,10 +1,11 @@
-import type { MatchState, PlayerId, RandomFn } from '../../../engine/types';
+import type { MatchState, PlayerId } from '../../../engine/types';
 import { createSimpleChoice, queueInteraction } from '../../../engine/systems/InteractionSystem';
 import type { SmashUpCore, SmashUpEvent } from './types';
 import { SU_EVENTS, STARTING_HAND_SIZE } from './types';
 import type { InteractionHandler } from './abilityInteractionHandlers';
 import { registerInteractionHandler } from './abilityInteractionHandlers';
-import type { HandShuffledIntoDeckEvent, CardsDrawnEvent, StartingHandMulliganUsedEvent } from './types';
+import { drawCards } from './utils';
+import type { CardsDiscardedEvent, CardsDrawnEvent, DeckReshuffledEvent, RevealHandEvent, StartingHandMulliganUsedEvent } from './types';
 
 export const STARTING_HAND_MULLIGAN_SOURCE_ID = 'starting_hand_mulligan';
 
@@ -61,30 +62,58 @@ export function registerMulliganInteractionHandlers(): void {
       return { state, events: [used] };
     }
 
-    // mulligan: shuffle hand+deck into a fresh deck order, then draw starting hand
-    const all = [...player.hand, ...player.deck];
-    const shuffled = (random as RandomFn).shuffle(all);
-    const newDeckUids = shuffled.map(c => c.uid);
-    const drawCount = Math.min(STARTING_HAND_SIZE, shuffled.length);
-    const drawnUids = shuffled.slice(0, drawCount).map(c => c.uid);
-
-    const shuffleEvt: HandShuffledIntoDeckEvent = {
-      type: SU_EVENTS.HAND_SHUFFLED_INTO_DECK,
-      payload: { playerId, newDeckUids, reason: STARTING_HAND_MULLIGAN_SOURCE_ID },
+    // mulligan: reveal and discard the original no-minion hand, then draw a new hand.
+    const originalHand = [...player.hand];
+    const originalHandUids = originalHand.map(card => card.uid);
+    const revealEvt: RevealHandEvent = {
+      type: SU_EVENTS.REVEAL_HAND,
+      payload: {
+        targetPlayerId: playerId,
+        viewerPlayerId: 'all',
+        sourcePlayerId: playerId,
+        cards: originalHand.map(card => ({ uid: card.uid, defId: card.defId })),
+        reason: STARTING_HAND_MULLIGAN_SOURCE_ID,
+      },
       timestamp,
-    } as any;
-    const drawnEvt: CardsDrawnEvent = {
-      type: SU_EVENTS.CARDS_DRAWN,
-      payload: { playerId, count: drawCount, cardUids: drawnUids },
+    };
+    const discardEvt: CardsDiscardedEvent = {
+      type: SU_EVENTS.CARDS_DISCARDED,
+      payload: { playerId, cardUids: originalHandUids },
       timestamp: timestamp + 1,
-    } as any;
+    };
+    const ownDiscardedCards = originalHand.filter(card => (core.players[card.owner] ? card.owner : playerId) === playerId);
+    const drawSourcePlayer = {
+      ...player,
+      hand: [],
+      discard: [...player.discard, ...ownDiscardedCards],
+    };
+    const drawResult = drawCards(drawSourcePlayer, STARTING_HAND_SIZE, random);
+    const events: SmashUpEvent[] = [revealEvt, discardEvt] as unknown as SmashUpEvent[];
+
+    if (drawResult.reshuffledDeckUids && drawResult.reshuffledDeckUids.length > 0) {
+      const reshuffleEvt: DeckReshuffledEvent = {
+        type: SU_EVENTS.DECK_RESHUFFLED,
+        payload: { playerId, deckUids: drawResult.reshuffledDeckUids },
+        timestamp: timestamp + 2,
+      };
+      events.push(reshuffleEvt as unknown as SmashUpEvent);
+    }
+    if (drawResult.drawnUids.length > 0) {
+      const drawnEvt: CardsDrawnEvent = {
+        type: SU_EVENTS.CARDS_DRAWN,
+        payload: { playerId, count: drawResult.drawnUids.length, cardUids: drawResult.drawnUids },
+        timestamp: timestamp + 3,
+      };
+      events.push(drawnEvt as unknown as SmashUpEvent);
+    }
     const usedEvt: StartingHandMulliganUsedEvent = {
       type: SU_EVENTS.STARTING_HAND_MULLIGAN_USED,
       payload: { playerId, used: true },
-      timestamp: timestamp + 2,
-    } as any;
+      timestamp: timestamp + 4,
+    };
+    events.push(usedEvt as unknown as SmashUpEvent);
 
-    return { state, events: [shuffleEvt, drawnEvt, usedEvt] as unknown as SmashUpEvent[] };
+    return { state, events };
   };
 
   registerInteractionHandler(STARTING_HAND_MULLIGAN_SOURCE_ID, handler);

--- a/src/games/smashup/domain/types.ts
+++ b/src/games/smashup/domain/types.ts
@@ -2051,8 +2051,8 @@ export interface RevealHandEvent extends GameEvent<typeof SU_EVENTS.REVEAL_HAND>
     payload: {
         /** 被查看的玩家（单人或多人） */
         targetPlayerId: string | string[];
-        /** 查看者 */
-        viewerPlayerId: string;
+        /** 查看者（'all' = 所有人，PlayerId = 指定玩家） */
+        viewerPlayerId: string | 'all';
         /** 被展示的卡牌列表 */
         cards: { uid: string; defId: string }[];
         /** 触发展示的玩家（viewerPlayerId='all' 时由此玩家关闭展示） */


### PR DESCRIPTION
## 修复内容
- 起手无随从选择重抽时，先公开展示原手牌，再将原手牌弃置
- 新手牌从剩余牌库抽取，不再把原手牌与牌库合并重洗
- 若牌库不足，继续复用既有 drawCards 的弃牌堆重洗逻辑
- 将 REVEAL_HAND 的 viewerPlayerId 类型补齐为支持 all，匹配现有公开展示用法

## 验证
- node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/mulligan.test.ts --configLoader native
- node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/revealSystem.test.ts --configLoader native
- npm run typecheck