### PR TITLE
补齐大杀四方 POD 能力校验

### DIFF
--- a/src/games/smashup/__tests__/podAutoMapping.test.ts
+++ b/src/games/smashup/__tests__/podAutoMapping.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { initAllAbilities, resetAbilityInit } from '../abilities';
+import { validatePodAbilities } from '../abilities/podAutoMapping';
+import { registerAbility } from '../domain/abilityRegistry';
+
+afterEach(() => {
+    resetAbilityInit();
+});
+
+describe('POD 能力完整性校验', () => {
+    it('完整初始化后不报告 POD 变体绑定缺口', () => {
+        resetAbilityInit();
+        initAllAbilities();
+
+        expect(validatePodAbilities()).toEqual([]);
+    });
+
+    it('共享经典能力缺少 POD 运行时绑定时会返回缺口', () => {
+        resetAbilityInit();
+        registerAbility('alien_invader', 'onPlay', () => ({ events: [] }));
+
+        expect(validatePodAbilities()).toEqual([
+            'POD 派系 aliens_pod 的共享 ability 缺少实现：alien_invader_pod 未覆盖经典 alien_invader 的 能力标签 onPlay',
+        ]);
+    });
+});

--- a/src/games/smashup/abilities/podAutoMapping.ts
+++ b/src/games/smashup/abilities/podAutoMapping.ts
@@ -22,6 +22,7 @@
 
 import { registerPodAbilityAliases } from '../domain/abilityRegistry';
 import { registerPodOngoingAliases } from '../domain/ongoingEffects';
+import { collectSmashUpVariantBindingErrors } from '../domain/variantBindingValidation';
 
 /**
  * 自动为所有 POD 版本创建能力映射
@@ -43,20 +44,14 @@ export function autoMapPodAbilities(): void {
 }
 
 /**
- * 检查是否有 POD 卡牌缺失能力注册
+ * 检查是否有 POD 变体缺失运行时绑定
  * 
  * 用于开发时验证：
- * - 所有 POD 卡牌都应该有对应的能力（自动映射或显式注册）
+ * - 共享玩法的 POD 卡牌/基地都应该有对应的运行时绑定（自动映射或显式注册）
  * - 如果发现缺失，输出警告
  * 
- * @returns 缺失的 POD 卡牌列表
+ * @returns 缺失的 POD 绑定列表
  */
 export function validatePodAbilities(): string[] {
-    const missing: string[] = [];
-    
-    // 获取所有 POD 卡牌的 defId
-    // 注意：这需要从 cards.ts 中获取，暂时跳过
-    // TODO: 实现完整的验证逻辑
-    
-    return missing;
+    return collectSmashUpVariantBindingErrors();
 }

--- a/src/games/smashup/domain/variantBindingValidation.ts
+++ b/src/games/smashup/domain/variantBindingValidation.ts
@@ -277,13 +277,19 @@ function validateBasePoolBindings(errors: string[], profile: SmashUpFactionVaria
     }
 }
 
-export function validateSmashUpVariantBindings(): void {
+export function collectSmashUpVariantBindingErrors(): string[] {
     const errors: string[] = [];
 
     for (const profile of getAllSmashUpVariantProfiles()) {
         validateBasePoolBindings(errors, profile);
         validateSharedRuntimeBindings(errors, profile);
     }
+
+    return errors;
+}
+
+export function validateSmashUpVariantBindings(): void {
+    const errors = collectSmashUpVariantBindingErrors();
 
     if (errors.length > 0) {
         throw new Error(`Smash Up 变体绑定校验失败:\n- ${errors.join('\n- ')}`);


### PR DESCRIPTION
## 变更
- 将 `validatePodAbilities()` 接到现有 Smash Up 变体绑定校验，返回真实的 POD 运行时绑定缺口。
- 将 `validateSmashUpVariantBindings()` 的内部错误收集拆成可复用的非抛错入口。
- 增加 POD 校验回归测试，覆盖完整注册无缺口与共享经典能力缺少 POD 绑定会报错两条路径。

## 影响
- 这是大杀四方 POD 能力完整性的质量门禁补齐，不宣称某张具体卡牌已存在玩法 bug。
- 后续新增/调整 POD 共享玩法时，可以通过 `validatePodAbilities()` 得到可审计的缺口列表。

## 验证
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/podAutoMapping.test.ts --configLoader native`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/variantBindingRuntime.test.ts --configLoader native`
- `npm run typecheck`