### PR TITLE
修正 Smash Up 胜利判定等待 endTurn 收口

### DIFF
--- a/src/games/smashup/__tests__/turnCycle.test.ts
+++ b/src/games/smashup/__tests__/turnCycle.test.ts
@@ -1111,13 +1111,14 @@ describe('手牌超限弃牌', () => {
 // ============================================================================
 
 describe('≥15 VP 胜利检查', () => {
-    it('基地计分完成后进入 draw 时，VP >= VP_TO_WIN 触发游戏结束', () => {
-        // 选秀后注入高 VP
+    it('VP 达标后会先结算 endTurn 能力，再锁定游戏结束', () => {
         const runner1 = createRunner();
         const draftResult = runner1.run({
             name: '选秀',
             commands: DRAFT_COMMANDS,
         });
+        const base0 = draftResult.finalState.core.bases[0];
+        const startingHandSize = draftResult.finalState.core.players['0'].hand.length;
         const modifiedState: MatchState<SmashUpCore> = {
             ...draftResult.finalState,
             core: {
@@ -1129,28 +1130,58 @@ describe('≥15 VP 胜利检查', () => {
                         vp: VP_TO_WIN,
                     },
                 },
+                bases: [
+                    {
+                        ...base0,
+                        minions: [
+                            ...base0.minions,
+                            {
+                                uid: 'victory-de-minion',
+                                defId: 'steampunk_steam_man',
+                                controller: '0',
+                                owner: '0',
+                                power: 2,
+                                powerCounters: 0,
+                                powerModifier: 0,
+                                tempPowerModifier: 0,
+                                attachedActions: [],
+                            },
+                        ],
+                        ongoingActions: [
+                            ...base0.ongoingActions,
+                            {
+                                uid: 'victory-de-ongoing',
+                                defId: 'steampunk_difference_engine',
+                                ownerId: '0',
+                                metadata: {},
+                            },
+                        ],
+                    },
+                    ...draftResult.finalState.core.bases.slice(1),
+                ],
             },
         };
 
         const runner2 = createRunner(() => modifiedState);
         const result = runner2.run({
-            name: 'VP 达标游戏结束',
+            name: 'VP 达标后先结算回合结束能力',
             commands: [
-        // P0 回合：playCards → 多轮自动推进（计分完成后进入 draw 时即可检查 isGameOver）
                 { type: 'ADVANCE_PHASE', playerId: '0', payload: undefined },
             ] as any[],
         });
 
-        // isGameOver 应该在基地计分链结束后检测到 P0 VP >= 15
         const core = result.finalState.core;
         expect(core.players['0'].vp).toBeGreaterThanOrEqual(VP_TO_WIN);
+        // 正常 draw 2 张 + Difference Engine 在 endTurn 再抽 1 张，证明没有在 draw 阶段抢跑。
+        expect(core.players['0'].hand.length).toBe(startingHandSize + DRAW_PER_TURN + 1);
+        expect(result.finalState.sys.phase).toBe('endTurn');
+        expect(core.currentPlayerIndex).toBe(0);
+        expect(core.gameResult?.winner).toBe('0');
+        expect(result.finalState.sys.gameover?.winner).toBe('0');
 
-        // GameTestRunner 在 isGameOver 返回结果时 break，
-        // 验证 isGameOver 确实返回了胜利结果
         const gameOver = SmashUpDomain.isGameOver!(core);
         expect(gameOver).toBeDefined();
         expect(gameOver!.winner).toBe('0');
-        expect(gameOver!.scores).toBeDefined();
         expect(gameOver!.scores!['0']).toBeGreaterThanOrEqual(VP_TO_WIN);
     });
 
@@ -1176,13 +1207,13 @@ describe('≥15 VP 胜利检查', () => {
         expect(result.finalState.core.currentPlayerIndex).toBe(1);
     });
 
-    it('未到基地计分完成后的结算时机时，即使 VP 达标也不应提前结束', () => {
+    it('运行态只接受 endTurn 已锁定的 gameResult，不在 draw/endTurn 直接按 VP 抢跑', () => {
         const runner = createRunner();
         const draftResult = runner.run({
             name: 'draft',
             commands: DRAFT_COMMANDS,
         });
-        const core = {
+        const core: SmashUpCore = {
             ...draftResult.finalState.core,
             turnPhase: 'playCards',
             players: {
@@ -1200,8 +1231,15 @@ describe('≥15 VP 胜利检查', () => {
         expect(SmashUpDomain.isGameOver!(core)).toBeUndefined();
 
         core.turnPhase = 'draw';
-        const gameOver = SmashUpDomain.isGameOver!(core);
-        expect(gameOver).toBeDefined();
-        expect(gameOver!.winner).toBe('0');
+        expect(SmashUpDomain.isGameOver!(core)).toBeUndefined();
+
+        core.turnPhase = 'endTurn';
+        expect(SmashUpDomain.isGameOver!(core)).toBeUndefined();
+
+        core.gameResult = {
+            winner: '0',
+            scores: { '0': VP_TO_WIN, '1': 0 },
+        };
+        expect(SmashUpDomain.isGameOver!(core)).toEqual(core.gameResult);
     });
 });

--- a/src/games/smashup/domain/index.ts
+++ b/src/games/smashup/domain/index.ts
@@ -1663,6 +1663,18 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
                 && !(state.core.triggerQueue ?? []).some(trigger => trigger.frameId?.startsWith('turn-end:'));
 
             if (resumedAfterTurnEndReactionResolution) {
+                const gameResult = evaluateSmashUpVictory(core);
+                if (gameResult) {
+                    return {
+                        events: [],
+                        halt: true,
+                        updatedState: {
+                            ...state,
+                            core: { ...core, gameResult },
+                        },
+                    } as PhaseExitResult;
+                }
+
                 const advance = buildTurnEndAdvancePayload(core);
                 return [{
                     type: SU_EVENTS.TURN_ENDED,
@@ -1733,12 +1745,25 @@ export const smashUpFlowHooks: FlowHooks<SmashUpCore> = {
                 }
             }
 
-            // 鍒囨崲鍒颁笅涓€涓帺瀹?
-            if (hasPendingTurnEndResolution) {
+            // 即使 onTurnEnd 触发已自动结算，也先让 pipeline 真正归约这一批事件；
+            // 下一轮 endTurn 会走 resumed 分支，再基于最终 core 判胜。
+            if (hasPendingTurnEndResolution || hasQueuedTurnEndResolution) {
                 return {
                     events,
                     halt: true,
                     updatedState: keepSysUpdatesOnly(state, currentMatchState),
+                } as PhaseExitResult;
+            }
+
+            const gameResult = evaluateSmashUpVictory(currentMatchState.core);
+            if (gameResult) {
+                return {
+                    events: [],
+                    halt: true,
+                    updatedState: {
+                        ...state,
+                        core: { ...core, gameResult },
+                    },
                 } as PhaseExitResult;
             }
 
@@ -2367,10 +2392,7 @@ function playerView(state: SmashUpCore, playerId: PlayerId): Partial<SmashUpCore
 // isGameOver
 // ============================================================================
 
-function isGameOver(state: SmashUpCore): GameOverResult | undefined {
-    if (state.gameResult) return state.gameResult;
-    if (state.turnPhase && state.turnPhase !== 'draw' && state.turnPhase !== 'endTurn') return undefined;
-
+function evaluateSmashUpVictory(state: SmashUpCore): GameOverResult | undefined {
     if (isSmashUpTwoVsTwoMode(state)) {
         const rawTeamTotals = getSmashUpRawTeamVpTotals(state);
         const candidateTeams = Object.entries(rawTeamTotals)
@@ -2427,6 +2449,15 @@ function isGameOver(state: SmashUpCore): GameOverResult | undefined {
     if (winners.length === 1) return { winner: winners[0], scores };
 
     return { winner: winners[0], winners, scores };
+}
+
+function isGameOver(state: SmashUpCore): GameOverResult | undefined {
+    if (state.gameResult) return state.gameResult;
+
+    // 正常运行态只发布 endTurn 收口后锁定的结果，避免 draw/endTurn 能力尚未结算时抢跑。
+    // 无 turnPhase 的旧快照/纯规则测试保留直接计算兼容路径。
+    if (state.turnPhase !== undefined) return undefined;
+    return evaluateSmashUpVictory(state);
 }
 
 export function getScores(state: SmashUpCore): Record<PlayerId, number> {


### PR DESCRIPTION
## What changed

- Delay Smash Up victory publication until the endTurn phase has fully settled.
- Split raw VP evaluation into `evaluateSmashUpVictory`, while `isGameOver` now returns only a locked `gameResult` during normal runtime phases.
- Add regression coverage that VP >= 15 still allows draw/endTurn abilities to resolve before the game result is locked.

## Why

The previous runtime `isGameOver` path could report victory from VP alone while draw/endTurn effects were still pending. That could end the match before required end-of-turn abilities or prompts had a chance to resolve.

## Validation

- `git diff --check`
- `npx eslint src/games/smashup/domain/index.ts src/games/smashup/__tests__/turnCycle.test.ts`
- `npm run typecheck`
- `node scripts/infra/vitest-cli-safe.mjs run src/games/smashup/__tests__/turnCycle.test.ts src/games/smashup/__tests__/revealSystem.test.ts --config vitest.config.core.ts --pool forks --no-file-parallelism --maxWorkers 1`
- Extra tsx scenario: Spikey Chair Room endTurn prompt appears before `gameResult`, then locks victory after resolving the prompt.

Note: `npm run quality:changed` in local mode expands this small Smash Up domain change to hundreds of Smash Up test files, so I used the targeted checks above for this PR.